### PR TITLE
fix(#1988): split the grey puzzle into a working block and a broken one

### DIFF
--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -12,6 +12,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {
@@ -29,6 +30,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
@@ -44,15 +46,54 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-22T05:02:06.732014Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1a51675721a983b8aa8889d913453ee93196621ee7dd61f28baab622ea79f9b6",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T05:02:19.059580Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:18ad93b94ea52c36b74fb1663cc44d7a369b4e590d7f33492dd4a27650075d7c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "0a835b50cf26578827aba4009794babb555cd5b7",
+    "shas": [
+      "0a835b50cf26578827aba4009794babb555cd5b7"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -240,6 +281,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.105035Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.120328Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.135182Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.149389Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.162933Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.177657Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.191499Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.206026Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.220446Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.234644Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:19.252277Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.658380Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.674661Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.691005Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.706973Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.722498Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.739238Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.756781Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.774270Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.791158Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.806817Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T05:02:44.827636Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -254,27 +471,45 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "4345232e7",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/1988-guided-1988-node-fallback-visual.json",
+      "CHANGELOG.md",
+      "docs/adr/ADR-050.md",
+      "frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts",
+      "frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts",
+      "frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx",
+      "frontend/src/types/ui.ts"
+    ],
+    "diff_fingerprint": "sha256:0a91f7e4a00961a1fa0c196a5e0c52bc77d67edade8121d539d53d447cc7384a",
     "head": "HEAD",
-    "head_sha": "4f290a9d2",
+    "head_sha": "0a835b50c",
     "surfaces": {
-      "docs": 0,
-      "frontend": 0,
+      "docs": 1,
+      "frontend": 7,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 7,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 8,
+      "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Owner: blocks that inherit the base Block class directly render with an ugly grey canvas body; replace it with something better looking. Owner recalled this had been raised before; it is issue #1988.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      1988
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-22T04:51:28.525172Z",
@@ -291,6 +526,22 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T05:02:19.252313Z",
+      "diff_fingerprint": "sha256:0a91f7e4a00961a1fa0c196a5e0c52bc77d67edade8121d539d53d447cc7384a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T05:02:44.827672Z",
+      "diff_fingerprint": "sha256:0a91f7e4a00961a1fa0c196a5e0c52bc77d67edade8121d539d53d447cc7384a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "1988-guided-1988-node-fallback-visual",
@@ -299,10 +550,13 @@
     "admin_labels": [],
     "checks": [
       "format_check",
+      "frontend",
       "full_audit",
       "lint_format"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -316,7 +570,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,

--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -275,9 +275,9 @@
     }
   ],
   "commit": {
-    "sha": "0a835b50cf26578827aba4009794babb555cd5b7",
+    "sha": "e4905e98dda7c8441ae08d2aba657c6f93bec127",
     "shas": [
-      "0a835b50cf26578827aba4009794babb555cd5b7"
+      "e4905e98dda7c8441ae08d2aba657c6f93bec127"
     ],
     "trailers": []
   },
@@ -1047,6 +1047,268 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.782712Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.797058Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.811547Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.826739Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.841752Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.855851Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.870014Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.884028Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.919588Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.934075Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:34:50.954702Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.919146Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.935258Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.949455Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.963417Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.978084Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:16.994009Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:17.009202Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:17.024933Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:17.040712Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:17.057341Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:35:17.077898Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1059,7 +1321,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "4345232e7337d7b37280b6a3327f295de5e98120",
     "base_sha": "4345232e7",
     "changed_files": [
       ".workflow/records/1988-guided-1988-node-fallback-visual.json",
@@ -1078,9 +1340,9 @@
       "tests/workflow/test_validator.py",
       "tests/workflow/test_validator_codeblock_v2.py"
     ],
-    "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
+    "diff_fingerprint": "sha256:0193333c0ea994d59b8e71639af8f7da896b8d2685e2a3ea9386515ba451e471",
     "head": "HEAD",
-    "head_sha": "074e6baa3",
+    "head_sha": "e4905e98d",
     "surfaces": {
       "docs": 1,
       "frontend": 7,
@@ -1102,7 +1364,7 @@
     "closes": [
       1988
     ],
-    "number": null,
+    "number": 2127,
     "url": null
   },
   "reconcile_events": [
@@ -1161,6 +1423,26 @@
     {
       "at": "2026-08-22T07:32:20.703128Z",
       "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-22T07:34:50.954725Z",
+      "diff_fingerprint": "sha256:0193333c0ea994d59b8e71639af8f7da896b8d2685e2a3ea9386515ba451e471",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-22T07:35:17.077924Z",
+      "diff_fingerprint": "sha256:0193333c0ea994d59b8e71639af8f7da896b8d2685e2a3ea9386515ba451e471",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -84,9 +84,196 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:41:51.596011Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:502773a54c0f0b8023adfed92746aa92784136048ab54269d83fe29ead16a83f",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:41:52.895117Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:18e836cf7933ed53729af544a9ae1b45911150922538d89316a63db99e5dd0a3",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:41:52.920725Z",
+      "command": "ruff format src/scistudio/api/schemas.py src/scistudio/blocks/registry/__init__.py src/scistudio/workflow/validator.py tests/workflow/test_validator.py tests/workflow/test_validator_codeblock_v2.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:101f3da03fb4874d0422455fd40ebabf881e94333d69bd634af7b0c4b4ff8099",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T06:43:14.915740Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9f6a852aee3f50f898fa68143e27c03cf322ff27ba3309ed5bf462d3c614de8f",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:43:28.238581Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5fd1d9b4b500ed4c7df1bdf2c707bdddfafb3811e4247de0c739700b0bc582a9",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:43:28.502869Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f8a8b922a6379c55e9b3a33e578cbb78b21a4be38ad37cedd11cfe24eb331412",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:43:28.535343Z",
+      "command": "ruff check src/scistudio/api/schemas.py src/scistudio/blocks/registry/__init__.py src/scistudio/workflow/validator.py tests/workflow/test_validator.py tests/workflow/test_validator_codeblock_v2.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:de2a089ad7cbab03d72738e91fa91bc3432939ec62b8c6cbc8e2f09c9f721015",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T06:44:53.290470Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api tests/blocks tests/workflow tests/workflow/test_validator.py tests/workflow/test_validator_codeblock_v2.py",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9ea97f651c3687bb5626cba5c9924af62d29adeb5c13257595477dd3df74c29c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T06:44:54.599070Z",
+      "command": "mypy src/scistudio/api/schemas.py src/scistudio/blocks/registry/__init__.py src/scistudio/workflow/validator.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98792b11a5cd065af60d2ac412892e87c3ea523e4fc74cf9427f81f45ad09f7c",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-22T07:00:58.929387Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api tests/blocks tests/workflow tests/workflow/test_validator.py tests/workflow/test_validator_codeblock_v2.py",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9ea97f651c3687bb5626cba5c9924af62d29adeb5c13257595477dd3df74c29c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T07:32:20.422497Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api tests/blocks tests/workflow tests/workflow/test_validator.py tests/workflow/test_validator_codeblock_v2.py",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9ea97f651c3687bb5626cba5c9924af62d29adeb5c13257595477dd3df74c29c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Blocked by issue #2047 (Windows zarr directory-rename race in utils/atomic_io.py under xdist), reproduced five times with four different failing parametrisations and unrelated to this diff. Owner authorised the preflight skip; ci.yml/Test runs the full suite on Ubuntu and remains the authoritative pass."
+    }
+  ],
   "commit": {
     "sha": "0a835b50cf26578827aba4009794babb555cd5b7",
     "shas": [
@@ -125,6 +312,11 @@
       "at": "2026-08-22T06:23:21.771954Z",
       "owner_directive": "Owner: I will apply the admin-approved:core-change label \u2014 do the rest and open the PR. That takes in the node-level unregistered-block-type check in validate_workflow and the base_category docstring drift in the registry and API schemas.",
       "reason": "Owner authorised the protected-core scope that was held back"
+    },
+    {
+      "at": "2026-08-22T07:34:26.956804Z",
+      "owner_directive": "Owner: \u53ef\u4ee5 \u2014 authorised opening the PR with SCISTUDIO_SKIP_PREFLIGHT=1. Five local runs produced four different failing node ids, always PermissionError WinError 5 at utils/atomic_io.py:308 on a zarr directory rename under an xdist worker (issue #2047). Nothing in this diff touches zarr, atomic_io or the IO blocks. CI is Ubuntu-only and runs the full suite as the authoritative gate.",
+      "reason": "python_tests is blocked by issue #2047, a Windows zarr directory-rename race that is unrelated to this diff; owner authorised opening the PR with the preflight skip and letting CI be the gate"
     }
   ],
   "docs_events": [
@@ -462,6 +654,399 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.669899Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.684931Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.699504Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.715416Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.730614Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.747584Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.763181Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.779555Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.795214Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.809945Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T06:44:54.828171Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:58.983715Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:58.997659Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.010939Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.024592Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.038495Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.054498Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.069064Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.082180Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.095353Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.108311Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:00:59.125897Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.547754Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.562276Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.577192Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.591810Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.607342Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.621826Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.636732Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.653831Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.669811Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.684026Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T07:32:20.703111Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -486,22 +1071,27 @@
       "frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts",
       "frontend/src/components/nodes/BlockNode.tsx",
       "frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx",
-      "frontend/src/types/ui.ts"
+      "frontend/src/types/ui.ts",
+      "src/scistudio/api/schemas.py",
+      "src/scistudio/blocks/registry/__init__.py",
+      "src/scistudio/workflow/validator.py",
+      "tests/workflow/test_validator.py",
+      "tests/workflow/test_validator_codeblock_v2.py"
     ],
-    "diff_fingerprint": "sha256:0a91f7e4a00961a1fa0c196a5e0c52bc77d67edade8121d539d53d447cc7384a",
+    "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
     "head": "HEAD",
-    "head_sha": "0a835b50c",
+    "head_sha": "074e6baa3",
     "surfaces": {
       "docs": 1,
       "frontend": 7,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 7,
+      "implementation": 10,
       "packaging": 0,
       "protected_architecture": 0,
-      "protected_core": 0,
-      "sentrux": 8,
-      "test": 2,
+      "protected_core": 2,
+      "sentrux": 13,
+      "test": 4,
       "workflow_ci": 0
     }
   },
@@ -547,6 +1137,36 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T06:44:54.828197Z",
+      "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-22T07:00:59.125914Z",
+      "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-22T07:32:20.703128Z",
+      "diff_fingerprint": "sha256:e755ce462e3b229e8abf7d08ecd04e50697283c0083196ad283f273db54b7c6e",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "1988-guided-1988-node-fallback-visual",
@@ -559,12 +1179,19 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
     "checks": [
+      "architecture_tests",
+      "deferral_discipline",
       "format_check",
       "frontend",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
     ],
     "docs": [
       "docs_required_or_na"
@@ -645,7 +1272,7 @@
     }
   ],
   "session_id": "9b8b8cad-dcb4-42e8-a8d9-08cd318d571c",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -1,0 +1,376 @@
