### PR TITLE
fix(#2141): match edge colour to dynamic-port type when driving param unset

### DIFF
--- a/.workflow/records/2141-guided-2141-edge-port-color.json
+++ b/.workflow/records/2141-guided-2141-edge-port-color.json
@@ -72,9 +72,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "68381fd77",
+    "sha": "b314f3728",
     "shas": [
-      "68381fd77"
+      "b314f3728"
     ],
     "trailers": []
   },
@@ -288,6 +288,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.377250Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.398007Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.416866Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.434383Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.453789Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.472676Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.488536Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.504292Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.522655Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.540474Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:11.560520Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.444738Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.460988Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.499420Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.515774Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.554885Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.570817Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.610760Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.626489Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.665835Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.680890Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:52:23.722519Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -300,7 +476,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "ab8bc5ab39cf4c9cb417a5eb8ca37a18d8d0c73e",
     "base_sha": "ab8bc5ab3",
     "changed_files": [
       ".workflow/records/2141-guided-2141-edge-port-color.json",
@@ -310,9 +486,9 @@
       "frontend/src/utils/__tests__/computeEffectivePorts.test.ts",
       "frontend/src/utils/computeEffectivePorts.ts"
     ],
-    "diff_fingerprint": "sha256:f502d23567a433570b9246c49617f7a86d49d8170116076542a563939347d6c0",
+    "diff_fingerprint": "sha256:5fa058bf245e618c879923f3f05ca137cdb231fdd804c27726534ec902218efb",
     "head": "HEAD",
-    "head_sha": "68381fd77",
+    "head_sha": "b314f3728",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -334,7 +510,7 @@
     "closes": [
       2141
     ],