+{
+  "branch": "guided/1988-node-fallback-visual",
+  "check_events": [
+    {
+      "at": "2026-08-22T04:51:12.672403Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-22T04:51:28.235932Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-22T04:51:28.320079Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/nodes/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-22T04:18:14.676104Z",
+      "owner_directive": "Owner: do all three asks in #1988. Colour: candidate B periwinkle (#b5c4f2). For ask (a) name-based category inference, only handle the IO case; do not build a general name->category guesser.",
+      "reason": "Owner reviewed the rendered candidates and settled scope for #1988"
+    },
+    {
+      "at": "2026-08-22T04:24:30.280619Z",
+      "owner_directive": "Owner: use the Lucide 'blocks' glyph for the no-category fallback node. Ask (c) is implemented as a frontend-only visible unresolved state (dashed body, block_type shown as the label, warning affordance); the node-level validate_workflow check is NOT in this PR because src/scistudio/workflow/** is protected and needs admin-approved:core-change.",
+      "reason": "Owner picked the fallback glyph; recording the narrowest reading of ask (c) so the diff stays out of protected core"
+    },
+    {
+      "at": "2026-08-22T04:27:50.518724Z",
+      "owner_directive": "Owner: the concrete case for name-based IO inference is an AI agent wiring a package-owned subclassed load block instead of the core load block. That node renders grey today. It must read as a loader whether it went grey via an unresolved block_type or via base_category=unknown.",
+      "reason": "Owner supplied the real-world scenario that ask (a) has to serve"
+    },
+    {
+      "at": "2026-08-22T04:50:13.806745Z",
+      "owner_directive": "Implement all three #1988 asks in the frontend: periwinkle no-category macaron with the blocks glyph, IO-only name inference for unresolved block types, and a dashed body plus a naming warning that keeps the unresolved fact visible.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-22T04:50:13.806775Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-22T04:50:13.806781Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-22T04:50:13.806787Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "ADR-050 spec describes node geometry and status surface, not the category fallback vocabulary; the fallback contract lives in the ADR section that was updated.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-22T04:51:28.357111Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.372700Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.387512Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.401762Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.417018Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.431434Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.463524Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.478637Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.494106Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.510031Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:51:28.525118Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.192553Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.209033Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.226062Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.242185Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.258571Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.274400Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.289865Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.306583Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.323241Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.339811Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-22T04:53:57.355316Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 1988,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4345232e7",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "4f290a9d2",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner: blocks that inherit the base Block class directly render with an ugly grey canvas body; replace it with something better looking. Owner recalled this had been raised before; it is issue #1988.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-22T04:51:28.525172Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-22T04:53:57.355364Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "1988-guided-1988-node-fallback-visual",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-22T04:18:14.676125Z",
+      "pattern": "frontend/src/components/WorkflowCanvas.parts/**",
+      "reason": "Owner reviewed the rendered candidates and settled scope for #1988"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T04:18:14.676135Z",
+      "pattern": "frontend/src/components/BlockPalette.parts/**",
+      "reason": "Owner reviewed the rendered candidates and settled scope for #1988"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T04:50:13.806761Z",
+      "pattern": "frontend/src/types/ui.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T04:50:13.806766Z",
+      "pattern": "docs/adr/ADR-050.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T04:50:13.806768Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "9b8b8cad-dcb4-42e8-a8d9-08cd318d571c",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-22T04:50:13.806792Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-22T04:50:13.806795Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -317,6 +317,11 @@
       "at": "2026-08-22T07:34:26.956804Z",
       "owner_directive": "Owner: \u53ef\u4ee5 \u2014 authorised opening the PR with SCISTUDIO_SKIP_PREFLIGHT=1. Five local runs produced four different failing node ids, always PermissionError WinError 5 at utils/atomic_io.py:308 on a zarr directory rename under an xdist worker (issue #2047). Nothing in this diff touches zarr, atomic_io or the IO blocks. CI is Ubuntu-only and runs the full suite as the authoritative gate.",
       "reason": "python_tests is blocked by issue #2047, a Windows zarr directory-rename race that is unrelated to this diff; owner authorised opening the PR with the preflight skip and letting CI be the gate"
+    },
+    {
+      "at": "2026-08-23T03:33:53.784468Z",
+      "owner_directive": "Owner: fix Codex's one P1 and two P2s on PR #2127; ignore the gate-ledger one. (1) the schema cache is never evicted so a deleted block still reports resolved; (2) the unresolved warning badge still routes clicks to BottomPanel Config, the dead end its own tooltip disclaims; (3) the new Warning: diagnostic DOES change dispatch for scistudio run and the MCP validate_workflow tool, both of which treat any diagnostic as an error \u2014 my claim that it does not was verified only against the API path.",
+      "reason": "Codex review on PR #2127 found three real defects; owner directed fixing the P1 and both P2s"
     }
   ],
   "docs_events": [
@@ -342,6 +347,22 @@
       "kind": "na",
       "path": null,
       "rationale": "ADR-050 spec describes node geometry and status surface, not the category fallback vocabulary; the fallback contract lives in the ADR section that was updated.",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T03:43:01.372783Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-050.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T03:43:01.372801Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
       "verified_in_diff": null
     }
   ],
@@ -1551,6 +1572,42 @@
       "at": "2026-08-22T06:23:21.772016Z",
       "pattern": "tests/workflow/**",
       "reason": "Owner authorised the protected-core scope that was held back"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:33:53.784489Z",
+      "pattern": "src/scistudio/cli/main.py",
+      "reason": "Codex review on PR #2127 found three real defects; owner directed fixing the P1 and both P2s"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:33:53.784495Z",
+      "pattern": "src/scistudio/ai/agent/mcp/tools_workflow/read.py",
+      "reason": "Codex review on PR #2127 found three real defects; owner directed fixing the P1 and both P2s"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:33:53.784499Z",
+      "pattern": "frontend/src/store/paletteSlice.ts",
+      "reason": "Codex review on PR #2127 found three real defects; owner directed fixing the P1 and both P2s"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:33:53.784502Z",
+      "pattern": "tests/cli/**",
+      "reason": "Codex review on PR #2127 found three real defects; owner directed fixing the P1 and both P2s"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:52:57.099605Z",
+      "pattern": "tests/ai/agent/mcp/**",
+      "reason": "the review fixes need tests next to the code they cover: the MCP validate_workflow verdict and the frontend block-schema cache"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T03:52:57.099624Z",
+      "pattern": "frontend/src/store/__tests__/**",
+      "reason": "the review fixes need tests next to the code they cover: the MCP validate_workflow verdict and the frontend block-schema cache"
     }
   ],
   "session_id": "9b8b8cad-dcb4-42e8-a8d9-08cd318d571c",
@@ -1570,6 +1627,30 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T03:43:01.372804Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/cli/test_validation_warning_prefix.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T03:43:01.372807Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/agent/mcp/test_validate_workflow_warning_prefix.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T03:43:01.372809Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/store/__tests__/blockSchemaEviction.test.ts",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/1988-guided-1988-node-fallback-visual.json
+++ b/.workflow/records/1988-guided-1988-node-fallback-visual.json
@@ -120,6 +120,11 @@
       "at": "2026-08-22T04:50:13.806745Z",
       "owner_directive": "Implement all three #1988 asks in the frontend: periwinkle no-category macaron with the blocks glyph, IO-only name inference for unresolved block types, and a dashed body plus a naming warning that keeps the unresolved fact visible.",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-22T06:23:21.771954Z",
+      "owner_directive": "Owner: I will apply the admin-approved:core-change label \u2014 do the rest and open the PR. That takes in the node-level unregistered-block-type check in validate_workflow and the base_category docstring drift in the registry and API schemas.",
+      "reason": "Owner authorised the protected-core scope that was held back"
     }
   ],
   "docs_events": [
@@ -545,7 +550,14 @@
     }
   ],
   "record_id": "1988-guided-1988-node-fallback-visual",
-  "requested_admin_labels": [],
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
   "required_obligations": {
     "admin_labels": [],
     "checks": [
@@ -606,6 +618,30 @@
       "at": "2026-08-22T04:50:13.806768Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T06:23:21.771994Z",
+      "pattern": "src/scistudio/workflow/validator.py",
+      "reason": "Owner authorised the protected-core scope that was held back"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T06:23:21.772008Z",
+      "pattern": "src/scistudio/blocks/registry/__init__.py",
+      "reason": "Owner authorised the protected-core scope that was held back"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T06:23:21.772011Z",
+      "pattern": "src/scistudio/api/schemas.py",
+      "reason": "Owner authorised the protected-core scope that was held back"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-22T06:23:21.772016Z",
+      "pattern": "tests/workflow/**",
+      "reason": "Owner authorised the protected-core scope that was held back"
     }
   ],
   "session_id": "9b8b8cad-dcb4-42e8-a8d9-08cd318d571c",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   unresolved block type once — as a warning, not an error, so a workflow that
   used to save and run still saves and runs. The silence is what changed, not
   the rules.
+  Keeping that promise took two more fixes. A validation warning was only
+  advisory to the app: `scistudio run` on the command line stopped on any
+  diagnostic at all, and the tool the AI assistant uses to check a workflow
+  called it invalid on the same basis. Both now do what the app already did —
+  show the warning, and stop only for a real error.
   One case gets a further nudge. Package-owned loaders are folded into the core
   Load block on purpose and aren't offered separately, so an AI agent wiring one
   by name produces a node that can't resolve. When an unresolved block type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   That warning matters more than the colour did. Nothing was reporting these
   nodes: the workflow validator finds unregistered block types by walking edges,
   and a node with no ports has no edges, so a workflow full of them validated
-  clean and only failed at run time. The canvas is where that fact now surfaces.
+  clean and only failed at run time. Both surfaces report it now. The canvas
+  draws the node, and validation gained a per-node pass that names every
+  unresolved block type once — as a warning, not an error, so a workflow that
+  used to save and run still saves and runs. The silence is what changed, not
+  the rules.
   One case gets a further nudge. Package-owned loaders are folded into the core
   Load block on purpose and aren't offered separately, so an AI agent wiring one
   by name produces a node that can't resolve. When an unresolved block type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#1988] **A block that isn't one of the six kinds no longer looks broken.**
+  Every canvas node that wasn't IO, Process, Code, App, AI or Subworkflow fell
+  back to one grey body with a puzzle-piece glyph — and that single grey was
+  answering two completely different questions. A block whose class extends
+  `Block` directly works perfectly well; it just has no base category to report.
+  A block whose type can't be loaded here at all is broken. Both looked the
+  same, so the working one looked broken and the broken one looked ordinary.
+  They are now two visuals. A block with no category gets a body colour of its
+  own alongside the other six, and a glyph that doesn't imply something is
+  missing. A block that didn't resolve is drawn as a dashed outline rather than
+  a solid body — an empty slot in the graph, not a seventh kind of block — and
+  it now carries a warning that names the block type it was looking for and says
+  the node has no ports and will fail on run.
+  That warning matters more than the colour did. Nothing was reporting these
+  nodes: the workflow validator finds unregistered block types by walking edges,
+  and a node with no ports has no edges, so a workflow full of them validated
+  clean and only failed at run time. The canvas is where that fact now surfaces.
+  One case gets a further nudge. Package-owned loaders are folded into the core
+  Load block on purpose and aren't offered separately, so an AI agent wiring one
+  by name produces a node that can't resolve. When an unresolved block type
+  reads as a loader or a saver, the node borrows the IO palette and the matching
+  load/save glyph, so it still reads as what it was meant to be. The guess is
+  about appearance only — it is limited to IO, and it never removes the dashed
+  body or the warning.
 - [#2093] **`npm run dev` in `desktop/` starts again on Windows.** The desktop
   dev launcher spawns npm twice — once for Vite, once for Electron — and on
   Windows the `npm` it reaches is `npm.cmd`, a batch shim. Node hardened

--- a/docs/adr/ADR-050.md
+++ b/docs/adr/ADR-050.md
@@ -157,8 +157,27 @@ model and removes inline config from the node body.
 `Block-kind mark` means the existing block category carried by
 `base_category` / `data.category`, not a data type and not a role subtitle.
 The current category values are `io`, `process`, `code`, `app`, `ai`, and
-`subworkflow`, with `custom` as the frontend fallback when no known base
-category is available.
+`subworkflow`.
+
+Two further values cover what is not one of those six. They were a single
+`custom` fallback until #1988 showed it was answering two different questions
+with one grey body, so a working block and a broken one were indistinguishable:
+
+- `unknown` — the block RESOLVED, but its class inherits `Block` directly, so
+  the registry's `_infer_category` reports no base category. It has ports and it
+  runs; it is simply not one of the six. It carries its own body colour and
+  raises no problem signal. (`custom` remains an accepted alias for this value.)
+- `unresolved` — the `block_type` resolved to NOTHING in this environment. There
+  is no class to ask, therefore no ports and no metadata. It is drawn with a
+  dashed body and MUST raise a `warning` problem severity naming the missing
+  block type. That signal is load-bearing rather than decorative: the workflow
+  validator's unregistered-type check walks edges, and a node with no ports has
+  no edges, so the canvas is the only surface on which the fact appears.
+
+For an `unresolved` node only, the frontend MAY infer a category from the
+`block_type` string so a loader still reads as a loader. The inference is
+restricted to IO and is a statement about appearance alone — it never clears
+the `unresolved` flag, the dashed body, or the warning.
 
 ### 2.2 Complete Node Instance
 

--- a/docs/adr/ADR-050.md
+++ b/docs/adr/ADR-050.md
@@ -170,9 +170,17 @@ with one grey body, so a working block and a broken one were indistinguishable:
 - `unresolved` — the `block_type` resolved to NOTHING in this environment. There
   is no class to ask, therefore no ports and no metadata. It is drawn with a
   dashed body and MUST raise a `warning` problem severity naming the missing
-  block type. That signal is load-bearing rather than decorative: the workflow
-  validator's unregistered-type check walks edges, and a node with no ports has
-  no edges, so the canvas is the only surface on which the fact appears.
+  block type.
+
+The `unresolved` signal is load-bearing rather than decorative. Before #1988 the
+only thing that noticed an unregistered `block_type` was the workflow
+validator's Check 5, which walks EDGES — and a node with no ports attracts no
+edges, so these nodes were reported nowhere and a workflow full of them
+validated clean until the run reached dispatch. #1988 closes that on both
+surfaces: the canvas draws the node as `unresolved`, and `validate_workflow`
+gained a per-node pass (Check 4.5) that names every such node once, as a
+`Warning:` so that reporting the fact does not change whether the workflow saves
+or dispatches.
 
 For an `unresolved` node only, the frontend MAY infer a category from the
 `block_type` string so a loader still reads as a loader. The inference is

--- a/docs/adr/ADR-050.md
+++ b/docs/adr/ADR-050.md
@@ -182,6 +182,14 @@ gained a per-node pass (Check 4.5) that names every such node once, as a
 `Warning:` so that reporting the fact does not change whether the workflow saves
 or dispatches.
 
+That last property is a contract every CALLER of `validate_workflow` MUST
+honour: a diagnostic carrying the `Warning:` prefix MUST NOT block saving,
+dispatching, or a validity verdict. It was only true of the API layer when
+#1988 landed — `cli/main.py` exited on any non-empty diagnostic list and the MCP
+`validate_workflow` tool reported `valid=not errors` — and both were corrected
+as part of that change. A caller that treats the whole list as fatal turns any
+future advisory into a refusal.
+
 For an `unresolved` node only, the frontend MAY infer a category from the
 `block_type` string so a loader still reads as a loader. The inference is
 restricted to IO and is a statement about appearance alone — it never clears

--- a/frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts
@@ -1,0 +1,196 @@
+// #1988 — the grey puzzle used to mean two unrelated things at once:
+//
+//   1. a REGISTERED block that is none of the six base categories (the backend
+//      reports `base_category: "unknown"` for a direct `Block` subclass), and
+//   2. a `block_type` that resolved to NOTHING in this environment.
+//
+// (1) works and must look like an ordinary block; (2) is broken and must keep
+// saying so. These tests pin that separation, plus the IO-only name inference
+// that lets an unresolved loader still read as a loader.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBlockNode,
+  computeProblemSeverity,
+  inferUnresolvedCategory,
+} from "../flowNodeBuilder";
+import { categoryVisuals, getCategoryVisual } from "../../nodes/BlockNode.parts/categoryVisuals";
+import type { BlockSchemaResponse, BlockSummary, WorkflowNode } from "../../../types/api";
+import type { BlockNodeData } from "../../../types/ui";
+
+function build(
+  overrides: {
+    blockType?: string;
+    summary?: BlockSummary;
+    schema?: BlockSchemaResponse;
+    status?: string;
+  } = {},
+): BlockNodeData {
+  const node = {
+    id: "n1",
+    block_type: overrides.blockType ?? "spectrum_baseline_block",
+    config: {},
+  } as unknown as WorkflowNode;
+
+  const built = buildBlockNode({
+    node,
+    position: { x: 0, y: 0 },
+    params: {},
+    summary: overrides.summary,
+    schema: overrides.schema,
+    status: overrides.status ?? "idle",
+    errorMessage: undefined,
+    errorSummary: undefined,
+    callbacks: {},
+    label: overrides.blockType ?? "spectrum_baseline_block",
+    upstreamOmeFields: undefined,
+    selectedNodeId: null,
+  } as unknown as Parameters<typeof buildBlockNode>[0]);
+
+  return built.data as BlockNodeData;
+}
+
+function summaryWith(base_category: string): BlockSummary {
+  return {
+    name: "Peak Finder",
+    type_name: "peak_finder_block",
+    base_category,
+    input_ports: [],
+    output_ports: [],
+  } as unknown as BlockSummary;
+}
+
+describe("#1988 — a registered block with no base category", () => {
+  it("is NOT treated as unresolved just because base_category is 'unknown'", () => {
+    const data = build({ summary: summaryWith("unknown") });
+    expect(data.unresolved).toBe(false);
+    expect(data.category).toBe("unknown");
+  });
+
+  it("is NOT treated as unresolved when base_category comes back empty", () => {
+    // An empty string is what an older/partial backend payload carries; the
+    // block still resolved, so it must not acquire the broken-node treatment.
+    const data = build({ summary: summaryWith("") });
+    expect(data.unresolved).toBe(false);
+    expect(data.category).toBe("unknown");
+  });
+
+  it("carries no problem severity of its own", () => {
+    expect(build({ summary: summaryWith("unknown") }).problemSeverity).toBe("none");
+  });
+
+  it("gets a real macaron rather than the retired grey puzzle", () => {
+    const visual = getCategoryVisual("unknown");
+    expect(visual.bg).toBe("#b5c4f2");
+    expect(visual.dashed).toBeUndefined();
+    // The pre-#1988 grey must not survive anywhere in the palette.
+    const greys = Object.values(categoryVisuals).filter((v) => v.bg === "#c9d1d9");
+    expect(greys).toEqual([]);
+  });
+
+  it("keeps `custom` as an alias for the same visual, not for the broken one", () => {
+    expect(getCategoryVisual("custom")).toBe(getCategoryVisual("unknown"));
+  });
+
+  it("falls back to the no-category visual for an unrecognised category string", () => {
+    expect(getCategoryVisual("totally-made-up").bg).toBe("#b5c4f2");
+  });
+});
+
+describe("#1988 — a block_type that resolved to nothing", () => {
+  it("is flagged unresolved when neither a summary nor a schema came back", () => {
+    const data = build();
+    expect(data.unresolved).toBe(true);
+    expect(data.category).toBe("unresolved");
+  });
+
+  it("raises a warning so the canvas says what validate_workflow cannot", () => {
+    // validate_workflow's unregistered-type check walks EDGES, and an
+    // unresolved node has no ports, so it has no edges and is never reported.
+    expect(build().problemSeverity).toBe("warning");
+  });
+
+  it("is drawn as a dashed hole rather than a solid body", () => {
+    const visual = getCategoryVisual("unresolved");
+    expect(visual.dashed).toBe(true);
+    // It must not consume one of the category hues.
+    const hues = ["io", "process", "code", "app", "ai", "subworkflow", "unknown"];
+    expect(hues.map((k) => categoryVisuals[k].bg)).not.toContain(visual.bg);
+  });
+
+  it("still lets a runtime error outrank the unresolved warning", () => {
+    expect(build({ status: "error" }).problemSeverity).toBe("error");
+  });
+
+  it("keeps the raw block_type visible as the node label", () => {
+    expect(build({ blockType: "srs_load_block" }).blockType).toBe("srs_load_block");
+  });
+});
+
+describe("#1988 — IO-only inference from the block_type name", () => {
+  it("reads a loader as a loader", () => {
+    expect(inferUnresolvedCategory("srs_load_block")).toEqual({
+      category: "io",
+      iconHint: "folder-input",
+    });
+  });
+
+  it("reads a saver as a saver", () => {
+    expect(inferUnresolvedCategory("save_spectrum_block")).toEqual({
+      category: "io",
+      iconHint: "folder-output",
+    });
+  });
+
+  it.each(["read", "import", "open"])("treats '%s' as a load-side IO word", (word) => {
+    expect(inferUnresolvedCategory(`${word}_thing_block`).category).toBe("io");
+  });
+
+  it.each(["write", "export", "dump"])("treats '%s' as a save-side IO word", (word) => {
+    expect(inferUnresolvedCategory(`${word}_thing_block`).iconHint).toBe("folder-output");
+  });
+
+  it("matches whole words only, so a substring never fakes an IO block", () => {
+    // "payload" contains "load"; "download" contains "load" AND "own".
+    expect(inferUnresolvedCategory("payload_block").category).toBe("unresolved");
+    expect(inferUnresolvedCategory("reader_block").category).toBe("unresolved");
+  });
+
+  it("does not guess beyond IO", () => {
+    expect(inferUnresolvedCategory("spectrum_baseline_block").category).toBe("unresolved");
+    expect(inferUnresolvedCategory("train_model_block").category).toBe("unresolved");
+  });
+
+  it("gives an unresolved loader the IO palette AND the load glyph", () => {
+    const data = build({ blockType: "package_load_block" });
+    expect(data.category).toBe("io");
+    expect(data.uiIconHint).toBe("folder-input");
+    expect(getCategoryVisual(data.category, undefined, data.uiIconHint).bg).toBe(
+      categoryVisuals.io.bg,
+    );
+  });
+
+  it("keeps the unresolved FACT even when it borrows the IO palette", () => {
+    // This is the #1988 requirement that prettier styling must not erase.
+    const data = build({ blockType: "package_load_block" });
+    expect(data.unresolved).toBe(true);
+    expect(data.problemSeverity).toBe("warning");
+  });
+});
+
+describe("#1988 — computeProblemSeverity ordering", () => {
+  const base = {
+    category: "process",
+    config: {},
+    upstreamOmeFields: undefined,
+  };
+
+  it("puts a runtime error above an unresolved block", () => {
+    expect(computeProblemSeverity({ ...base, status: "error", unresolved: true })).toBe("error");
+  });
+
+  it("reports nothing for an ordinary resolved block", () => {
+    expect(computeProblemSeverity({ ...base, status: "idle", unresolved: false })).toBe("none");
+  });
+});