-    "number": null,
+    "number": 2142,
     "url": null
   },
   "reconcile_events": [
@@ -349,6 +525,22 @@
     {
       "at": "2026-08-23T09:51:31.369071Z",
       "diff_fingerprint": "sha256:f502d23567a433570b9246c49617f7a86d49d8170116076542a563939347d6c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T09:52:11.560555Z",
+      "diff_fingerprint": "sha256:5fa058bf245e618c879923f3f05ca137cdb231fdd804c27726534ec902218efb",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T09:52:23.722554Z",
+      "diff_fingerprint": "sha256:5fa058bf245e618c879923f3f05ca137cdb231fdd804c27726534ec902218efb",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2141-guided-2141-edge-port-color.json
+++ b/.workflow/records/2141-guided-2141-edge-port-color.json
@@ -1,0 +1,119 @@
+{
+  "branch": "guided/2141-edge-port-color",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/WorkflowCanvas.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/utils/computeEffectivePorts.ts"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-23T09:45:22.727129Z",
+      "owner_directive": "\u6309\u786e\u8ba4\u65b9\u6848\u4fee\u590d\uff1a\u63d0\u53d6\u5171\u4eab resolveDrivingConfigValue\uff0cBlockNode \u4e0e WorkflowCanvas \u5171\u7528\uff0c\u52a0\u56de\u5f52\u6d4b\u8bd5\uff0c\u63d0\u4ea4 PR \u5173\u95ed #2141\u3002",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-23T09:45:22.727260Z",
+      "class": "user-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "\u7eaf\u524d\u7aef\u6e32\u67d3 bug \u4fee\u590d\uff0c\u6062\u590d\u65e2\u6709\u9884\u671f\u884c\u4e3a\uff08\u8fde\u7ebf\u989c\u8272\u8ddf\u968f\u7aef\u53e3\u7c7b\u578b\uff09\uff0c\u4e0d\u6539\u53d8\u4efb\u4f55\u7528\u6237\u53ef\u89c1\u5951\u7ea6\u3001\u914d\u7f6e\u3001API \u6216\u5de5\u4f5c\u6d41\u8bed\u4e49",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:45:22.727267Z",
+      "class": "spec/adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "\u4e0d\u6539\u53d8 ADR-028 \u52a8\u6001\u7aef\u53e3\u5951\u7ea6\uff0c\u4ec5\u6d88\u9664\u524d\u7aef\u4e24\u5904\u89e3\u6790\u8def\u5f84\u7684\u5b9e\u73b0\u6f02\u79fb",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2141,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "\u4fee\u590d load block \u8fde\u51fa\u7684\u7ebf\u989c\u8272\u4e0e\u7aef\u53e3\u989c\u8272\u4e0d\u4e00\u81f4\uff08\u7070\u9ed1\u8272\uff09\u7684 bug\uff1a\u8fde\u7ebf\u989c\u8272\u89e3\u6790\u7f3a\u5c11 schema \u9ed8\u8ba4\u503c\u56de\u9000\uff0c\u4e0e\u52a8\u6001\u7aef\u53e3\u7c7b\u578b\u6709\u5173\u3002\u8c03\u67e5\u540e\u786e\u8ba4\u6839\u56e0\u5e76\u4fee\u590d\uff0c\u6700\u540e\u63d0\u4ea4 PR\u3002",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2141-guided-2141-edge-port-color",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "agents-kimi-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:45:22.727148Z",
+      "pattern": "frontend/src/components/WorkflowCanvas.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:45:22.727154Z",
+      "pattern": "frontend/src/components/nodes/BlockNode.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:45:22.727157Z",
+      "pattern": "frontend/src/utils/computeEffectivePorts.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:45:22.727159Z",
+      "pattern": "frontend/src/utils/__tests__/computeEffectivePorts.test.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:45:22.727160Z",
+      "pattern": "frontend/src/components/__tests__/edgePortColorParity.test.tsx",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "184aa11b-0d01-4a17-a0a2-7dd276062715",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-23T09:45:22.727272Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/utils/__tests__/computeEffectivePorts.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:45:22.727277Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/edgePortColorParity.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2141-guided-2141-edge-port-color.json
+++ b/.workflow/records/2141-guided-2141-edge-port-color.json
@@ -1,8 +1,83 @@
 {
   "branch": "guided/2141-edge-port-color",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-23T09:49:21.382045Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-23T09:50:52.954876Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3d372934d77f270cae03762a9a126f215e74c5703550eaa35990e8ca9511d528",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T09:51:06.151621Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T09:51:06.238713Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "68381fd77",
+    "shas": [
+      "68381fd77"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -37,7 +112,184 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-23T09:51:06.282564Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.298763Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.315572Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.331462Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.348588Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.364930Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.381270Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.398232Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.413606Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.429153Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:06.447405Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.220357Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.235707Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.249948Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.263912Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.278760Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.295046Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.309839Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.323598Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.338436Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.353224Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T09:51:31.369037Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -47,19 +299,91 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "ab8bc5ab3",
+    "changed_files": [
+      ".workflow/records/2141-guided-2141-edge-port-color.json",
+      "frontend/src/components/WorkflowCanvas.tsx",
+      "frontend/src/components/__tests__/edgePortColorParity.test.tsx",
+      "frontend/src/components/nodes/BlockNode.tsx",
+      "frontend/src/utils/__tests__/computeEffectivePorts.test.ts",
+      "frontend/src/utils/computeEffectivePorts.ts"
+    ],
+    "diff_fingerprint": "sha256:f502d23567a433570b9246c49617f7a86d49d8170116076542a563939347d6c0",
+    "head": "HEAD",
+    "head_sha": "68381fd77",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 5,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 5,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 5,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "\u4fee\u590d load block \u8fde\u51fa\u7684\u7ebf\u989c\u8272\u4e0e\u7aef\u53e3\u989c\u8272\u4e0d\u4e00\u81f4\uff08\u7070\u9ed1\u8272\uff09\u7684 bug\uff1a\u8fde\u7ebf\u989c\u8272\u89e3\u6790\u7f3a\u5c11 schema \u9ed8\u8ba4\u503c\u56de\u9000\uff0c\u4e0e\u52a8\u6001\u7aef\u53e3\u7c7b\u578b\u6709\u5173\u3002\u8c03\u67e5\u540e\u786e\u8ba4\u6839\u56e0\u5e76\u4fee\u590d\uff0c\u6700\u540e\u63d0\u4ea4 PR\u3002",
   "persona": "live_implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2141
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-23T09:51:06.447439Z",
+      "diff_fingerprint": "sha256:f502d23567a433570b9246c49617f7a86d49d8170116076542a563939347d6c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T09:51:31.369071Z",
+      "diff_fingerprint": "sha256:f502d23567a433570b9246c49617f7a86d49d8170116076542a563939347d6c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2141-guided-2141-edge-port-color",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "agents-kimi-code",
   "schema_version": 2,
@@ -96,7 +420,7 @@
     }
   ],
   "session_id": "184aa11b-0d01-4a17-a0a2-7dd276062715",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "guided",
   "test_events": [
     {

--- a/frontend/src/components/WorkflowCanvas.tsx
+++ b/frontend/src/components/WorkflowCanvas.tsx
@@ -6,7 +6,7 @@ import { resolveTypeColor, type DeclaredTypeColors } from "../config/typeColorMa
 import { useAppStore } from "../store";
 import { useDeclaredTypeColors } from "../store/useTypeCatalog";
 import type { BlockSchemaResponse, BlockSummary, WorkflowEdge, WorkflowNode } from "../types/api";
-import { computeEffectivePorts } from "../utils/computeEffectivePorts";
+import { computeEffectivePorts, resolveDrivingConfigValue } from "../utils/computeEffectivePorts";
 import { arePortTypesCompatible } from "../utils/portCompat";
 import { AnnotationNode } from "./nodes/AnnotationNode";
 import { BlockNode } from "./nodes/BlockNode";
@@ -135,6 +135,10 @@ function useFlowEdges(
       // to the static schema spec while BlockNode rendered the real
       // per-instance type — that was the visible "edge color mismatches
       // port color" symptom.
+      // #2141: the driving value comes from the shared
+      // ``resolveDrivingConfigValue`` (params value, then schema default) —
+      // the same helper BlockNode uses, so an edge and the port it leaves
+      // cannot disagree when the driving param was never explicitly set.
       const sourceParams = (sourceNode?.config.params as Record<string, unknown> | undefined) ?? {};
       const targetParams = (targetNode?.config.params as Record<string, unknown> | undefined) ?? {};
       const variadicSourcePorts =
@@ -147,9 +151,11 @@ function useFlowEdges(
             )
           : (sourceSchema?.output_ports ?? []);
       const sourceDynamicPorts = sourceSchema?.dynamic_ports ?? null;
-      const sourceConfigKey = sourceDynamicPorts?.source_config_key;
-      const sourceDrivingConfigValue =
-        sourceConfigKey != null ? (sourceParams[sourceConfigKey] as string | undefined) : undefined;
+      const sourceDrivingConfigValue = resolveDrivingConfigValue(
+        sourceParams,
+        sourceSchema,
+        sourceDynamicPorts?.source_config_key,
+      );
       const effectiveSourcePorts = computeEffectivePorts(
         sourceDynamicPorts,
         sourceDrivingConfigValue,
@@ -175,9 +181,11 @@ function useFlowEdges(
             )
           : (targetSchema?.input_ports ?? []);
       const targetDynamicPorts = targetSchema?.dynamic_ports ?? null;
-      const targetConfigKey = targetDynamicPorts?.source_config_key;
-      const targetDrivingConfigValue =
-        targetConfigKey != null ? (targetParams[targetConfigKey] as string | undefined) : undefined;
+      const targetDrivingConfigValue = resolveDrivingConfigValue(
+        targetParams,
+        targetSchema,
+        targetDynamicPorts?.source_config_key,
+      );
       const effectiveTargetPorts = computeEffectivePorts(
         targetDynamicPorts,
         targetDrivingConfigValue,

--- a/frontend/src/components/__tests__/edgePortColorParity.test.tsx
+++ b/frontend/src/components/__tests__/edgePortColorParity.test.tsx
@@ -1,0 +1,244 @@
+// #2141 — edge/port colour parity for dynamic-port blocks.
+//
+// A freshly dropped Load block never materializes ``core_type`` into
+// ``config.params`` (the palette drop only seeds ``direction``). The port
+// surface (BlockNode) fell back to the config-schema default ("DataFrame")
+// while the edge surface (WorkflowCanvas.useFlowEdges) did not, so the port
+// rendered DataFrame amber and the edge rendered the DataObject gray fallback.
+// Both surfaces now resolve the driving value through the same
+// ``resolveDrivingConfigValue`` helper; this file proves the parity end to end
+// on the rendered canvas.
+
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReactFlowProvider } from "@xyflow/react";
+
+import { resetAppStore } from "../../testUtils";
+import type {
+  BlockPortResponse,
+  BlockSchemaResponse,
+  DynamicPortsConfig,
+  WorkflowEdge,
+  WorkflowNode,
+} from "../../types/api";
+import { WorkflowCanvas } from "../WorkflowCanvas";
+
+const listTypes = vi.fn();
+vi.mock("../../lib/api/code", () => ({
+  codeApi: {
+    listTypes: () => listTypes(),
+  },
+}));
+
+/** React Flow measures its container; jsdom has no layout engine. The mocks
+ * below follow the official React Flow jsdom testing recipe: a ResizeObserver
+ * that fires immediately (so nodes register dimensions), a DOMMatrixReadOnly
+ * that understands scale transforms, offset sizes, and an SVG getBBox. */
+class MockResizeObserver {
+  callback: globalThis.ResizeObserverCallback;
+  constructor(callback: globalThis.ResizeObserverCallback) {
+    this.callback = callback;
+  }
+  observe(target: Element) {
+    this.callback([{ target } as globalThis.ResizeObserverEntry], this);
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+class MockDOMMatrixReadOnly {
+  m22: number;
+  constructor(transform?: string) {
+    const scale = transform?.match(/scale\(([\d.]+)\)/)?.[1];
+    this.m22 = scale !== undefined ? Number(scale) : 1;
+  }
+}
+
+function installReactFlowJsdomMocks() {
+  vi.stubGlobal("ResizeObserver", MockResizeObserver);
+  vi.stubGlobal("DOMMatrixReadOnly", MockDOMMatrixReadOnly);
+  Object.defineProperties(globalThis.HTMLElement.prototype, {
+    offsetHeight: {
+      configurable: true,
+      get(this: HTMLElement) {
+        return parseFloat(this.style.height) || 1;
+      },
+    },
+    offsetWidth: {
+      configurable: true,
+      get(this: HTMLElement) {
+        return parseFloat(this.style.width) || 1;
+      },
+    },
+  });
+  (globalThis.SVGElement.prototype as { getBBox?: () => unknown }).getBBox = () => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  });
+}
+
+function port(name: string, direction: "input" | "output", accepted: string[]): BlockPortResponse {
+  return {
+    name,
+    direction,
+    accepted_types: accepted,
+    required: true,
+    description: "",
+    constraint_description: "",
+    is_collection: false,
+  };
+}
+
+/** Mirrors the LoadData backend ``dynamic_ports`` ClassVar shape. */
+const LOAD_DATA_DYNAMIC: DynamicPortsConfig = {
+  source_config_key: "core_type",
+  output_port_mapping: {
+    data: {
+      Array: ["Array"],
+      DataFrame: ["DataFrame"],
+      Series: ["Series"],
+      Text: ["Text"],
+      Artifact: ["Artifact"],
+      CompositeData: ["CompositeData"],
+    },
+  },
+};
+
+function loadSchema(): BlockSchemaResponse {
+  return {
+    name: "Load Data",
+    type_name: "load_data",
+    base_category: "io",
+    subcategory: "io",
+    description: "",
+    version: "1.0",
+    input_ports: [],
+    // Static placeholder port — the dynamic mapping retypes it per instance.
+    output_ports: [port("data", "output", ["DataObject"])],
+    config_schema: {
+      type: "object",
+      properties: {
+        core_type: { type: "string", default: "DataFrame" },
+      },
+      required: ["core_type"],
+    },
+    type_hierarchy: [
+      { name: "DataObject", base_type: "", description: "" },
+      { name: "DataFrame", base_type: "DataObject", description: "" },
+      { name: "Array", base_type: "DataObject", description: "" },
+    ],
+    dynamic_ports: LOAD_DATA_DYNAMIC,
+    direction: "input",
+  };
+}
+
+function sinkSchema(): BlockSchemaResponse {
+  return {
+    name: "Sink",
+    type_name: "sink_block",
+    base_category: "process",
+    subcategory: "",
+    description: "",
+    version: "1.0",
+    input_ports: [port("input", "input", ["DataFrame", "Array"])],
+    output_ports: [],
+    config_schema: { type: "object", properties: {} },
+    type_hierarchy: [
+      { name: "DataObject", base_type: "", description: "" },
+      { name: "DataFrame", base_type: "DataObject", description: "" },
+      { name: "Array", base_type: "DataObject", description: "" },
+    ],
+    dynamic_ports: null,
+    direction: null,
+  };
+}
+
+function loadNode(params: Record<string, unknown>): WorkflowNode {
+  // The palette drop seeds only ``direction`` — ``core_type`` is absent until
+  // the user touches the dropdown (useCanvasHandlers.handleAddBlockFromPalette).
+  return { id: "load1", block_type: "load_data", config: { params } };
+}
+
+const SINK_NODE: WorkflowNode = { id: "sink1", block_type: "sink_block", config: { params: {} } };
+const EDGE: WorkflowEdge = { source: "load1:data", target: "sink1:input" };
+
+function renderCanvas(nodes: WorkflowNode[]) {
+  return render(
+    <ReactFlowProvider>
+      <WorkflowCanvas
+        blockErrorSummaries={{}}
+        blockErrors={{}}
+        blockStates={{}}
+        blocks={[]}
+        edges={[EDGE]}
+        minimapVisible={false}
+        nodes={nodes}
+        onAddNode={vi.fn()}
+        onConnect={vi.fn(async () => {})}
+        onDeleteEdge={vi.fn()}
+        onDeleteNode={vi.fn()}
+        onErrorClick={vi.fn()}
+        onResizeNode={vi.fn()}
+        onRunBlock={vi.fn()}
+        onSelectNode={vi.fn()}
+        onUpdateNodeConfig={vi.fn()}
+        onUpdateNodePosition={vi.fn()}
+        schemas={{ load_data: loadSchema(), sink_block: sinkSchema() }}
+        selectedNodeId={null}
+      />
+    </ReactFlowProvider>,
+  );
+}
+
+function edgePath(container: HTMLElement): SVGElement {
+  const path = container.querySelector(".react-flow__edge-path");
+  // jsdom exposes SVGElement but not the SVGPathElement subclass.
+  if (!(path instanceof SVGElement)) {
+    throw new Error("no .react-flow__edge-path rendered");
+  }
+  return path;
+}
+
+function handleFor(container: HTMLElement, portName: string): HTMLElement {
+  const handle = container.querySelector(`[data-handleid="${portName}"]`);
+  if (!(handle instanceof HTMLElement)) {
+    throw new Error(`no handle for ${portName}`);
+  }
+  return handle;
+}
+
+beforeEach(() => {
+  resetAppStore();
+  installReactFlowJsdomMocks();
+  listTypes.mockResolvedValue({ types: [] });
+});
+
+afterEach(() => {
+  cleanup();
+  listTypes.mockReset();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("edge/port colour parity for dynamic-port blocks (#2141)", () => {
+  it("colours the edge by the schema-default core_type when the param was never set", () => {
+    // Regression: the edge used to fall back to the DataObject gray (#374151)
+    // here while the port rendered the DataFrame amber.
+    const { container } = renderCanvas([loadNode({}), SINK_NODE]);
+
+    const dataFrameRgb = "rgb(245, 158, 11)"; // typeColorMap.DataFrame #f59e0b
+    expect(handleFor(container, "data").style.backgroundColor).toBe(dataFrameRgb);
+    // jsdom normalizes backgroundColor to rgb() but keeps stroke as authored.
+    expect(edgePath(container).style.stroke).toBe("#f59e0b");
+  });
+
+  it("colours the edge by the configured core_type when the param is set", () => {
+    const { container } = renderCanvas([loadNode({ core_type: "Array" }), SINK_NODE]);
+
+    const arrayRgb = "rgb(59, 130, 246)"; // typeColorMap.Array #3b82f6
+    expect(handleFor(container, "data").style.backgroundColor).toBe(arrayRgb);
+    expect(edgePath(container).style.stroke).toBe("#3b82f6");
+  });
+});

--- a/frontend/src/components/nodes/BlockNode.tsx
+++ b/frontend/src/components/nodes/BlockNode.tsx
@@ -23,7 +23,10 @@ import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 import type { BlockNodeData } from "../../types/ui";
-import { computeEffectivePorts } from "../../utils/computeEffectivePorts";
+import {
+  computeEffectivePorts,
+  resolveDrivingConfigValue,
+} from "../../utils/computeEffectivePorts";
 
 import { BlockDetailPopover, type PopoverAnchor } from "../BlockDetailPopover";
 import { PromoteToLibraryAction } from "../promotion/PromoteToLibraryAction";
@@ -55,7 +58,7 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
   // user picked there still drives the port type shown on the canvas.
   const dynamicPorts = data.schema?.dynamic_ports ?? null;
   const sourceConfigKey = dynamicPorts?.source_config_key;
-  const drivingConfigValue = resolveDrivingConfigValue(data, sourceConfigKey);
+  const drivingConfigValue = resolveDrivingConfigValue(data.config, data.schema, sourceConfigKey);
   const effectiveInputPorts = computeEffectivePorts(
     dynamicPorts,
     drivingConfigValue,
@@ -268,23 +271,4 @@ export function BlockNode({ id: nodeId, data, selected }: NodeProps<Node<BlockNo
       </span>
     </div>
   );
-}
-
-/**
- * Read the dynamic-port driving config value (e.g. LoadData `core_type`) from
- * the node config, falling back to the schema default. The user edits this in
- * BottomPanel Config; the node body only reads it to colour ports.
- */
-function resolveDrivingConfigValue(
-  data: BlockNodeData,
-  sourceConfigKey: string | undefined,
-): string | undefined {
-  if (sourceConfigKey == null) return undefined;
-  const configured = data.config?.[sourceConfigKey];
-  if (typeof configured === "string" && configured) return configured;
-  const properties = data.schema?.config_schema?.properties as
-    | Record<string, Record<string, unknown>>
-    | undefined;
-  const schemaDefault = properties?.[sourceConfigKey]?.default;
-  return typeof schemaDefault === "string" && schemaDefault ? schemaDefault : undefined;
 }

--- a/frontend/src/utils/__tests__/computeEffectivePorts.test.ts
+++ b/frontend/src/utils/__tests__/computeEffectivePorts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { BlockPortResponse, DynamicPortsConfig } from "../../types/api";
-import { computeEffectivePorts } from "../computeEffectivePorts";
+import type { BlockPortResponse, BlockSchemaResponse, DynamicPortsConfig } from "../../types/api";
+import { computeEffectivePorts, resolveDrivingConfigValue } from "../computeEffectivePorts";
 
 // ---------------------------------------------------------------------------
 // Test fixtures
@@ -214,5 +214,61 @@ describe("computeEffectivePorts — graceful fallback", () => {
     // unnecessary clone).
     expect(result[1]).toBe(ports[1]);
     expect(result[1].accepted_types).toEqual(["Text"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveDrivingConfigValue (#2141) — the single resolution shared by the
+// port surface (BlockNode) and the edge surface (WorkflowCanvas) so an edge
+// and the port it leaves can never disagree.
+// ---------------------------------------------------------------------------
+
+/** Minimal schema carrying only what resolveDrivingConfigValue reads. */
+function schemaWithDefault(defaultValue: unknown): BlockSchemaResponse {
+  return {
+    config_schema: {
+      type: "object",
+      properties: { core_type: { type: "string", default: defaultValue } },
+    },
+  } as unknown as BlockSchemaResponse;
+}
+
+describe("resolveDrivingConfigValue (#2141)", () => {
+  it("returns undefined when sourceConfigKey is undefined", () => {
+    expect(
+      resolveDrivingConfigValue({ core_type: "Array" }, schemaWithDefault("DataFrame"), undefined),
+    ).toBeUndefined();
+  });
+
+  it("prefers the configured params value over the schema default", () => {
+    expect(
+      resolveDrivingConfigValue(
+        { core_type: "Array" },
+        schemaWithDefault("DataFrame"),
+        "core_type",
+      ),
+    ).toBe("Array");
+  });
+
+  it("falls back to the schema default when the param was never set", () => {
+    // The #2141 case: a freshly dropped Load block has no ``core_type`` in
+    // ``config.params``; the schema default ("DataFrame") must still drive the
+    // effective port types so port and edge colours agree.
+    expect(resolveDrivingConfigValue({}, schemaWithDefault("DataFrame"), "core_type")).toBe(
+      "DataFrame",
+    );
+  });
+
+  it("falls back to the schema default when the param is an empty string", () => {
+    expect(
+      resolveDrivingConfigValue({ core_type: "" }, schemaWithDefault("DataFrame"), "core_type"),
+    ).toBe("DataFrame");
+  });
+
+  it("returns undefined when neither params nor the schema provide a value", () => {
+    expect(
+      resolveDrivingConfigValue({}, schemaWithDefault(undefined), "core_type"),
+    ).toBeUndefined();
+    expect(resolveDrivingConfigValue(undefined, undefined, "core_type")).toBeUndefined();
   });
 });

--- a/frontend/src/utils/computeEffectivePorts.ts
+++ b/frontend/src/utils/computeEffectivePorts.ts
@@ -16,9 +16,42 @@
  * Per ``docs/specs/phase11-implementation-standards.md`` T-TRK-009.
  */
 
-import type { BlockPortResponse, DynamicPortsConfig } from "../types/api";
+import type { BlockPortResponse, BlockSchemaResponse, DynamicPortsConfig } from "../types/api";
 
 export type { DynamicPortsConfig };
+
+/**
+ * Read the dynamic-port driving config value (e.g. LoadData ``core_type``)
+ * from the node's params envelope, falling back to the schema default.
+ *
+ * #2141: this resolution MUST be shared by every surface that colours ports
+ * or edges. ``BlockNode`` previously fell back to the schema default while
+ * ``WorkflowCanvas`` did not, so a freshly dropped Load block (whose
+ * ``core_type`` is never materialized into ``config.params``) rendered an
+ * amber DataFrame port with a gray DataObject edge. One helper, one answer.
+ *
+ * The user edits the driving field in BottomPanel Config; the canvas only
+ * reads it to colour ports and edges.
+ *
+ * @param config - the node's params envelope (``node.config.params``; the
+ *   ``BlockNodeData.config`` field already carries exactly this envelope)
+ * @param schema - the block schema, consulted for the config-schema default
+ * @param sourceConfigKey - ``schema.dynamic_ports.source_config_key``
+ * @returns the configured string value, else the schema default, else
+ *   ``undefined``
+ */
+export function resolveDrivingConfigValue(
+  config: Record<string, unknown> | undefined,
+  schema: BlockSchemaResponse | undefined,
+  sourceConfigKey: string | undefined,
+): string | undefined {
+  if (sourceConfigKey == null) return undefined;
+  const configured = config?.[sourceConfigKey];
+  if (typeof configured === "string" && configured) return configured;
+  const properties = schema?.config_schema?.properties;
+  const schemaDefault = properties?.[sourceConfigKey]?.default;
+  return typeof schemaDefault === "string" && schemaDefault ? schemaDefault : undefined;
+}
 
 /**
  * Compute the effective port list for a block instance.


### PR DESCRIPTION
# fix(#2141): match edge colour to dynamic-port type when driving param unset

Closes #2141

## Problem

Edges leaving a Load block rendered gray-black (`#374151`, the `DataObject`
fallback) instead of the colour matching the block's output port (e.g.
DataFrame amber). The port and the edge resolved the dynamic-port driving
value (`core_type`) through two different code paths:

- `BlockNode` (port surface): `config.params.core_type`, falling back to the
  config-schema default (`"DataFrame"`).
- `WorkflowCanvas.useFlowEdges` (edge surface): `config.params.core_type`
  only, no schema-default fallback.

A freshly dropped Load block never materializes `core_type` into
`config.params` (the palette drop seeds only `direction`), so the edge kept
the static placeholder port (`accepted_types=["DataObject"]`) and rendered
gray while the port rendered the default-driven colour. Touching the
`core_type` dropdown once hid the bug, which is why it looked intermittent.

## Fix

Extract the driving-value resolution (params value → config-schema default)
into `resolveDrivingConfigValue` in `frontend/src/utils/computeEffectivePorts.ts`
and call it from both surfaces (`BlockNode.tsx`, `WorkflowCanvas.tsx` — source
and target side). One helper, one answer: an edge and the port it leaves can
no longer disagree. The edge-side type-compatibility re-validation also uses
the same value now, so it stops misjudging edges whose driving param was never
explicitly set.

## Tests

- `frontend/src/utils/__tests__/computeEffectivePorts.test.ts` — unit tests
  for `resolveDrivingConfigValue` (params value wins, schema-default fallback,
  empty-string fallback, unset-everywhere → undefined).
- `frontend/src/components/__tests__/edgePortColorParity.test.tsx` — canvas-level
  regression: renders `WorkflowCanvas` with a Load node whose `config.params`
  lacks `core_type` and asserts the rendered edge stroke equals the port
  handle colour, for both the schema-default and the explicitly-set case.
  Verified the first test fails against the pre-fix `WorkflowCanvas`.