--- a/frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts
@@ -105,9 +105,11 @@ describe("#1988 — a block_type that resolved to nothing", () => {
     expect(data.category).toBe("unresolved");
   });
 
-  it("raises a warning so the canvas says what validate_workflow cannot", () => {
-    // validate_workflow's unregistered-type check walks EDGES, and an
-    // unresolved node has no ports, so it has no edges and is never reported.
+  it("raises a warning rather than leaving the node silent", () => {
+    // Before #1988 nothing reported these nodes: validate_workflow's
+    // unregistered-type check walked EDGES, and an unresolved node has no
+    // ports and therefore no edges. The validator now reports them per node
+    // too (Check 4.5); this is the same fact where the user is looking.
     expect(build().problemSeverity).toBe("warning");
   });
 

--- a/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
@@ -195,10 +195,11 @@ export function inferUnresolvedCategory(blockType: string): {
  * #1988 — an unresolved `block_type` is also a "warning". It outranks the
  * lossy-save check because it is unconditional: a node whose block cannot be
  * loaded has no schema, so no other signal on this node can fire. This is the
- * half of #1988 that colour cannot do — `validate_workflow` stays silent about
- * these nodes (its unregistered-type check walks EDGES, and an unresolved node
- * has no ports, so it has no edges), which left the canvas as the only place
- * the fact could surface at all.
+ * half of #1988 that colour cannot do. Until #1988 nothing reported these nodes
+ * at all — `validate_workflow`'s unregistered-type check walked EDGES, and an
+ * unresolved node has no ports and therefore no edges. The validator now also
+ * reports them per node (Check 4.5); this is the same fact on the canvas, where
+ * the user is actually looking when they place the node.
  */
 export function computeProblemSeverity(opts: {
   status: string;

--- a/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
+++ b/frontend/src/components/WorkflowCanvas.parts/flowNodeBuilder.ts
@@ -142,6 +142,48 @@ export interface BlockNodeCallbacks {
 }
 
 /**
+ * #1988 — what a node's `block_type` string alone can tell us, once the block
+ * itself has failed to resolve.
+ *
+ * `block_type` is an IDENTIFIER, not a category: the real `base_category` is
+ * derived on the backend from the class hierarchy (`issubclass(cls, IOBlock)`
+ * and friends), which needs a class that can actually be imported. An
+ * unresolved block is precisely the case where there is no class to ask, so
+ * the name is all that is left.
+ *
+ * Scope is deliberately IO-only (owner directive). The case this exists for is
+ * an agent wiring a package-owned load block instead of the core one — package
+ * loaders are folded into the core Load block by design and are not offered
+ * separately, so an agent naming one produces a node that cannot resolve here.
+ * Owner feedback on #1988: "even when the agent picked the wrong block, a
+ * loader should still read as a loader". It stays a guess about APPEARANCE
+ * only — `unresolved` is tracked separately and still drives the dashed body
+ * and the warning badge, so a prettier colour never hides the defect.
+ *
+ * Anything that is not recognisably IO returns `unresolved` rather than a
+ * broader guess; there is no general name→category heuristic here.
+ */
+export function inferUnresolvedCategory(blockType: string): {
+  category: string;
+  iconHint?: string;
+} {
+  // Match on snake_case word boundaries so `payload_block` never reads as a
+  // "load" and `download_block` never reads as a save.
+  const words = blockType
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  const has = (...candidates: string[]) => candidates.some((c) => words.includes(c));
+  if (has("save", "write", "export", "dump")) {
+    return { category: "io", iconHint: "folder-output" };
+  }
+  if (has("load", "read", "import", "open")) {
+    return { category: "io", iconHint: "folder-input" };
+  }
+  return { category: "unresolved" };
+}
+
+/**
  * ADR-050 §2.5 — compute the highest-priority problem signal for a node.
  *
  * Priority: an `error` runtime status is always "error". Otherwise, for a
@@ -149,6 +191,14 @@ export interface BlockNodeCallbacks {
  * single) capability whose `metadata_fidelity` would drop any of those fields,
  * the severity is "warning" (the lossy-save signal — verbose detail lives in
  * BottomPanel Config, FR-014). Everything else is "none".
+ *
+ * #1988 — an unresolved `block_type` is also a "warning". It outranks the
+ * lossy-save check because it is unconditional: a node whose block cannot be
+ * loaded has no schema, so no other signal on this node can fire. This is the
+ * half of #1988 that colour cannot do — `validate_workflow` stays silent about
+ * these nodes (its unregistered-type check walks EDGES, and an unresolved node
+ * has no ports, so it has no edges), which left the canvas as the only place
+ * the fact could surface at all.
  */
 export function computeProblemSeverity(opts: {
   status: string;
@@ -156,9 +206,12 @@ export function computeProblemSeverity(opts: {
   schema?: BlockSchemaResponse;
   config: Record<string, unknown>;
   upstreamOmeFields: string[] | undefined;
+  /** #1988 — true when neither a summary nor a schema resolved for this node. */
+  unresolved?: boolean;
 }): BlockNodeData["problemSeverity"] {
-  const { status, category, schema, config, upstreamOmeFields } = opts;
+  const { status, category, schema, config, upstreamOmeFields, unresolved } = opts;
   if (status === "error") return "error";
+  if (unresolved) return "warning";
 
   const isSaveIo =
     category === "io" && (schema?.direction === "output" || schema?.direction === "save");
@@ -211,16 +264,25 @@ export function buildBlockNode(opts: BlockOpts): Node {
     selectedNodeId,
     highlighted,
   } = opts;
-  const category = summary?.base_category ?? schema?.base_category ?? "custom";
+  // #1988 — an EMPTY base_category still counts as resolved: the block was
+  // found, the backend simply reports "unknown" for a direct `Block` subclass.
+  // Only the absence of BOTH a summary and a schema means the `block_type`
+  // resolved to nothing here, and that is the state that must stay visible.
+  const resolvedCategory = summary?.base_category || schema?.base_category;
+  const unresolved = !summary && !schema;
+  const inferred = unresolved ? inferUnresolvedCategory(node.block_type) : undefined;
+  const category = resolvedCategory || inferred?.category || "unknown";
   // ADR-050 §2.5 — highest-priority problem signal, surfaced by the node's
   // unified NodeStatusSurface (error from runtime status, warning from the
-  // lossy-save check). Verbose detail stays in Logs / BottomPanel.
+  // lossy-save check or an unresolved block type). Verbose detail stays in
+  // Logs / BottomPanel.
   const problemSeverity = computeProblemSeverity({
     status,
     category,
     schema,
     config: params,
     upstreamOmeFields,
+    unresolved,
   });
   return {
     id: node.id,
@@ -234,6 +296,10 @@ export function buildBlockNode(opts: BlockOpts): Node {
       label,
       blockType: node.block_type,
       category,
+      // #1988 — carried so the node can draw the dashed body and so the
+      // warning badge can say WHY, instead of the generic Config wording.
+      unresolved,
+      uiIconHint: inferred?.iconHint,
       summary,
       schema,
       config: params,

--- a/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
+++ b/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
@@ -141,6 +141,13 @@ export interface NodeStatusSurfaceProps {
   /** Concise error detail surfaced in the tooltip (never inline). */
   errorSummary?: string;
   errorMessage?: string;
+  /**
+   * #1988 — concise warning detail for the tooltip, mirroring `errorSummary`.
+   * The default wording points at BottomPanel Config, which is right for the
+   * lossy-save warning but wrong for an unresolved block type (Config cannot
+   * fix a block that will not load). Callers that know better say so here.
+   */
+  warningSummary?: string;
   /** FR-012 — error activation: select node + open Logs. */
   onErrorClick?: () => void;
   /** FR-013 — warning activation: select node + open BottomPanel Config. */
@@ -172,6 +179,7 @@ export function NodeStatusSurface({
   problemSeverity = "none",
   errorSummary,
   errorMessage,
+  warningSummary,
   onErrorClick,
   onWarningClick,
 }: NodeStatusSurfaceProps) {
@@ -193,7 +201,7 @@ export function NodeStatusSurface({
     kind === "error"
       ? (errorSummary ?? errorMessage ?? "Error — open Logs for details")
       : kind === "warning"
-        ? "Warning — open Config for details"
+        ? (warningSummary ?? "Warning — open Config for details")
         : style.label;
 
   // Elapsed pill — absolute, pointer-events-none, sits just left of the badge.

--- a/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
+++ b/frontend/src/components/nodes/BlockNode.parts/categoryVisuals.ts
@@ -13,10 +13,28 @@
 // #1839 (per-block color + icon): a block may now declare its OWN node color
 // (`ui_color`, a CSS hex) and/or icon (`ui_icon`, a Lucide icon NAME) on its
 // backend `BlockSummary`. Resolution order is
-// `block-declared ?? category default ?? CUSTOM`: a block that declares neither
+// `block-declared ?? category default ?? UNKNOWN`: a block that declares neither
 // looks exactly as before. An unknown `ui_icon` name (not in the curated set
 // below) silently falls back to the category icon — never an error, never a
 // missing glyph. Custom SVG/asset glyphs are deferred (issue #1839 option b).
+//
+// #1988 (the grey puzzle did two jobs): everything that was not one of the six
+// used to land on a single grey `Puzzle` body, which conflated two unrelated
+// states. They are now separate visuals:
+//
+//   `unknown`    — a REGISTERED block whose class inherits `Block` directly, so
+//                  the registry's `_infer_category` reports "unknown". It has
+//                  ports, it runs, it is simply not one of the six. It gets a
+//                  macaron of its own (periwinkle) and the `Blocks` glyph.
+//   `unresolved` — a `block_type` that resolved to NOTHING here: package not
+//                  installed, drop-in deleted, or an agent naming a block that
+//                  does not exist. There is no class to ask, so there are no
+//                  ports and no metadata. It is drawn as a DASHED hole in the
+//                  canvas rather than a solid body, so it can never be mistaken
+//                  for a block that works.
+//
+// `Puzzle` is retired from both: a puzzle piece reads as "missing", which is
+// the wrong story for the first state and too mild for the second.
 
 import { createElement, forwardRef, type ComponentProps, type CSSProperties } from "react";
 // #1847: a block's `ui_icon` may now name ANY lucide glyph (PascalCase or
@@ -28,11 +46,12 @@ import * as LucideIcons from "lucide-react";
 import {
   // Base-category default icons (the 6 core block kinds), resolved statically.
   AppWindow,
+  Blocks,
   Code2,
+  FileQuestionMark,
   FolderInput,
   FunctionSquare,
   Package,
-  Puzzle,
   Sparkles,
   type LucideIcon,
 } from "lucide-react";
@@ -48,18 +67,44 @@ export interface CategoryVisual {
   border: string;
   /** Human label for the category (tooltip / a11y). */
   label: string;
+  /**
+   * #1988 — draw the body outline dashed instead of solid. Reserved for
+   * `unresolved`: a dashed outline reads as "there is supposed to be a block
+   * here", which a solid body never can.
+   */
+  dashed?: boolean;
 }
 
 // Saturated macaron fills — chosen to read clearly against the warm
 // `canvas` (#f5f1e8) background while staying soft (not neon). Each base
 // category gets a distinct hue; `fg` (icon/accent) is a deeper shade of the
 // same family for AA contrast, `border` sits one step under the fill.
-const CUSTOM: CategoryVisual = {
-  Icon: Puzzle,
-  bg: "#c9d1d9",
-  fg: "#4f5b66",
-  border: "#aeb9c4",
+
+// #1988 — the seventh macaron. Periwinkle is the widest gap left in the wheel
+// once io (sky), process (mint), code (violet), app (yellow), ai (coral) and
+// subworkflow (pink) are placed, so a no-category block stays tellable apart
+// from all six. Glyph/body contrast is 4.69, inside the 2.77–4.13 band the
+// shipping six already occupy.
+const UNKNOWN: CategoryVisual = {
+  Icon: Blocks,
+  bg: "#b5c4f2",
+  fg: "#33499e",
+  border: "#93a8e8",
   label: "Custom",
+};
+
+// #1988 — the unresolved state deliberately spends NO hue. Its body is a shade
+// of the canvas itself under a dashed border, so it reads as an empty slot in
+// the graph rather than as a seventh kind of block. Pairing it with the warning
+// badge (see `flowNodeBuilder`) is what keeps the "this did not resolve" fact
+// visible instead of hidden behind nicer styling.
+const UNRESOLVED: CategoryVisual = {
+  Icon: FileQuestionMark,
+  bg: "#efeade",
+  fg: "#8a8069",
+  border: "#b8ae99",
+  label: "Unresolved",
+  dashed: true,
 };
 
 export const categoryVisuals: Record<string, CategoryVisual> = {
@@ -81,7 +126,14 @@ export const categoryVisuals: Record<string, CategoryVisual> = {
     border: "#e49dbe",
     label: "Subworkflow",
   },
-  custom: CUSTOM,
+  // #1988 — a registered block that is none of the six (registry
+  // `_infer_category` returns "unknown" for a direct `Block` subclass).
+  unknown: UNKNOWN,
+  // Retained alias: `custom` was the pre-#1988 sentinel for the same "no base
+  // category" idea and is still what some persisted/older node data carries.
+  custom: UNKNOWN,
+  // #1988 — a `block_type` nothing in this environment could load.
+  unresolved: UNRESOLVED,
 };
 
 /** PascalCase a kebab/snake/space name: "folder-down" -> "FolderDown". */
@@ -179,7 +231,7 @@ export function getCategoryVisual(
   uiColor?: string | null,
   uiIcon?: string | null,
 ): CategoryVisual {
-  const base = (category && categoryVisuals[category]) || CUSTOM;
+  const base = (category && categoryVisuals[category]) || UNKNOWN;
   if (!uiColor && !uiIcon) return base;
 
   const resolved = resolveIconByName(uiIcon);

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -43,7 +43,14 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   // category (lucide line icon), with optional per-block overrides (#1839):
   // a block may declare its own `ui_color` / `ui_icon` on its summary, which
   // take precedence over the category default (unknown icon name falls back).
-  const visual = getCategoryVisual(data.category, data.summary?.ui_color, data.summary?.ui_icon);
+  // #1988 — `uiIconHint` is the name-derived guess for an UNRESOLVED node and
+  // is only consulted when the block declared nothing itself, which an
+  // unresolved block never can (it has no summary at all).
+  const visual = getCategoryVisual(
+    data.category,
+    data.summary?.ui_color,
+    data.summary?.ui_icon ?? data.uiIconHint,
+  );
   const CategoryIcon = visual.Icon;
 
   // ADR-028 Addendum 1 §D4 — compute effective ports from the dynamic-port
@@ -213,6 +220,14 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           borderRadius: NODE_BORDER_RADIUS,
           backgroundColor: visual.bg,
           borderColor: selected ? undefined : visual.border,
+          // #1988 — a dashed outline marks the unresolved state. It is driven
+          // by the FACT (`data.unresolved`), not by the palette: an unresolved
+          // loader borrows the solid IO colours so it still reads as a loader,
+          // and it must stay dashed anyway or the borrowed palette would be the
+          // prettier styling that hides the defect. Selection still wins (it
+          // repaints the border via `border-ember`), so the dash never fights
+          // the selection affordance.
+          borderStyle: (visual.dashed || data.unresolved) && !selected ? "dashed" : undefined,
         }}
       >
         {/* Block-kind mark — single lucide line icon in the category accent
@@ -232,6 +247,15 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
           problemSeverity={data.problemSeverity}
           errorSummary={data.errorSummary}
           errorMessage={data.errorMessage}
+          // #1988 — name the actual defect. The generic "open Config" wording
+          // would be a dead end here: no Config exists for a block that never
+          // loaded, and the workflow validator never mentions this node either.
+          warningSummary={
+            data.unresolved
+              ? `Block type "${data.blockType}" is not available in this project — ` +
+                "its package or file could not be loaded, so this node has no ports and will fail on run."
+              : undefined
+          }
           onErrorClick={data.onErrorClick}
           onWarningClick={data.onWarningClick}
         />

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -257,7 +257,13 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
               : undefined
           }
           onErrorClick={data.onErrorClick}
-          onWarningClick={data.onWarningClick}
+          // #1988 — withhold the warning action for an unresolved node. The
+          // shared handler selects the node and opens BottomPanel Config
+          // (FR-013), which is the dead end the tooltip above disclaims: a
+          // block that never loaded has no config to edit. Passing undefined
+          // leaves the badge as a non-interactive marker carrying the
+          // explanation, rather than a control that goes nowhere useful.
+          onWarningClick={data.unresolved ? undefined : data.onWarningClick}
         />
 
         {/* Port handles + variadic +/- controls on the left/right rails.

--- a/frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx
@@ -1,0 +1,96 @@
+// #1988 — how the two ex-grey states actually render.
+//
+// The colour half of #1988 is covered by the palette tests; this file pins the
+// half that colour cannot do: an unresolved node must keep LOOKING unresolved
+// after the restyle, and it must say what is wrong in words a user can act on.
+
+import { cleanup, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderNode } from "./test-utils";
+
+afterEach(cleanup);
+
+function body(container: HTMLElement): HTMLElement {
+  const el = container.querySelector("[data-testid='block-node-body']");
+  if (!(el instanceof HTMLElement)) throw new Error("node body not rendered");
+  return el;
+}
+
+describe("#1988 unresolved node rendering", () => {
+  it("draws the body with a dashed outline", () => {
+    const { container } = renderNode({ category: "unresolved", unresolved: true });
+    expect(body(container).style.borderStyle).toBe("dashed");
+  });
+
+  it("leaves every resolved category solid", () => {
+    const { container } = renderNode({ category: "process" });
+    expect(body(container).style.borderStyle).toBe("");
+  });
+
+  it("stays dashed even when it borrows the IO palette", () => {
+    // An unresolved loader is drawn with the IO body so it still reads as a
+    // loader. If the dash were driven by the palette instead of by the fact,
+    // that borrowed colour would be exactly the prettier styling #1988 says
+    // must not hide the defect.
+    const { container } = renderNode({
+      category: "io",
+      unresolved: true,
+      uiIconHint: "folder-input",
+    });
+    const el = body(container);
+    expect(el.style.borderStyle).toBe("dashed");
+    expect(el.style.backgroundColor).toBe("rgb(159, 212, 238)");
+  });
+
+  it("leaves a no-category block solid — it works, it is just not one of the six", () => {
+    const { container } = renderNode({ category: "unknown" });
+    const el = body(container);
+    expect(el.style.borderStyle).toBe("");
+    expect(el.style.backgroundColor).toBe("rgb(181, 196, 242)");
+  });
+
+  it("does not fight the selection border", () => {
+    // Selection repaints the border through `border-ember`; the dash would
+    // otherwise override the selected affordance.
+    const { container } = renderNode({ category: "unresolved", unresolved: true }, true);
+    expect(body(container).style.borderStyle).toBe("");
+  });
+
+  it("raises the warning badge, not a silent node", () => {
+    renderNode({ category: "unresolved", unresolved: true, problemSeverity: "warning" });
+    const surface = screen.getByTestId("node-status-surface");
+    expect(surface.getAttribute("data-surface-kind")).toBe("warning");
+    expect(surface.getAttribute("data-icon")).toBe("alert-triangle");
+  });
+
+  it("names the missing block type instead of pointing at a Config that cannot help", () => {
+    renderNode({
+      category: "unresolved",
+      unresolved: true,
+      problemSeverity: "warning",
+      blockType: "srs_baseline_block",
+    });
+    const title = screen.getByTestId("node-status-surface").getAttribute("title") ?? "";
+    expect(title).toContain("srs_baseline_block");
+    expect(title).toContain("not available in this project");
+    expect(title).not.toContain("open Config");
+  });
+
+  it("keeps the generic Config wording for the lossy-save warning", () => {
+    // The unresolved copy is opt-in, so the pre-existing warning is unchanged.
+    renderNode({ category: "io", problemSeverity: "warning" });
+    const title = screen.getByTestId("node-status-surface").getAttribute("title") ?? "";
+    expect(title).toBe("Warning — open Config for details");
+  });
+
+  it("shows the raw block type under an unresolved node so it can be identified", () => {
+    renderNode({
+      category: "unresolved",
+      unresolved: true,
+      label: "srs_baseline_block",
+      blockType: "srs_baseline_block",
+    });
+    expect(screen.getByTestId("block-node-label").textContent).toBe("srs_baseline_block");
+  });
+});

--- a/frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx
+++ b/frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx
@@ -77,6 +77,27 @@ describe("#1988 unresolved node rendering", () => {
     expect(title).not.toContain("open Config");
   });
 
+  it("offers no click-through on the unresolved warning", () => {
+    // The shared warning handler opens BottomPanel Config, which cannot help a
+    // block that never loaded — the tooltip says so, so the badge must not
+    // still act as a control that goes there.
+    renderNode({
+      category: "unresolved",
+      unresolved: true,
+      problemSeverity: "warning",
+      onWarningClick: () => {
+        throw new Error("unresolved node must not route to Config");
+      },
+    });
+    expect(screen.queryByTestId("node-status-surface-button")).toBeNull();
+    expect(screen.getByTestId("node-status-surface")).toBeTruthy();
+  });
+
+  it("keeps the click-through for an ordinary warning", () => {
+    renderNode({ category: "io", problemSeverity: "warning", onWarningClick: () => {} });
+    expect(screen.getByTestId("node-status-surface-button")).toBeTruthy();
+  });
+
   it("keeps the generic Config wording for the lossy-save warning", () => {
     // The unresolved copy is opt-in, so the pre-existing warning is unchanged.
     renderNode({ category: "io", problemSeverity: "warning" });

--- a/frontend/src/store/__tests__/blockSchemaEviction.test.ts
+++ b/frontend/src/store/__tests__/blockSchemaEviction.test.ts
@@ -1,0 +1,75 @@
+// #1988 — the block catalog is the authority on which block types exist.
+//
+// `setBlockSchema` only merges, so before this the schema map grew
+// monotonically: deleting a drop-in block and reloading the catalog left its
+// schema behind forever. Anything asking "did this block type resolve?" would
+// still find a schema and draw the node as a working block — stale ports, no
+// warning — which is precisely the state #1988 exists to surface.
+
+import { describe, expect, it } from "vitest";
+
+import { useAppStore } from "../index";
+import type { BlockSchemaResponse, BlockSummary } from "../../types/api";
+
+function summary(type_name: string): BlockSummary {
+  return {
+    name: type_name,
+    type_name,
+    base_category: "process",
+    input_ports: [],
+    output_ports: [],
+  } as unknown as BlockSummary;
+}
+
+function schema(type_name: string): BlockSchemaResponse {
+  return {
+    name: type_name,
+    type_name,
+    input_ports: [],
+    output_ports: [],
+  } as unknown as BlockSchemaResponse;
+}
+
+describe("#1988 block schema cache eviction", () => {
+  it("drops schemas for types the refreshed catalog no longer contains", () => {
+    const store = useAppStore.getState();
+    store.setBlocks([summary("keeper_block"), summary("doomed_block")]);
+    store.setBlockSchema(schema("keeper_block"));
+    store.setBlockSchema(schema("doomed_block"));
+    expect(Object.keys(useAppStore.getState().blockSchemas).sort()).toEqual([
+      "doomed_block",
+      "keeper_block",
+    ]);
+
+    // The drop-in file was deleted and the catalog reloaded without it.
+    useAppStore.getState().setBlocks([summary("keeper_block")]);
+
+    const after = useAppStore.getState().blockSchemas;
+    expect(Object.keys(after)).toEqual(["keeper_block"]);
+    expect(after.doomed_block).toBeUndefined();
+  });
+
+  it("keeps schemas for types still in the catalog", () => {
+    const store = useAppStore.getState();
+    store.setBlocks([summary("a_block"), summary("b_block")]);
+    store.setBlockSchema(schema("a_block"));
+    store.setBlockSchema(schema("b_block"));
+
+    useAppStore.getState().setBlocks([summary("b_block"), summary("a_block")]);
+
+    expect(Object.keys(useAppStore.getState().blockSchemas).sort()).toEqual(["a_block", "b_block"]);
+  });
+
+  it("does not prune on an empty catalog", () => {
+    // `setBlocks([])` happens while a project loads and between projects.
+    // Pruning there would throw away schemas the next render needs.
+    const store = useAppStore.getState();
+    store.setBlocks([summary("live_block")]);
+    store.setBlockSchema(schema("live_block"));
+
+    useAppStore.getState().setBlocks([]);
+
+    expect(useAppStore.getState().blocks).toEqual([]);
+    expect(useAppStore.getState().blockSchemas.live_block).toBeDefined();
+  });
+});

--- a/frontend/src/store/paletteSlice.ts
+++ b/frontend/src/store/paletteSlice.ts
@@ -6,7 +6,26 @@ export const createPaletteSlice: StateCreator<AppStore, [], [], PaletteSlice> = 
   blocks: [],
   blockSchemas: {},
   paletteSearch: "",
-  setBlocks: (blocks) => set({ blocks }),
+  // #1988 — the block catalog is the authority on which block types exist, so
+  // replacing it must also evict schemas for types it no longer contains.
+  // `setBlockSchema` only ever merges, so without this the map grows
+  // monotonically: delete a drop-in block and reload the catalog, and its stale
+  // schema survives. Anything asking "did this type resolve?" would then still
+  // see a schema and render the node as a working block — with stale ports and
+  // no warning — which is exactly the state #1988 exists to make visible.
+  //
+  // Guarded on a non-empty catalog: `setBlocks([])` happens while a project is
+  // loading or between projects, and pruning on that would throw away schemas
+  // the very next render needs.
+  setBlocks: (blocks) =>
+    set((state) => {
+      if (blocks.length === 0) return { blocks };
+      const live = new Set(blocks.map((block) => block.type_name));
+      const kept = Object.fromEntries(
+        Object.entries(state.blockSchemas).filter(([typeName]) => live.has(typeName)),
+      );
+      return { blocks, blockSchemas: kept };
+    }),
   setBlockSchema: (schema) =>
     set((state) => ({
       blockSchemas: {

--- a/frontend/src/types/ui.ts
+++ b/frontend/src/types/ui.ts
@@ -24,6 +24,21 @@ export interface BlockNodeData extends Record<string, unknown> {
   label: string;
   blockType: string;
   category: string;
+  /**
+   * #1988 — true when `blockType` resolved to NOTHING in this environment
+   * (neither a `BlockSummary` nor a `BlockSchemaResponse` came back): the
+   * package is not installed, the drop-in file is gone, or an agent named a
+   * block that does not exist. Distinct from a block that resolved fine but
+   * reports `base_category: "unknown"` because it inherits `Block` directly —
+   * that one works and is drawn as an ordinary node.
+   */
+  unresolved?: boolean;
+  /**
+   * #1988 — a Lucide icon name guessed from `blockType` for an unresolved node
+   * (IO only), so a loader still reads as a loader. Weaker than the block's own
+   * `summary.ui_icon`, which is authoritative whenever the block resolved.
+   */
+  uiIconHint?: string;
   summary?: BlockSummary;
   schema?: BlockSchemaResponse;
   config?: Record<string, unknown>;

--- a/src/scistudio/ai/agent/mcp/tools_workflow/read.py
+++ b/src/scistudio/ai/agent/mcp/tools_workflow/read.py
@@ -244,8 +244,14 @@ async def validate_workflow(
     # the validator falls back to the backend process's working directory and
     # falsely rejects a valid project-relative CodeBlock ``script_path`` that run
     # start accepts.
-    errors = _validate(definition, registry=ctx.block_registry, project_dir=ctx.project_dir)
-    return ValidateWorkflowResult(valid=not errors, errors=list(errors))
+    diagnostics = _validate(definition, registry=ctx.block_registry, project_dir=ctx.project_dir)
+    # #1988: a leading ``Warning:`` marks an advisory diagnostic, the convention
+    # the API layer already applies (``api/runtime/_workflows.py``). ``valid``
+    # must reflect hard errors only, or an advisory would tell the agent a
+    # workflow is invalid when run start would dispatch it happily. Every
+    # diagnostic is still returned, so nothing is hidden from the agent.
+    valid = not any(not d.startswith("Warning:") for d in diagnostics)
+    return ValidateWorkflowResult(valid=valid, errors=list(diagnostics))
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/api/schemas.py
+++ b/src/scistudio/api/schemas.py
@@ -167,8 +167,11 @@ class BlockSummary(BaseModel):
 
     name: str
     type_name: str
-    # #588: base_category is always one of 6 base types (io, process, code,
-    # app, ai, subworkflow).  subcategory is the optional palette grouping label.
+    # #588: base_category is one of the 6 base types (io, process, code, app,
+    # ai, subworkflow). #1988: it is also "unknown" for a block that extends
+    # Block directly, which _infer_category resolves by issubclass and cannot
+    # place — a valid block, drawn with its own node colour rather than as an
+    # error. subcategory is the optional palette grouping label.
     base_category: str = ""
     subcategory: str = ""
     # #1839: optional block-declared canvas-node display hints. ``ui_color`` is

--- a/src/scistudio/blocks/registry/__init__.py
+++ b/src/scistudio/blocks/registry/__init__.py
@@ -218,7 +218,12 @@ class BlockSpec:
     """Broad block family.
 
     One of ``"io"``, ``"process"``, ``"code"``, ``"app"``, ``"ai"``, or
-    ``"subworkflow"``.
+    ``"subworkflow"`` -- or ``"unknown"`` for a class that extends
+    :class:`~scistudio.blocks.base.block.Block` directly rather than one of the
+    six bases, which :func:`~scistudio.blocks.registry._spec._infer_category`
+    resolves by ``issubclass`` and cannot place. ``"unknown"`` describes a
+    perfectly valid block; the canvas gives it its own node colour (#1988) and
+    does not treat it as an error.
     """
     subcategory: str = ""
     """Optional finer grouping within :attr:`base_category`, for palette organisation."""

--- a/src/scistudio/cli/main.py
+++ b/src/scistudio/cli/main.py
@@ -96,8 +96,27 @@ def _validate_workflow(
         return []
 
 
-def _report_validation_errors(errors: list[str]) -> None:
-    """Print validation errors and exit if the list is non-empty."""
+def _report_validation_errors(diagnostics: list[str]) -> None:
+    """Print validation diagnostics and exit only when one is a hard error.
+
+    ``validate_workflow`` returns a single list in which a leading ``Warning:``
+    marks an advisory diagnostic. The API layer has always split on that prefix
+    (``api/runtime/_workflows.py``), but this CLI treated the list as
+    all-or-nothing, so an advisory made ``scistudio run`` refuse to dispatch.
+
+    That was latent until #1988: the validator's unregistered-block-type report
+    used to reach only nodes that had edges, and a node whose block does not
+    resolve has no ports and therefore no edges — so the warning that now fires
+    for those nodes had no way to fire before. Widening the report exposed the
+    prefix being ignored here. Warnings are printed either way; only hard errors
+    stop the command.
+    """
+    warnings = [d for d in diagnostics if d.startswith("Warning:")]
+    errors = [d for d in diagnostics if not d.startswith("Warning:")]
+    if warnings:
+        typer.echo("Validation warnings:")
+        for warning in warnings:
+            typer.echo(f"  - {warning}")
     if errors:
         typer.echo("Validation errors:")
         for err in errors:

--- a/src/scistudio/workflow/validator.py
+++ b/src/scistudio/workflow/validator.py
@@ -338,10 +338,17 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
     # canvas has the same gap (ADR-050 §2.1) and now draws these nodes as
     # `unresolved`; this is the diagnostics half of that fact.
     #
-    # Emitted with the ``Warning:`` prefix, which callers treat as
-    # non-blocking (see ``api/runtime/_workflows.py``). Reporting it does not
-    # change whether the workflow saves or dispatches — it only stops the
-    # silence.
+    # Emitted with the ``Warning:`` prefix so that reporting the fact does not
+    # change whether a workflow saves or dispatches — it only stops the silence.
+    #
+    # That property is a contract across CALLERS, not something this function
+    # can guarantee alone, and it did not hold when this check was written. The
+    # API layer split on the prefix (``api/runtime/_workflows.py``), but
+    # ``cli/main.py::_report_validation_errors`` exited on any non-empty list
+    # and the MCP ``validate_workflow`` tool computed ``valid=not errors``, so
+    # both would have refused a workflow over an advisory. Nothing exposed it
+    # because the pre-#1988 report only reached nodes with edges. Both were
+    # fixed alongside this check; a new consumer must split on the prefix too.
     #
     # ``subworkflow_broken`` is excluded: it is a synthetic flattener marker
     # rather than a real block type, and Check 1.5 already reports it (as a

--- a/src/scistudio/workflow/validator.py
+++ b/src/scistudio/workflow/validator.py
@@ -200,6 +200,12 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
     3. **Edge node references** -- source / target nodes exist.
     4. **Cycle detection** -- delegates to :func:`~scistudio.engine.dag.build_dag`
        and :func:`~scistudio.engine.dag.topological_sort`.
+    4.5. **Unregistered block types, per node** (#1988) -- every node whose
+       ``block_type`` is absent from *registry* is reported once, as a
+       ``Warning:``. Check 5 notices the same thing but walks edges, and a node
+       that does not resolve has no ports and therefore no edges, so such nodes
+       used to produce no diagnostic at all (only a run-time failure). Only
+       when *registry* is provided.
     5. **Type compatibility** -- port type matching via
        :func:`~scistudio.blocks.base.ports.validate_connection` (only when
        *registry* is provided).
@@ -322,6 +328,40 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
 
     node_map = {node.id: node for node in workflow.nodes}
 
+    # ------------------------------------------------------------------
+    # Check 4.5 (#1988): unregistered block types, reported per NODE
+    # ------------------------------------------------------------------
+    # Check 5 below also notices an unregistered block type, but it walks
+    # EDGES. A node whose ``block_type`` does not resolve has no ports, so it
+    # attracts no edges, so it was reported nowhere at all: a workflow of such
+    # nodes validated clean and only failed once the run reached dispatch. The
+    # canvas has the same gap (ADR-050 §2.1) and now draws these nodes as
+    # `unresolved`; this is the diagnostics half of that fact.
+    #
+    # Emitted with the ``Warning:`` prefix, which callers treat as
+    # non-blocking (see ``api/runtime/_workflows.py``). Reporting it does not
+    # change whether the workflow saves or dispatches — it only stops the
+    # silence.
+    #
+    # ``subworkflow_broken`` is excluded: it is a synthetic flattener marker
+    # rather than a real block type, and Check 1.5 already reports it (as a
+    # hard error in strict mode). Warning about it here would double-report
+    # the same node.
+    # Imported locally for the same reason Check 1.5 does: `workflow.flatten`
+    # imports back into this package.
+    from scistudio.workflow.flatten import SUBWORKFLOW_BROKEN_TYPE as _BROKEN_TYPE
+
+    unregistered_node_ids: set[str] = set()
+    for node in workflow.nodes:
+        if node.block_type == _BROKEN_TYPE:
+            continue
+        if registry.get_spec(node.block_type) is None:
+            unregistered_node_ids.add(node.id)
+            errors.append(
+                f"Warning: node '{node.id}' uses block type '{node.block_type}', "
+                "which is not registered in this project"
+            )
+
     # ADR-028 Addendum 1 D6: cache effective ports per node so we only
     # instantiate each block once across both Check 5 and Check 6.
     effective_ports_cache: dict[str, tuple[list[Any], list[Any]]] = {}
@@ -351,20 +391,26 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
         if src_node is None or tgt_node is None:
             continue  # already reported in Check 3
 
+        # #1988: Check 4.5 already named every unregistered node once. Repeating
+        # it here per incident edge would report the same node several times, so
+        # the edge walk now only says what is specific to it — that this edge's
+        # type check is being skipped — and stays silent when 4.5 has spoken.
         src_spec = registry.get_spec(src_node.block_type)
         if src_spec is None:
-            errors.append(
-                f"Warning: block type '{src_node.block_type}' not in registry, "
-                f"skipping type check for node '{src_node_id}'"
-            )
+            if src_node_id not in unregistered_node_ids:
+                errors.append(
+                    f"Warning: block type '{src_node.block_type}' not in registry, "
+                    f"skipping type check for node '{src_node_id}'"
+                )
             continue
 
         tgt_spec = registry.get_spec(tgt_node.block_type)
         if tgt_spec is None:
-            errors.append(
-                f"Warning: block type '{tgt_node.block_type}' not in registry, "
-                f"skipping type check for node '{tgt_node_id}'"
-            )
+            if tgt_node_id not in unregistered_node_ids:
+                errors.append(
+                    f"Warning: block type '{tgt_node.block_type}' not in registry, "
+                    f"skipping type check for node '{tgt_node_id}'"
+                )
             continue
 
         # ADR-028 Addendum 1 D6: use effective ports from a per-node block

--- a/tests/ai/agent/mcp/test_validate_workflow_warning_prefix.py
+++ b/tests/ai/agent/mcp/test_validate_workflow_warning_prefix.py
@@ -1,0 +1,87 @@
+"""#1988 — an advisory diagnostic must not tell the agent a workflow is invalid.
+
+``validate_workflow`` returns one list in which a leading ``Warning:`` marks an
+advisory, the convention the API layer already applies. The MCP tool computed
+``valid=not errors``, so any advisory reported ``valid=False`` — telling the
+agent to fix a workflow that run start would dispatch. That became reachable
+when #1988 widened the unregistered-block-type report to nodes with no edges.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scistudio.ai.agent.mcp import _context, tools_workflow
+from scistudio.blocks.registry import BlockRegistry
+from scistudio.core.types.registry import TypeRegistry
+
+
+@dataclass
+class _StubRuntime:
+    """The slice of the MCP context these two tools actually read."""
+
+    block_registry: BlockRegistry = field(default_factory=BlockRegistry)
+    type_registry: TypeRegistry = field(default_factory=TypeRegistry)
+    workflow_runs: dict[str, Any] = field(default_factory=dict)
+    active_workflow_id: str | None = None
+    _project_dir: Path | None = None
+
+    @property
+    def project_dir(self) -> Path | None:
+        return self._project_dir
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> Iterator[_StubRuntime]:
+    runtime = _StubRuntime(_project_dir=tmp_path)
+    runtime.block_registry.scan()
+    runtime.type_registry.scan_builtins()
+    _context.set_context(runtime)
+    yield runtime
+    _context.set_context(None)
+
+
+def _run(coro: Coroutine[Any, Any, Any]) -> Any:
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+_UNRESOLVED_ONLY = """
+workflow:
+  name: unresolved-only
+  nodes:
+    - id: orphan
+      block_type: srs_baseline_block
+  edges: []
+"""
+
+_WITH_A_HARD_ERROR = """
+workflow:
+  name: duplicate-ids
+  nodes:
+    - id: dup
+      block_type: srs_baseline_block
+    - id: dup
+      block_type: srs_baseline_block
+  edges: []
+"""
+
+
+def test_an_unresolved_node_reports_valid_with_the_warning_returned(ctx: _StubRuntime) -> None:
+    result = _run(tools_workflow.validate_workflow(_UNRESOLVED_ONLY))
+
+    assert result.valid is True, result.errors
+    assert any("srs_baseline_block" in d for d in result.errors)
+    assert all(d.startswith("Warning:") for d in result.errors), result.errors
+
+
+def test_a_hard_error_still_reports_invalid(ctx: _StubRuntime) -> None:
+    result = _run(tools_workflow.validate_workflow(_WITH_A_HARD_ERROR))
+
+    assert result.valid is False
+    assert any("Duplicate node id" in d for d in result.errors), result.errors

--- a/tests/cli/test_validation_warning_prefix.py
+++ b/tests/cli/test_validation_warning_prefix.py
@@ -1,0 +1,58 @@
+"""#1988 — an advisory diagnostic must not stop a CLI command.
+
+``validate_workflow`` returns one list in which a leading ``Warning:`` marks an
+advisory. The API layer has always split on that prefix; the CLI treated the
+list as all-or-nothing, so an advisory made ``scistudio run`` refuse to
+dispatch. That was latent until #1988 widened the unregistered-block-type report
+to nodes with no edges — which is every node whose block failed to resolve,
+because such a node has no ports and therefore no edges.
+"""
+
+from __future__ import annotations
+
+import pytest
+import typer
+
+from scistudio.cli.main import _report_validation_errors
+
+
+def test_warnings_alone_do_not_stop_the_command(capsys: pytest.CaptureFixture[str]) -> None:
+    _report_validation_errors(
+        [
+            "Warning: node 'orphan' uses block type 'srs_baseline_block', which is not registered in this project",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert "Validation warnings:" in out
+    assert "srs_baseline_block" in out
+    assert "Validation errors:" not in out
+
+
+def test_a_hard_error_still_stops_the_command(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(typer.Exit) as excinfo:
+        _report_validation_errors(["Workflow contains a cycle"])
+
+    assert excinfo.value.exit_code == 1
+    assert "Validation errors:" in capsys.readouterr().out
+
+
+def test_a_hard_error_alongside_a_warning_still_stops(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(typer.Exit) as excinfo:
+        _report_validation_errors(
+            [
+                "Warning: node 'orphan' uses block type 'ghost_block', which is not registered in this project",
+                "Duplicate node id: 'a'",
+            ]
+        )
+
+    assert excinfo.value.exit_code == 1
+    out = capsys.readouterr().out
+    # Both are reported; only the hard error decides the exit.
+    assert "ghost_block" in out
+    assert "Duplicate node id" in out
+
+
+def test_no_diagnostics_prints_nothing(capsys: pytest.CaptureFixture[str]) -> None:
+    _report_validation_errors([])
+    assert capsys.readouterr().out == ""

--- a/tests/workflow/test_validator.py
+++ b/tests/workflow/test_validator.py
@@ -272,7 +272,81 @@ class TestValidatorTypeCompat:
             edges=[EdgeDef(source="A:out", target="B:in")],
         )
         errors = validate_workflow(wf, registry=reg)
-        assert any("Warning: block type 'unknown_producer' not in registry" in e for e in errors)
+        # #1988 reports this per node (Check 4.5) rather than per edge, so both
+        # ends are now named — the old edge walk stopped at the source.
+        assert any("Warning: node 'A' uses block type 'unknown_producer'" in e for e in errors)
+        assert any("Warning: node 'B' uses block type 'unknown_consumer'" in e for e in errors)
+
+    def test_unregistered_node_reported_without_any_edges(self) -> None:
+        """#1988: an unresolved node is reported even when nothing connects to it.
+
+        This is the hole the issue was filed for. The edge walk (Check 5) was
+        the only thing reporting unregistered block types, and a node whose
+        block does not resolve has no ports, so it attracts no edges and was
+        never reported at all: the workflow validated clean and only failed once
+        the run reached dispatch.
+        """
+        reg = _registry_from_specs()  # empty registry
+
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="orphan", block_type="srs_baseline_block")],
+            edges=[],
+        )
+        errors = validate_workflow(wf, registry=reg)
+
+        assert any("Warning: node 'orphan' uses block type 'srs_baseline_block'" in e for e in errors)
+
+    def test_unregistered_node_warning_is_not_a_hard_error(self) -> None:
+        """#1988: reporting the fact must not change whether the workflow runs.
+
+        Callers split diagnostics on the ``Warning:`` prefix
+        (``api/runtime/_workflows.py``), so the new report has to carry it or a
+        workflow that used to save and dispatch would suddenly be refused.
+        """
+        reg = _registry_from_specs()
+        wf = WorkflowDefinition(
+            nodes=[NodeDef(id="orphan", block_type="nope_block")],
+            edges=[],
+        )
+        errors = validate_workflow(wf, registry=reg)
+
+        assert errors, "the unresolved node must produce a diagnostic"
+        assert all(e.startswith("Warning:") for e in errors), errors
+
+    def test_unregistered_node_reported_once_not_once_per_edge(self) -> None:
+        """#1988: Check 4.5 and Check 5 must not both report the same node."""
+        spec = _make_spec(
+            "consumer",
+            input_ports=[InputPort(name="a", accepted_types=[Array]), InputPort(name="b", accepted_types=[Array])],
+        )
+        reg = _registry_from_specs(spec)
+
+        # One unregistered producer feeding two edges: the old edge walk would
+        # have named it twice.
+        wf = WorkflowDefinition(
+            nodes=[
+                NodeDef(id="ghost", block_type="ghost_block"),
+                NodeDef(id="sink", block_type="consumer"),
+            ],
+            edges=[
+                EdgeDef(source="ghost:out", target="sink:a"),
+                EdgeDef(source="ghost:out", target="sink:b"),
+            ],
+        )
+        errors = validate_workflow(wf, registry=reg)
+
+        mentions = [e for e in errors if "ghost_block" in e]
+        assert len(mentions) == 1, mentions
+
+    def test_registered_nodes_produce_no_unregistered_warning(self) -> None:
+        """#1988: the new pass stays quiet for a workflow that resolves."""
+        spec = _make_spec("producer", output_ports=[OutputPort(name="out", accepted_types=[Array])])
+        reg = _registry_from_specs(spec)
+
+        wf = WorkflowDefinition(nodes=[NodeDef(id="A", block_type="producer")], edges=[])
+        errors = validate_workflow(wf, registry=reg)
+
+        assert not any("is not registered in this project" in e for e in errors)
 
     def test_unknown_port_name_warning(self) -> None:
         """Port name not found on the block spec produces a warning."""

--- a/tests/workflow/test_validator_codeblock_v2.py
+++ b/tests/workflow/test_validator_codeblock_v2.py
@@ -19,7 +19,13 @@ class _CodeBlockValidationRegistry(BlockRegistry):
         self._registry[spec.name] = spec
         self._aliases[spec.type_name] = spec.name
 
-    def find_saver_capability(
+    # These two stubs deliberately narrow the registry's signature: the tests
+    # below only need a truthy capability, never a real ``FormatCapability``.
+    # The mismatch is intentional and pre-dates #1988; it is only visible now
+    # because the pre-commit mypy hook type-checks staged files directly while
+    # pyproject's mypy is scoped to ``packages = ["scistudio"]`` and never sees
+    # ``tests/`` at all (issue #2115).
+    def find_saver_capability(  # type: ignore[override]
         self,
         *,
         data_type: type,
@@ -28,7 +34,7 @@ class _CodeBlockValidationRegistry(BlockRegistry):
     ) -> object:
         return object()
 
-    def find_loader_capability(
+    def find_loader_capability(  # type: ignore[override]
         self,
         *,
         data_type: type,
@@ -69,7 +75,7 @@ def _node_config(project_dir: Path, script_path: str, **params: object) -> dict[
             ],
         }
     }
-    config["params"].update(params)  # type: ignore[union-attr]
+    config["params"].update(params)  # type: ignore[union-attr, attr-defined]
     return config
 
 
@@ -164,7 +170,12 @@ def test_validate_workflow_preserves_unknown_block_warning() -> None:
 
     errors = validate_workflow(workflow, registry=BlockRegistry())
 
-    assert any("Warning: block type 'not_registered_source' not in registry" in error for error in errors)
+    # #1988 moved this report from the edge walk (Check 5) to a per-node pass
+    # (Check 4.5), so the diagnostic now names the node rather than the edge it
+    # happened to sit on. What this test guards is unchanged: an unregistered
+    # block type is still reported, and is still not mistaken for a CodeBlock
+    # problem.
+    assert any("Warning: node 'source' uses block type 'not_registered_source'" in error for error in errors)
     assert not any("CodeBlock" in error for error in errors)
 
 


### PR DESCRIPTION
## What

The canvas fell back to one grey `Puzzle` body for everything that was not one
of the six base categories. That single grey was answering two unrelated
questions, so a block that works and a block that is broken looked identical.
This splits them and closes all three asks in #1988.

**A registered block with no base category** (`base_category: "unknown"` — its
class extends `Block` directly) now gets a body colour of its own,
`#b5c4f2` with the `blocks` glyph. It has ports and it runs; it raises no
problem signal. `Puzzle` is retired: a puzzle piece reads as "missing", which
is the wrong story for a working block.

**A `block_type` that resolved to nothing here** is drawn as a dashed outline in
a shade of the canvas — an empty slot in the graph rather than a seventh kind of
block — and raises a `warning` that names the block type and says the node has
no ports and will fail on run.

That warning is the load-bearing part. `validate_workflow` found unregistered
block types only from Check 5, which walks **edges**; an unresolved node has no
ports, therefore no edges, therefore no report. A workflow full of these
validated clean and only failed at run time.

Both surfaces report it now. The canvas draws the node, and `validate_workflow`
gains **Check 4.5**, a per-node pass that names every unregistered `block_type`
once. It carries the `Warning:` prefix so reporting the fact does not change
whether a workflow saves or dispatches — only that it is no longer silent.
Check 5 keeps its own message solely for the one case 4.5 skips: a
`subworkflow_broken` marker in draft mode, where Check 1.5 does not run.

That non-blocking property is a contract across **callers**, and it did not hold
when the check was first written here — see the review-fix section below.

**IO-only name inference.** Package-owned loaders are folded into the core Load
block by design and are not offered separately, so an agent naming one produces
a node that cannot resolve. When an unresolved `block_type` reads as a loader or
a saver, the node borrows the IO palette and the matching load/save glyph so it
still reads as what it was meant to be. Scope is IO only — there is no general
name→category heuristic.

## Two things worth a reviewer's eye

- **The dash is driven by the fact, not by the palette.** An unresolved loader
  takes the solid IO colours, so if the dashed border came from the visual it
  would be lost exactly in the case where the node looks most plausible. It is
  keyed off `data.unresolved` instead.
- **An empty `base_category` is still resolved.** The old `??` chain treated
  `""` as present. A block that came back with an empty category is a block that
  was found, so it is `unknown`, not unresolved.

## Protected-core scope (owner-authorised)

Three files under protected paths are touched. The owner authorised this scope
and is applying `admin-approved:core-change`; the ledger records the directive.

- `src/scistudio/workflow/validator.py` — Check 4.5, above.
- `src/scistudio/blocks/registry/__init__.py` and `src/scistudio/api/schemas.py`
  — a contract drift found while doing this: both documented `base_category` as
  "always one of 6 base types", while `_infer_category` has always returned a
  seventh value, `"unknown"`. Docstring/comment only, no behaviour change.

## Fixed after the Codex review

Three real defects, all confirmed against the code before fixing.

**The `Warning:` prefix was not actually non-blocking (was P2, effectively worse).**
The claim that reporting an unresolved node changes nothing about dispatch was
verified against the API layer only, and then stated as if it were general. It
was false for two other consumers: `cli/main.py::_report_validation_errors`
exited on any non-empty diagnostic list, so `scistudio run` would have refused a
workflow containing an unconnected unregistered node; and the MCP
`validate_workflow` tool computed `valid=not errors`, so it would have told the
agent such a workflow was invalid. Both now split on the prefix, matching what
the API already did. The claim is corrected in the validator comment, ADR-050
and the changelog rather than quietly made true.

**A deleted block still rendered as a working node (P1).** `setBlockSchema` only
ever merged into `blockSchemas`, so the map never shrank. Delete a drop-in block,
reload the catalog, and its stale schema survived — `unresolved` then computed
`false` and the node drew solid, with stale ports and no warning, which is the
exact state this PR exists to surface. `setBlocks` now prunes schemas for types
the refreshed catalog no longer contains, guarded so an empty catalog (project
loading, or between projects) does not wipe the cache.

**The unresolved warning still clicked through to Config (P2).** The tooltip says
Config cannot help a block that never loaded, but the badge was still passing the
shared warning handler, which selects the node and opens BottomPanel Config. The
handler is now withheld for an unresolved node, so the badge renders as a
non-interactive marker carrying the explanation.

The fourth finding, against the gate ledger, is not addressed: it reports that
`checks.python_tests` has no passing reconciliation, which is the known blocker
described below and the reason this PR was opened with the owner-authorised
preflight skip.

## Tests

- `frontend/src/components/WorkflowCanvas.parts/__tests__/unresolvedBlockNode.test.ts`
  — the resolved/unresolved split, severity ordering, and the IO inference
  including whole-word matching (`payload_block` is not a loader).
- `frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx`
  — dashed rendering (including under the borrowed IO palette), the warning
  badge, and that the pre-existing lossy-save warning wording is unchanged.

- `tests/cli/test_validation_warning_prefix.py` and
  `tests/ai/agent/mcp/test_validate_workflow_warning_prefix.py` — an advisory
  alone does not stop the command or flip `valid`; a hard error still does.
- `frontend/src/store/__tests__/blockSchemaEviction.test.ts` — schemas for
  vanished types are evicted, surviving types are kept, an empty catalog does
  not prune.
- `frontend/src/components/nodes/__tests__/BlockNode/unresolvedNode.test.tsx` —
  no click-through on an unresolved warning, click-through preserved for an
  ordinary one.
- `tests/workflow/test_validator.py` — Check 4.5: a node reported with no edges
  at all (the hole #1988 was filed for), the `Warning:` prefix so it stays
  non-blocking, one report per node rather than one per incident edge, and
  silence for a workflow that resolves.

Two existing assertions were updated rather than kept: `test_validator.py` and
`test_validator_codeblock_v2.py` asserted Check 5's edge-shaped wording for a
case Check 4.5 now reports first. Both still assert the same fact.

`test_validator_codeblock_v2.py` also picked up three `type: ignore` codes it
was always missing. They are not related to this change and are not a new
mismatch: its registry stubs deliberately narrow the supertype signature. They
surfaced only because the pre-commit mypy hook type-checks staged files
directly, while pyproject's mypy is scoped to `packages = ["scistudio"]` and
never sees `tests/` — issue #2115. Silenced in place rather than bypassing the
hook.

Full frontend suite, typecheck, eslint and prettier pass locally; `tests/workflow`
and `tests/api/test_public_surface.py` pass.

### On the local `python_tests` run

Recorded here rather than left implicit: the first pre-PR `python_tests` run on
this branch failed, and the passing evidence in the ledger comes from a re-run.
The failure was classified before re-running, not after.

It was `tests/blocks/io/test_io_coverage_matrix.py`, `PermissionError [WinError 5]`
from `utils/atomic_io.py:308` on a zarr directory rename, under an xdist worker.
Three consecutive local runs of that file gave: all-pass, then
`FAILED [Array:npy->zarr]`, then `FAILED [Array:npz->zarr]` — a different
parametrization each time at the same call site. That is the signature of
issue #2047 (a Windows directory-rename race), it reproduces without this branch,
and nothing here touches zarr, `atomic_io`, or the IO blocks. CI is Ubuntu-only
and does not hit it.

Worth noting for #2102's follow-up: that file was pulled in at all only because
the diff-scoped selector maps a source file to its whole mirrored test
directory. A comment-only edit to `src/scistudio/blocks/registry/__init__.py`
selected all of `tests/blocks`, so the local run still executed 2579 tests.

## Docs

- `docs/adr/ADR-050.md` §2.1 — the sentence describing `custom` as *the*
  frontend fallback was no longer true; replaced with the two-value contract.
- `CHANGELOG.md` — Unreleased / Fixed.

Gate record: `.workflow/records/1988-guided-1988-node-fallback-visual.json`

Closes #1988
