### PR TITLE
fix(#2143): report a failed check in full and measure a stacked branch against its own base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,14 @@ frontend/e2e/artifacts/
 .workflow/records/*-scratch.json
 .workflow/full-audit-*.json
 
+# Linked git worktrees created inside the checkout for parallel agent work.
+# Untracked and unignored, they were visible to the repository-scoped check
+# commands: the `ruff check .` fallback linted another agent's worktree and
+# failed a commit on files that commit never touched (#2143). Ruff respects
+# .gitignore, so ignoring the directory is what keeps a repo-scoped check
+# inside this checkout.
+.worktrees/
+
 # Scratch audit output (CI writes .audit/full-audit.json; never committed)
 .audit/
 

--- a/.workflow/records/2143-gate-failure-reporting-and-base.json
+++ b/.workflow/records/2143-gate-failure-reporting-and-base.json
@@ -53,6 +53,140 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-23T10:27:59.875358Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:37502682d76dca2083e06c1150cedf05eea3e1f0d96c3e3e5461f6ce3ad553a9",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:28:01.186166Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fec0790c4c2cdaeb24c6fcfc24f00df789a9afdc0c76a62c45e02aad4ce3456d",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:28:01.212952Z",
+      "command": "ruff format src/scistudio/qa/governance/gate_record/checks.py src/scistudio/qa/governance/gate_record/cli.py src/scistudio/qa/governance/gate_record/evaluator.py src/scistudio/qa/governance/gate_record/io.py src/scistudio/qa/governance/gate_record/ledger.py src/scistudio/qa/governance/gate_record/workflow.py tests/qa/test_gate_record.py tests/qa/test_gate_record_bugfixes.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ce6b76546d1c2471a3f9bb724e853809fd2ed25089fb0af2770e7c1858d0631b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-23T10:28:12.857766Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c18085adc1275d0189d53b44323d22d4027fe7e777c421f4306dd12d859dd9cc",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:28:13.133730Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e2a856ac5dc587824aa863897c3a649b7cb6a29dbcdab4204d4ad087516f49b3",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:28:13.156791Z",
+      "command": "ruff check src/scistudio/qa/governance/gate_record/checks.py src/scistudio/qa/governance/gate_record/cli.py src/scistudio/qa/governance/gate_record/evaluator.py src/scistudio/qa/governance/gate_record/io.py src/scistudio/qa/governance/gate_record/ledger.py src/scistudio/qa/governance/gate_record/workflow.py tests/qa/test_gate_record.py tests/qa/test_gate_record_bugfixes.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e3dd9a5e29fc8a7f8dea2a05bdb9911710abe79229d75ae79be03455867e954d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-23T10:28:24.010304Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/qa/governance tests/qa/test_gate_record.py tests/qa/test_gate_record_bugfixes.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8fbf3e5c0d33bbf743dc9a259551196c4cb6f2b424299ae416cefbccfc19be4d",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:28:24.964390Z",
+      "command": "mypy src/scistudio/qa/governance/gate_record/checks.py src/scistudio/qa/governance/gate_record/cli.py src/scistudio/qa/governance/gate_record/evaluator.py src/scistudio/qa/governance/gate_record/io.py src/scistudio/qa/governance/gate_record/ledger.py src/scistudio/qa/governance/gate_record/workflow.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:71051d12b760c9f3487c83409a6d6c2efb0e8b10bd15f9d69a63e473bd00a2d3",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -104,6 +238,14 @@
       "class": null,
       "kind": "path",
       "path": "docs/ai-developer/specific_rules/gated-workflow.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T10:28:28.703967Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
       "rationale": null,
       "verified_in_diff": null
     }
@@ -175,6 +317,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.007611Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.021916Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.036647Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.051914Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.067605Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.082656Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.097812Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.112740Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.126900Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.141204Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:28:25.157795Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -189,21 +419,36 @@
   "observed_diff": {
     "base": "ab8bc5ab39cf4c9cb417a5eb8ca37a18d8d0c73e",
     "base_sha": "ab8bc5ab3",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".gitignore",
+      ".workflow/records/2143-gate-failure-reporting-and-base.json",
+      "docs/ai-developer/gate-cli-command-set.md",
+      "docs/ai-developer/rules.md",
+      "docs/ai-developer/specific_rules/gated-workflow.md",
+      "docs/specs/adr-042-gate-ledger-runtime.md",
+      "src/scistudio/qa/governance/gate_record/checks.py",
+      "src/scistudio/qa/governance/gate_record/cli.py",
+      "src/scistudio/qa/governance/gate_record/evaluator.py",
+      "src/scistudio/qa/governance/gate_record/io.py",
+      "src/scistudio/qa/governance/gate_record/ledger.py",
+      "src/scistudio/qa/governance/gate_record/workflow.py",
+      "tests/qa/test_gate_record.py",
+      "tests/qa/test_gate_record_bugfixes.py"
+    ],
+    "diff_fingerprint": "sha256:4ddaa5f63292112053008ec5dc2fe9e36d14f3192dcbd5c86274e6d35c44cafb",
     "head": "HEAD",
-    "head_sha": "ab8bc5ab3",
+    "head_sha": "6024a3174",
     "surfaces": {
-      "docs": 0,
+      "docs": 4,
       "frontend": 0,
-      "governance": 0,
-      "governed_docs": 0,
-      "implementation": 0,
+      "governance": 9,
+      "governed_docs": 3,
+      "implementation": 6,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 9,
+      "test": 2,
       "workflow_ci": 0
     }
   },
@@ -220,6 +465,14 @@
       "unsatisfied": [
         "checks.format_check"
       ]
+    },
+    {
+      "at": "2026-08-23T10:28:25.157837Z",
+      "diff_fingerprint": "sha256:4ddaa5f63292112053008ec5dc2fe9e36d14f3192dcbd5c86274e6d35c44cafb",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "2143-gate-failure-reporting-and-base",
@@ -227,11 +480,18 @@
   "required_obligations": {
     "admin_labels": [],
     "checks": [
+      "architecture_tests",
+      "deferral_discipline",
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -245,7 +505,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
@@ -261,10 +523,16 @@
       "at": "2026-08-23T09:57:27.859238Z",
       "pattern": "docs/ai-developer/specific_rules/gated-workflow.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T10:28:28.703945Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "Repository convention lands developer/gate tooling fixes in CHANGELOG.md (precedent: #2075, #2120); add it to scope."
     }
   ],
   "session_id": "b729e5d3-d2bc-41fe-ada9-880b3ef8f9b9",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2143-gate-failure-reporting-and-base.json
+++ b/.workflow/records/2143-gate-failure-reporting-and-base.json
@@ -203,6 +203,22 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:31:58.644619Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:89435a4458a3ab7ffc65e8bce2e5eaeb01c0da669d70b611e5de4057bc44b63e",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -779,6 +795,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.694056Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.710871Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.748569Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.763316Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.778346Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.792449Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.806402Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.819973Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.833362Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.847453Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:31:58.862421Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -791,8 +895,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "ab8bc5ab39cf4c9cb417a5eb8ca37a18d8d0c73e",
-    "base_sha": "ab8bc5ab3",
+    "base": "7398d3eddca04a77fd23325c27be0077a6c134e8",
+    "base_sha": "7398d3edd",
     "changed_files": [
       ".gitignore",
       ".workflow/records/2143-gate-failure-reporting-and-base.json",
@@ -810,9 +914,9 @@
       "tests/qa/test_gate_record.py",
       "tests/qa/test_gate_record_bugfixes.py"
     ],
-    "diff_fingerprint": "sha256:62a8a563493e122879b59ea2c5e155a5a4016bb3db5c9bd338b847144482f36f",
+    "diff_fingerprint": "sha256:3317202997e38b461652085bd5ca2cb145a84634e6b2f90f4c865eff4e545d33",
     "head": "HEAD",
-    "head_sha": "51dd7173a",
+    "head_sha": "26becd859",
     "surfaces": {
       "docs": 4,
       "frontend": 0,
@@ -883,6 +987,14 @@
     {
       "at": "2026-08-23T10:30:37.363780Z",
       "diff_fingerprint": "sha256:62a8a563493e122879b59ea2c5e155a5a4016bb3db5c9bd338b847144482f36f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T10:31:58.862467Z",
+      "diff_fingerprint": "sha256:3317202997e38b461652085bd5ca2cb145a84634e6b2f90f4c865eff4e545d33",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2143-gate-failure-reporting-and-base.json
+++ b/.workflow/records/2143-gate-failure-reporting-and-base.json
@@ -207,10 +207,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "46bd5bf4d26ba6bd40e17a446bfe3ad156878644",
+    "sha": "51dd7173a49a0d07e64b4d9bf1952eb91ea8ed9c",
     "shas": [
-      "46bd5bf4d26ba6bd40e17a446bfe3ad156878644",
-      "6024a3174d4b49c275bd004a8b4c2f4f818710d1"
+      "51dd7173a49a0d07e64b4d9bf1952eb91ea8ed9c"
     ],
     "trailers": []
   },
@@ -604,6 +603,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.154917Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.171266Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.187188Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.201489Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.215437Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.229247Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.243038Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.257171Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.271602Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.284901Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:27.299733Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.203303Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.217059Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.231328Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.245690Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.259416Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.295514Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.308752Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.321589Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.334519Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.347531Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:37.363740Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -635,9 +810,9 @@
       "tests/qa/test_gate_record.py",
       "tests/qa/test_gate_record_bugfixes.py"
     ],
-    "diff_fingerprint": "sha256:8ab0073aee0963f24447fd123ddf4b9f0adfa57d020a3d4f95a6548eb2af01ea",
+    "diff_fingerprint": "sha256:62a8a563493e122879b59ea2c5e155a5a4016bb3db5c9bd338b847144482f36f",
     "head": "HEAD",
-    "head_sha": "46bd5bf4d",
+    "head_sha": "51dd7173a",
     "surfaces": {
       "docs": 4,
       "frontend": 0,
@@ -659,7 +834,7 @@
     "closes": [
       2143
     ],
-    "number": null,
+    "number": 2145,
     "url": null
   },
   "reconcile_events": [
@@ -692,6 +867,22 @@
     {
       "at": "2026-08-23T10:30:04.007012Z",
       "diff_fingerprint": "sha256:8ab0073aee0963f24447fd123ddf4b9f0adfa57d020a3d4f95a6548eb2af01ea",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T10:30:27.299772Z",
+      "diff_fingerprint": "sha256:62a8a563493e122879b59ea2c5e155a5a4016bb3db5c9bd338b847144482f36f",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T10:30:37.363780Z",
+      "diff_fingerprint": "sha256:62a8a563493e122879b59ea2c5e155a5a4016bb3db5c9bd338b847144482f36f",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2143-gate-failure-reporting-and-base.json
+++ b/.workflow/records/2143-gate-failure-reporting-and-base.json
@@ -1,0 +1,303 @@
+{
+  "base_ref": "origin/main",
+  "branch": "fix/2143-gate-failure-reporting-and-base",
+  "check_events": [
+    {
+      "at": "2026-08-23T10:26:09.526625Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-23T10:26:20.822599Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-23T10:26:20.895763Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/qa/governance/gate_record/**",
+      "tests/qa/**",
+      ".gitignore",
+      "docs/specs/adr-042-gate-ledger-runtime.md",
+      "docs/ai-developer/gate-cli-command-set.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-23T09:57:27.859212Z",
+      "owner_directive": "Four fixes: (1) disclose the full finding count and log path on a truncated failed-check excerpt; (2) render a structured summary for a failed check that reports only to a JSON file (full_audit); (3) make the diff base an explicit ledger field base_ref with precedence --base > SCISTUDIO_GATE_BASE > ledger.base_ref > origin/main; (4) gitignore .worktrees/ so whole-repo ruff stops linting other agents' checkouts.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-23T09:57:27.859247Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-042-gate-ledger-runtime.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:57:27.859252Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/gate-cli-command-set.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:57:27.859255Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/rules.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:57:27.859256Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/specific_rules/gated-workflow.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-23T10:26:20.937617Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:20.953669Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:20.968991Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:20.983860Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:20.998975Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.014727Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.030342Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.046005Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.060413Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.074762Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:26:21.090287Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2143,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "ab8bc5ab39cf4c9cb417a5eb8ca37a18d8d0c73e",
+    "base_sha": "ab8bc5ab3",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "ab8bc5ab3",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Fix the four gate feedback/base defects in #2143 in one issue and one PR; do not lighten pre-commit. Base resolution becomes an explicit ledger field (base_ref) with precedence --base > SCISTUDIO_GATE_BASE > ledger.base_ref > origin/main.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-23T10:26:21.090347Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check"
+      ]
+    }
+  ],
+  "record_id": "2143-gate-failure-reporting-and-base",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:57:27.859232Z",
+      "pattern": "docs/ai-developer/rules.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-23T09:57:27.859238Z",
+      "pattern": "docs/ai-developer/specific_rules/gated-workflow.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "b729e5d3-d2bc-41fe-ada9-880b3ef8f9b9",
+  "strictness_tier": 2,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-23T09:57:27.859260Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_evaluator.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:57:27.859264Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_ledger.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T09:57:27.859266Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_record.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-23T10:25:26.083948Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/qa/test_gate_record_bugfixes.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2143-gate-failure-reporting-and-base.json
+++ b/.workflow/records/2143-gate-failure-reporting-and-base.json
@@ -187,10 +187,33 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-23T10:29:45.710629Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:80c7e75ef059d953681a157649be2bbe8058f3292423b755ac8eca2eea60bf73",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "46bd5bf4d26ba6bd40e17a446bfe3ad156878644",
+    "shas": [
+      "46bd5bf4d26ba6bd40e17a446bfe3ad156878644",
+      "6024a3174d4b49c275bd004a8b4c2f4f818710d1"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -405,6 +428,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.755341Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.769147Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.782851Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.796486Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.810402Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.824369Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.839257Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.853659Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.868083Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.883553Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:29:45.900282Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.843272Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.859055Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.875126Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.892502Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.911305Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.926223Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.942080Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.957063Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.972889Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:03.988383Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-23T10:30:04.006939Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -422,6 +621,7 @@
     "changed_files": [
       ".gitignore",
       ".workflow/records/2143-gate-failure-reporting-and-base.json",
+      "CHANGELOG.md",
       "docs/ai-developer/gate-cli-command-set.md",
       "docs/ai-developer/rules.md",
       "docs/ai-developer/specific_rules/gated-workflow.md",
@@ -435,9 +635,9 @@
       "tests/qa/test_gate_record.py",
       "tests/qa/test_gate_record_bugfixes.py"
     ],
-    "diff_fingerprint": "sha256:4ddaa5f63292112053008ec5dc2fe9e36d14f3192dcbd5c86274e6d35c44cafb",
+    "diff_fingerprint": "sha256:8ab0073aee0963f24447fd123ddf4b9f0adfa57d020a3d4f95a6548eb2af01ea",
     "head": "HEAD",
-    "head_sha": "6024a3174",
+    "head_sha": "46bd5bf4d",
     "surfaces": {
       "docs": 4,
       "frontend": 0,
@@ -454,7 +654,14 @@
   },
   "owner_directive": "Fix the four gate feedback/base defects in #2143 in one issue and one PR; do not lighten pre-commit. Base resolution becomes an explicit ledger field (base_ref) with precedence --base > SCISTUDIO_GATE_BASE > ledger.base_ref > origin/main.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2143
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-23T10:26:21.090347Z",
@@ -470,6 +677,22 @@
       "at": "2026-08-23T10:28:25.157837Z",
       "diff_fingerprint": "sha256:4ddaa5f63292112053008ec5dc2fe9e36d14f3192dcbd5c86274e6d35c44cafb",
       "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T10:29:45.900322Z",
+      "diff_fingerprint": "sha256:8ab0073aee0963f24447fd123ddf4b9f0adfa57d020a3d4f95a6548eb2af01ea",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-23T10:30:04.007012Z",
+      "diff_fingerprint": "sha256:8ab0073aee0963f24447fd123ddf4b9f0adfa57d020a3d4f95a6548eb2af01ea",
+      "mode": "pre-pr",
       "result": "pass",
       "tier": 1,
       "unsatisfied": []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -209,6 +209,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2143] **A failed gate check now tells you everything it found, and a
+  stacked branch is measured against its own base.** Four defects shared one
+  shape — the gate observed more than it reported — and together they meant a
+  fix round addressed a fraction of the problem and then paid the full check
+  cost again on the next attempt.
+  A failed check's excerpt was a fixed 50-line tail of the raw log with no
+  header. Line-oriented tools emit a block per violation, so it showed the last
+  few of many and said nothing about the rest: on a measured run, 5 of 17 ruff
+  violations. The excerpt now leads with a header naming the log file and
+  stating how much of it is shown, at a 200-line cap.
+  `full_audit` was worse than partial — it reported nothing. It writes its
+  findings into `.audit/full-audit.json` and prints nothing at all, so its
+  transcript held only section markers, the tail came back empty, and the
+  failure reached the reader as `checks.full_audit` with no reason while 58
+  findings sat unread in the file. A check can now declare the report file it
+  writes, and that report is rendered into the repair hint: the failing
+  sub-audits, their findings with blocking severities first, and a count of any
+  the display cap left out.
+  The diff base was the third. `SCISTUDIO_GATE_BASE` was the only way to point
+  the gate at anything other than `origin/main`, and nothing in the repository
+  ever set it, so local `check` and `finalize` measured a branch stacked on a
+  track branch against `origin/main` and read its parent's commits as work
+  authored here — false out-of-scope findings, a wrong strictness tier, and
+  guard hits on files the branch never touched. The base is now a recorded
+  ledger fact, `base_ref`, set with `--base-ref` on `init`/`plan`/`amend` and
+  resolved after an explicit `--base` and the environment variable but before
+  `origin/main`. A ref git cannot resolve is refused outright, because diffing
+  against a ref that does not exist observes nothing and a gate that observed
+  nothing reads as a clean one. CI was never affected: it passes the real PR
+  base explicitly.
+  Last, `.worktrees/` — where parallel agents put their linked worktrees — was
+  untracked and unignored, so the repository-scoped `ruff check .` fallback
+  linted other agents' checkouts and failed commits on files they never
+  touched. It is gitignored now, which is what keeps ruff inside the checkout.
+
 - [#2093] **`npm run dev` in `desktop/` starts again on Windows.** The desktop
   dev launcher spawns npm twice — once for Vite, once for Electron — and on
   Windows the `npm` it reaches is `npm.cmd`, a batch shim. Node hardened

--- a/docs/ai-developer/gate-cli-command-set.md
+++ b/docs/ai-developer/gate-cli-command-set.md
@@ -95,6 +95,7 @@ python -m scistudio.qa.governance.gate_record init \
 | `--runtime` | yes | no | AI runtime executing the task (Codex, Claude Code, Gemini, or a local CLI agent) |
 | `--branch` | yes | no | Branch this ledger governs |
 | `--owner-directive` | yes | yes | Initial owner instruction; repeat for additional directives at init time |
+| `--base-ref` | no | no | Record the branch's diff base in the ledger. Used when neither `--base` nor `SCISTUDIO_GATE_BASE` is supplied; a plain branch name resolves to its `origin/` form, a revision expression is taken as written, and a ref git cannot resolve is refused (exit 2) rather than silently observing an empty diff. Set it on a branch stacked on another feature or track branch (#2143) |
 | `--slug` | no | no | Short human-readable slug for the generated record path |
 | `--session-id` | no | no | Local session id under `.git/scistudio/gates/`; generated automatically when omitted |
 | `--issue` | no | yes | GitHub issue number linked to the task |
@@ -133,6 +134,7 @@ python -m scistudio.qa.governance.gate_record plan \
 |---|---:|---:|---|
 | `--record` | no | no | Explicit ledger path; normally auto-discovered from the current branch |
 | `--owner-directive` | no | yes | Owner/manager instruction that changes plan or scope |
+| `--base-ref` | no | no | Record the branch's diff base in the ledger. Used when neither `--base` nor `SCISTUDIO_GATE_BASE` is supplied; a plain branch name resolves to its `origin/` form, a revision expression is taken as written, and a ref git cannot resolve is refused (exit 2) rather than silently observing an empty diff. Set it on a branch stacked on another feature or track branch (#2143) |
 | `--include` / `--exclude` | no | yes | Add declared in-scope / out-of-scope path or glob |
 | `--issue` | no | yes | Add issue link |
 | `--docs-updated` | no | yes | Repo-relative docs/spec/ADR/changelog/checklist path |
@@ -173,6 +175,7 @@ python -m scistudio.qa.governance.gate_record amend \
 |---|---:|---:|---|
 | `--reason` | yes | no | Human-readable reason for the amendment |
 | `--owner-directive` | no | yes | Add or correct owner instruction |
+| `--base-ref` | no | no | Record the branch's diff base in the ledger. Used when neither `--base` nor `SCISTUDIO_GATE_BASE` is supplied; a plain branch name resolves to its `origin/` form, a revision expression is taken as written, and a ref git cannot resolve is refused (exit 2) rather than silently observing an empty diff. Set it on a branch stacked on another feature or track branch (#2143) |
 | `--task-kind` | no | no | Correct task kind when the original classification was wrong |
 | `--persona` | no | no | Correct persona when routing changes |
 | `--branch` | no | no | Correct branch metadata |
@@ -215,7 +218,7 @@ python -m scistudio.qa.governance.gate_record check \
 
 | Argument | Required | Repeatable | Meaning |
 |---|---:|---:|---|
-| `--base` | no | no | Base ref for diff; default `git merge-base <upstream> HEAD` falling back to the raw upstream. When `--base` is omitted, `<upstream>` is the `SCISTUDIO_GATE_BASE` env var if set, else `origin/main`. Set `SCISTUDIO_GATE_BASE=origin/track/<name>` so the commit-msg / pre-commit framework hooks of a **track-stacked sub-PR** diff against their track (not `origin/main`, which would misread the whole track delta as authored here) — the same var the push/PR wrappers already honor (#1627). An explicit `--base` still wins. Deeply-stacked branches may need an explicit `--base` |
+| `--base` | no | no | Base ref for diff; default `git merge-base <upstream> HEAD` falling back to the raw upstream. When `--base` is omitted, `<upstream>` is resolved in this order: the `SCISTUDIO_GATE_BASE` env var, the ledger's recorded `base_ref` (see `--base-ref`), then `origin/main`. Prefer recording `--base-ref` on a **track-stacked sub-PR** so every later command measures the branch against its track rather than misreading the whole track delta as authored here (#1627, #2143); the env var remains a per-shell override and an explicit `--base` still wins over both |
 | `--head` | no | no | Head ref for diff; default `HEAD` |
 | `--mode` | no | no | One of `local` (default), `pre-commit`, `commit-msg`, `pre-push`, `pre-pr`, `ci` |
 | `--pr-body-file` | no | no | Intended PR body file for pre-PR issue-closure checks |

--- a/docs/ai-developer/rules.md
+++ b/docs/ai-developer/rules.md
@@ -142,9 +142,9 @@ self-route a task; this section is only the quick index.
 
 | Need | Command |
 |---|---|
-| Create or update the gate ledger for the current task | `python -m scistudio.qa.governance.gate_record init --task-kind <kind> --persona <persona> --runtime <runtime> --branch <branch> --owner-directive "<directive>" [--issue <n>] [--include <path>] [--exclude <path>] [--governance-touch true]` |
-| Record or update the plan (scope, docs, tests, checks) | `python -m scistudio.qa.governance.gate_record plan [--owner-directive "<update>"] [--include <path>] [--issue <n>] [--docs-updated <path>] [--docs-na "<class>:<rationale>"] [--test-path <path>] [--test-na "<class>:<rationale>"] [--check <name>]` |
-| Append a correction or scope change with rationale | `python -m scistudio.qa.governance.gate_record amend --reason "<why>" [--owner-directive "<directive>"] [--include <path>] [--issue <n>] [--test-path <path>] [--docs-updated <path>]` |
+| Create or update the gate ledger for the current task | `python -m scistudio.qa.governance.gate_record init --task-kind <kind> --persona <persona> --runtime <runtime> --branch <branch> --owner-directive "<directive>" [--issue <n>] [--base-ref <ref>] [--include <path>] [--exclude <path>] [--governance-touch true]` |
+| Record or update the plan (scope, docs, tests, checks) | `python -m scistudio.qa.governance.gate_record plan [--owner-directive "<update>"] [--base-ref <ref>] [--include <path>] [--issue <n>] [--docs-updated <path>] [--docs-na "<class>:<rationale>"] [--test-path <path>] [--test-na "<class>:<rationale>"] [--check <name>]` |
+| Append a correction or scope change with rationale | `python -m scistudio.qa.governance.gate_record amend --reason "<why>" [--owner-directive "<directive>"] [--base-ref <ref>] [--include <path>] [--issue <n>] [--test-path <path>] [--docs-updated <path>]` |
 | Run tier-selected local CI-equivalent checks and reconcile | `python -m scistudio.qa.governance.gate_record check [--base origin/main] [--head HEAD] [--mode local\|pre-push\|pre-pr\|ci] [--pr-body-file <path>] [--only <name>] [--skip-execution] [--force-checks]` |
 | Record commit provenance (pre-PR, before PR exists) | `python -m scistudio.qa.governance.gate_record finalize --commit <sha> --pr-body-file .workflow/local/pr-body.md --closes "#<issue>"` |
 | Record PR provenance (post-PR, after PR is created) | `python -m scistudio.qa.governance.gate_record finalize --commit <sha> --pr <url-or-number> --pr-body-file <path>` |
@@ -180,6 +180,14 @@ linked worktree. Use `gate_record amend` before touching files outside the
 original plan when operating within a worktree. New worktrees are
 auto-provisioned with this hook via
 `src/scistudio/agent_provisioning/templates/hook_worktree_write_guard.py`.
+
+A branch stacked on another feature or track branch MUST record its base with
+`--base-ref <ref>`. Without it the local `check` and `finalize` commands measure
+the branch against `origin/main` and read the parent branch's commits as work
+authored here, producing false out-of-scope findings and guard hits on files the
+branch never touched (#2143). `--base` overrides one invocation and
+`SCISTUDIO_GATE_BASE` overrides one shell; only `--base-ref` is recorded as gate
+evidence.
 
 `gate_record check --mode pre-pr` is the only local command that should execute
 PR-ready checks by default, and it is incremental: current passing evidence is

--- a/docs/ai-developer/specific_rules/gated-workflow.md
+++ b/docs/ai-developer/specific_rules/gated-workflow.md
@@ -117,10 +117,18 @@ python -m scistudio.qa.governance.gate_record init \
   --owner-directive "<owner instruction>" \
   [--slug <task-slug>] \
   [--issue <number>] \
+  [--base-ref <ref>] \
   [--include <path-or-glob>] \
   [--exclude <path-or-glob>] \
   [--governance-touch true|false]
 ```
+
+Record `--base-ref` when the branch is stacked on another feature or track
+branch. It is the ledger's own record of what this branch's delta is measured
+against; without it local `check` and `finalize` fall back to `origin/main` and
+attribute the parent branch's commits to this branch (#2143). A plain branch
+name resolves to its `origin/` form; a ref git cannot resolve is refused with
+exit 2 and nothing is written.
 
 `init` creates or updates the ledger, records branch/task identity, prints the
 chosen ledger path, and prints task-specific instructions by default. The
@@ -137,6 +145,7 @@ Compatibility alias: `start` delegates to `init`.
 ```bash
 python -m scistudio.qa.governance.gate_record plan \
   [--owner-directive "<scope or plan update>"] \
+  [--base-ref <ref>] \
   [--include <path-or-glob>] \
   [--exclude <path-or-glob>] \
   [--issue <number>] \
@@ -163,6 +172,7 @@ aliases).
 python -m scistudio.qa.governance.gate_record amend \
   --reason "<why the ledger is being corrected>" \
   [--owner-directive "<new or corrected owner instruction>"] \
+  [--base-ref <ref>] \
   [--task-kind <kind>] \
   [--persona <persona>] \
   [--issue <number>] \
@@ -235,6 +245,14 @@ python -m scistudio.qa.governance.gate_record check \
 7. Records a reconciliation event.
 8. Exits nonzero when required obligations remain unsatisfied and prints an
    "Unsatisfied obligations" section with exact repair hints.
+
+A failed check's repair hint carries its failure detail. When the check reports
+into a file rather than to stdout (`full_audit` writes
+`.audit/full-audit.json`), the hint renders the failing sub-reports and their
+findings, blocking severities first. When it prints, the hint carries a tail of
+the transcript with a header stating how many of the log's lines are shown and
+where the whole log is. Read the hint before re-running: it is meant to state
+the whole failure in one pass, not a slice of it (#2143).
 
 The `--mode` argument dispatches behavior for different callers:
 

--- a/docs/specs/adr-042-gate-ledger-runtime.md
+++ b/docs/specs/adr-042-gate-ledger-runtime.md
@@ -387,11 +387,21 @@ The main local CI-equivalent preflight. Arguments: `--base` (default
 `merge-base(origin/main, HEAD)`), `--head` (default `HEAD`), `--mode`
 (`local|pre-commit|commit-msg|pre-push|pre-pr|ci`, default `local`),
 `--pr-body-file`, plus the additive field flags from `plan`, plus `--only`
-(repeatable, recovery) and `--skip-execution`. When `--base` is omitted it
-defaults to `git merge-base origin/main HEAD` so a branch's delta is its own
-commits (correct for normal branches, better for stacked branches), falling back
-to raw `origin/main` when the merge-base cannot be computed; deeply-stacked
-branches may still need an explicit `--base`.
+(repeatable, recovery) and `--skip-execution`. When `--base` is omitted the
+upstream is resolved in order: the `SCISTUDIO_GATE_BASE` environment variable,
+the ledger's `base_ref`, then `origin/main`. The chosen upstream is reduced to
+`git merge-base <upstream> HEAD` so a branch's delta is its own commits, falling
+back to the raw ref when the merge-base cannot be computed.
+
+`base_ref` is the ledger's recorded answer to "what is this branch measured
+against?", set by `--base-ref` on `init`/`plan`/`amend`. It exists because the
+environment variable was the only non-default channel and nothing in the
+repository ever set it, so every local `check` and `finalize` outside the PR
+wrappers diffed a stacked branch against `origin/main` and read its parent
+branch's commits as work authored here (#2143). A plain branch name is resolved
+to its `origin/` form (the ref a PR merges into); a revision expression is taken
+as written; an unresolvable ref is refused with exit 2 rather than producing an
+empty observed diff that would read as a clean gate.
 
 `check` runs the §3.3 pipeline: observe diff -> infer tier-selected check set
 from the CI graph -> run required commands (unless `--only`/`--skip-execution`)
@@ -752,6 +762,7 @@ new events. `schema_version` is bumped to `2`.
   "strictness_tier": 2,
   "persona": "implementer",
   "branch": "hotfix-save-data-extension",
+  "base_ref": null,
   "owner_directive": "Fix SaveData unified IO extension handling for #1505.",
   "governance_touch": false,
   "declared_scope": {

--- a/src/scistudio/qa/governance/gate_record/checks.py
+++ b/src/scistudio/qa/governance/gate_record/checks.py
@@ -18,14 +18,15 @@ and returns sanitized :class:`CheckEvent` payloads.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
 import subprocess
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 import scistudio.qa.governance.gate_record.parity as parity
 import scistudio.qa.governance.gate_record.surfaces as surfaces
@@ -59,6 +60,13 @@ class CheckSpec:
     pr_only: bool = False
     # When True, requires PYTHONPATH=src to import scistudio.
     needs_src_import: bool = False
+    # Repo-relative path of an AuditReport JSON this check writes instead of
+    # printing its findings. A check that reports only to a file leaves an empty
+    # transcript, so a tail of its raw log carries nothing and the failure reads
+    # as "failed, no reason given" (#2143). When set, the evaluator renders the
+    # report file into the repair hint. ``None`` means the check prints its own
+    # findings and the transcript is the whole story.
+    report_json: str | None = None
 
 
 # Canonical CI command snapshot (Addendum 6 §7.5 table). The single mapping the
@@ -113,6 +121,9 @@ CHECK_CATALOG: dict[str, CheckSpec] = {
         covered_surface="governance",
         ci_job="ci.yml/Full Audit",
         needs_src_import=True,
+        # ``--output`` above is the only place full_audit reports; stdout stays
+        # empty even on failure.
+        report_json=".audit/full-audit.json",
     ),
     "python_tests": CheckSpec(
         name="python_tests",
@@ -701,3 +712,102 @@ def event_is_valid_for(
     if event.input_fingerprint is None or input_fingerprint is None:
         return False
     return event.input_fingerprint == input_fingerprint
+
+
+# Findings rendered per failing sub-report before the rest are counted off. A
+# repair hint has to stay readable, but the count of what it left out is always
+# printed -- silently dropping findings is the defect this renderer exists to
+# fix (#2143).
+_REPORT_FINDINGS_SHOWN = 10
+_REPORT_MESSAGE_CHARS = 200
+
+
+def _report_fails(report: Mapping[str, Any]) -> bool:
+    """Return True when a report node is itself a failure (not just a parent)."""
+
+    if str(report.get("status", "")).lower() == "fail":
+        return True
+    findings = report.get("findings") or []
+    return any(str(f.get("severity", "")).lower() == "error" for f in findings if isinstance(f, Mapping))
+
+
+def _failing_leaves(report: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    """Return the deepest failing nodes, so a parent never masks its children."""
+
+    children = [c for c in (report.get("child_reports") or []) if isinstance(c, Mapping)]
+    leaves: list[Mapping[str, Any]] = []
+    for child in children:
+        leaves.extend(_failing_leaves(child))
+    if leaves:
+        return leaves
+    return [report] if _report_fails(report) else []
+
+
+# Blocking findings come first: only ``error`` fails the check, and a report
+# that leads with advisory findings can push every blocking one past the display
+# cap -- reintroducing, inside the summary, the same hiding this renderer exists
+# to end (#2143).
+_SEVERITY_ORDER: dict[str, int] = {"error": 0, "warning": 1, "info": 2}
+
+
+def _severity_rank(finding: Mapping[str, Any]) -> int:
+    return _SEVERITY_ORDER.get(str(finding.get("severity", "")).lower(), len(_SEVERITY_ORDER))
+
+
+def _finding_line(finding: Mapping[str, Any]) -> str:
+    """Render one finding as ``[severity] file: message`` on a single line."""
+
+    severity = str(finding.get("severity", "") or "?").lower()
+    where = str(finding.get("file") or finding.get("path") or "").strip()
+    message = " ".join(str(finding.get("message", "") or "").split())
+    if len(message) > _REPORT_MESSAGE_CHARS:
+        message = message[: _REPORT_MESSAGE_CHARS - 3] + "..."
+    return f"[{severity}] {where}: {message}" if where else f"[{severity}] {message}"
+
+
+def report_json_summary(repo_root: Path, name: str) -> list[str]:
+    """Render a failed check's JSON report into lines for its repair hint.
+
+    A check whose :attr:`CheckSpec.report_json` is set writes its findings to a
+    file instead of printing them, so its transcript is empty and a tail of the
+    raw log tells the reader nothing: the failure reads as "failed, no reason
+    given" while the reasons sit unread in the report file (#2143). This reads
+    that file and returns the failing sub-reports with their findings.
+
+    Returns ``[]`` when the check writes no report, the file is missing, or it
+    cannot be parsed -- the caller then falls back to the raw transcript.
+    Parsed with ``json`` rather than the pydantic ``AuditReport`` model on
+    purpose: the file is written by a separate process, and a schema mismatch
+    must degrade to "no summary" rather than raise inside failure reporting.
+    """
+
+    spec = CHECK_CATALOG.get(name)
+    if spec is None or not spec.report_json:
+        return []
+    try:
+        raw = (repo_root / spec.report_json).read_text(encoding="utf-8", errors="replace")
+        document = json.loads(raw)
+    except (OSError, ValueError):
+        return []
+    if not isinstance(document, Mapping):
+        return []
+
+    failing = _failing_leaves(document)
+    if not failing:
+        return []
+
+    lines = [f"report: {spec.report_json}"]
+    for report in failing:
+        findings = sorted(
+            (f for f in (report.get("findings") or []) if isinstance(f, Mapping)),
+            key=_severity_rank,
+        )
+        tool = str(report.get("tool", "") or "?")
+        status = str(report.get("status", "") or "?")
+        lines.append(f"{tool}: {status} ({len(findings)} findings)")
+        for finding in findings[:_REPORT_FINDINGS_SHOWN]:
+            lines.append(f"  {_finding_line(finding)}")
+        hidden = len(findings) - _REPORT_FINDINGS_SHOWN
+        if hidden > 0:
+            lines.append(f"  ... {hidden} more findings in {tool} (see {spec.report_json})")
+    return lines

--- a/src/scistudio/qa/governance/gate_record/cli.py
+++ b/src/scistudio/qa/governance/gate_record/cli.py
@@ -22,6 +22,9 @@ def _add_field_flags(parser: argparse.ArgumentParser) -> None:
     """Add the common additive field flags shared by plan/amend/check/finalize."""
 
     parser.add_argument("--owner-directive", action="append", default=[])
+    # Records the branch's diff base in the ledger. Distinct from ``check
+    # --base``, which overrides one invocation and is not recorded.
+    parser.add_argument("--base-ref", default=None)
     parser.add_argument("--include", action="append", default=[])
     parser.add_argument("--exclude", action="append", default=[])
     parser.add_argument("--issue", action="append", default=[])
@@ -50,6 +53,7 @@ def build_parser() -> argparse.ArgumentParser:
     init.add_argument("--runtime", required=True)
     init.add_argument("--branch", required=True)
     init.add_argument("--owner-directive", action="append", required=True, default=[])
+    init.add_argument("--base-ref", default=None)
     init.add_argument("--slug")
     init.add_argument("--session-id")
     init.add_argument("--issue", action="append", default=[])
@@ -148,6 +152,7 @@ def _add_alias(sub: argparse._SubParsersAction, name: str, target: str, template
     alias.add_argument("--runtime", required=True)
     alias.add_argument("--branch", required=True)
     alias.add_argument("--owner-directive", action="append", required=True, default=[])
+    alias.add_argument("--base-ref", default=None)
     alias.add_argument("--slug")
     alias.add_argument("--session-id")
     alias.add_argument("--issue", action="append", default=[])

--- a/src/scistudio/qa/governance/gate_record/evaluator.py
+++ b/src/scistudio/qa/governance/gate_record/evaluator.py
@@ -513,31 +513,64 @@ def _guard_repair_hint(guard_name: str, report: AuditReport) -> str:
     return "\n".join(lines)
 
 
-def _failed_check_excerpt(repo_root: Path, event: CheckEvent, *, max_lines: int = 50, max_chars: int = 6000) -> str:
-    """Return an indented tail excerpt of a failed check's raw log, or "".
+# Section markers ``checks._write_raw_log`` puts around a captured transcript.
+# Used only to tell "the tool printed nothing" from "the tool printed", so a
+# report-only check is not handed an empty output block.
+_RAW_LOG_MARKERS: frozenset[str] = frozenset({"--- stdout ---", "--- stderr ---"})
 
-    The committed ledger keeps only a one-line ``summary`` + ``raw_log_ref``; this
-    surfaces the actual findings inline in the repair hint so a failing check is
-    actionable without opening the log file (#1628). Tail-biased because most
-    tools (pytest/ruff/mypy) put their error summary last, and full_audit's
-    per-child status table also lands at the tail.
+
+def _failed_check_excerpt(repo_root: Path, event: CheckEvent, *, max_lines: int = 200, max_chars: int = 20000) -> str:
+    """Return the indented failure-detail block for a failed check, or "".
+
+    Two sources feed the block, in order: the structured report a check writes
+    instead of printing (``CheckSpec.report_json``), then a tail of its raw
+    transcript.
+
+    Both were silently lossy before #2143. ``full_audit`` reports only into
+    ``.audit/full-audit.json``, so its transcript is empty and the failure
+    reached the reader with no reason at all while its findings sat unread in
+    that file. And a fixed 50-line tail of a line-oriented tool showed the last
+    few violations of many with nothing saying more existed -- measured at 5 of
+    17 ruff violations -- so each round of fixes revealed only the next few and
+    the check had to be paid for again. The block now renders a report-only
+    check's findings, and the transcript header states how much of the log is
+    shown and where the whole log is.
+
+    Tail-biased because pytest/ruff/mypy put their error summary last.
     """
 
+    blocks: list[str] = []
+
+    summary_lines = checks.report_json_summary(repo_root, event.name)
+    if summary_lines:
+        rendered = "\n".join(f"  | {line}" for line in summary_lines)
+        blocks.append(f"  --- {event.name} findings ---\n{rendered}")
+
     ref = event.raw_log_ref
-    if not ref:
+    log_text = ""
+    if ref:
+        try:
+            log_text = (repo_root / ref).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            log_text = ""
+    lines = log_text.splitlines()
+    # ``lines[0]`` is the ``# <name> (exit N)`` header the writer always emits;
+    # everything after it is the tool's own output.
+    printed_anything = any(line.strip() and line.strip() not in _RAW_LOG_MARKERS for line in lines[1:])
+    if printed_anything:
+        tail = lines[-max_lines:]
+        excerpt = "\n".join(f"  | {line}" for line in tail).rstrip()
+        if len(excerpt) > max_chars:
+            excerpt = "  | ...(truncated)\n" + excerpt[-max_chars:]
+        extent = f"last {len(tail)} of {len(lines)} lines" if len(tail) < len(lines) else f"{len(lines)} lines"
+        blocks.append(f"  --- {event.name} output ({extent}; full log: {ref}) ---\n{excerpt}")
+
+    if not blocks:
         return ""
-    try:
-        text = (repo_root / ref).read_text(encoding="utf-8", errors="replace")
-    except OSError:
-        return ""
-    tail = text.splitlines()[-max_lines:]
-    excerpt = "\n".join(f"  | {line}" for line in tail).rstrip()
-    if len(excerpt) > max_chars:
-        excerpt = "  | ...(truncated)\n" + excerpt[-max_chars:]
     # Keep it printable on ANY console: a Windows GBK/cp1252 stdout cannot encode
     # the U+FFFD replacement char that ``errors="replace"`` emits for non-UTF-8
     # log bytes, which would crash ``_print_outcome``'s ``print``. ASCII-clean it.
-    return excerpt.encode("ascii", "replace").decode("ascii")
+    return "\n".join(blocks).encode("ascii", "replace").decode("ascii")
 
 
 def _is_global_check_config_path(path: str) -> bool:
@@ -1026,7 +1059,7 @@ def reconcile(
                 hint = f"- checks.{name}\n  Re-run the check after fixing:\n  {event.command}"
                 excerpt = _failed_check_excerpt(repo_root, event)
                 if excerpt:
-                    hint += f"\n  --- {name} output (tail) ---\n{excerpt}"
+                    hint += f"\n{excerpt}"
                 repair_hints.append(hint)
     elif mode not in ("commit-msg",):
         # Reuse previously recorded passing check evidence instead of executing

--- a/src/scistudio/qa/governance/gate_record/io.py
+++ b/src/scistudio/qa/governance/gate_record/io.py
@@ -185,6 +185,39 @@ def resolve_default_base(repo_root: Path, *, upstream: str | None = None, head: 
     return out or upstream
 
 
+def normalize_base_ref(repo_root: Path, ref: str) -> str | None:
+    """Return a resolvable git ref for *ref*, or ``None`` when it names nothing.
+
+    A bare branch name is what ``gh pr create --base`` takes and what an agent
+    naturally types. It resolves to the REMOTE form first, matching
+    ``scripts/hooks/check-gate-before-pr.sh``: the base a PR is measured against
+    is the branch it will merge into, not a local copy that may sit behind it.
+    A value already carrying a remote or ``refs/`` prefix is taken as written,
+    and a local-only branch still resolves once the remote form fails.
+
+    Returning ``None`` lets the caller refuse an unresolvable base loudly:
+    diffing against a ref git cannot find yields an empty changed-file set, and
+    a gate that observed nothing reports no findings and reads as a pass
+    (#2143).
+    """
+
+    candidate = ref.strip()
+    if not candidate:
+        return None
+    # Only a plain branch name gets the remote prefix. A revision expression
+    # such as ``HEAD~1`` must be taken as written: ``origin/HEAD`` exists (the
+    # remote default-branch symref), so ``origin/HEAD~1`` would resolve and
+    # silently answer a question nobody asked.
+    plain_branch = not candidate.startswith(("origin/", "upstream/", "refs/")) and not any(
+        ch in candidate for ch in "~^@:"
+    )
+    forms = (f"origin/{candidate}", candidate) if plain_branch else (candidate,)
+    for form in forms:
+        if resolve_sha(repo_root, form) is not None:
+            return form
+    return None
+
+
 def resolve_sha(repo_root: Path, ref: str) -> str | None:
     """Resolve ``ref`` to a short SHA, or None when unresolvable."""
 

--- a/src/scistudio/qa/governance/gate_record/ledger.py
+++ b/src/scistudio/qa/governance/gate_record/ledger.py
@@ -323,6 +323,15 @@ class GateLedger(BaseModel):
     strictness_tier: StrictnessTier | None = None
     persona: Persona
     branch: str
+    # The ref this branch's delta is measured against when no one-shot
+    # ``--base`` and no ``SCISTUDIO_GATE_BASE`` are supplied. A branch stacked
+    # on another feature or track branch is the case that needs it: measured
+    # against ``origin/main`` its parent's commits are attributed to this
+    # branch, producing false out-of-scope findings, a wrong tier, and guard
+    # hits on files it never touched (#2143). Recorded here rather than left
+    # to an environment variable so the base a run used is auditable evidence
+    # like every other gate fact.
+    base_ref: str | None = None
     owner_directive: str
     governance_touch: bool = False
     declared_scope: DeclaredScope = Field(default_factory=DeclaredScope)

--- a/src/scistudio/qa/governance/gate_record/workflow.py
+++ b/src/scistudio/qa/governance/gate_record/workflow.py
@@ -13,6 +13,7 @@ Exit codes (spec §5.7):
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -123,8 +124,24 @@ def _save(repo_root: Path, path: Path, ledger: GateLedger) -> CommandOutcome | N
 # ---------------------------------------------------------------------------
 
 
-def _apply_fields(ledger: GateLedger, args: Any, *, reason: str | None = None) -> None:
+def _apply_base_ref(ledger: GateLedger, value: str | None, *, repo_root: Path) -> None:
+    """Record the branch's diff base, refusing a ref git cannot resolve."""
+
+    if value is None:
+        return
+    resolved = io.normalize_base_ref(repo_root, value)
+    if resolved is None:
+        raise ValueError(
+            f"--base-ref {value!r} does not resolve to a git ref. Fetch the branch it "
+            "names, or pass a ref that exists locally."
+        )
+    ledger.base_ref = resolved
+
+
+def _apply_fields(ledger: GateLedger, args: Any, *, repo_root: Path, reason: str | None = None) -> None:
     """Append additive field events to the ledger (never overwrite)."""
+
+    _apply_base_ref(ledger, getattr(args, "base_ref", None), repo_root=repo_root)
 
     for directive in getattr(args, "owner_directive", None) or []:
         ledger.directive_events.append(DirectiveEvent(owner_directive=directive, reason=reason))
@@ -219,6 +236,10 @@ def run_init(repo_root: Path, args: Any) -> int:
         ledger.declared_scope = declared
     if args.governance_touch is not None:
         ledger.governance_touch = args.governance_touch
+    try:
+        _apply_base_ref(ledger, getattr(args, "base_ref", None), repo_root=repo_root)
+    except ValueError as exc:
+        return _print_outcome(CommandOutcome(EXIT_USAGE, [str(exc)]))
 
     save_err = _save(repo_root, path, ledger)
     if save_err:
@@ -263,7 +284,7 @@ def run_plan(repo_root: Path, args: Any) -> int:
         return _print_outcome(load_err)
     assert ledger is not None
     try:
-        _apply_fields(ledger, args, reason="plan")
+        _apply_fields(ledger, args, repo_root=repo_root, reason="plan")
     except ValueError as exc:
         return _print_outcome(CommandOutcome(EXIT_USAGE, [str(exc)]))
     save_err = _save(repo_root, path, ledger)
@@ -284,7 +305,7 @@ def run_amend(repo_root: Path, args: Any) -> int:
         return _print_outcome(load_err)
     assert ledger is not None
     try:
-        _apply_fields(ledger, args, reason=args.reason)
+        _apply_fields(ledger, args, repo_root=repo_root, reason=args.reason)
     except ValueError as exc:
         return _print_outcome(CommandOutcome(EXIT_USAGE, [str(exc)]))
     save_err = _save(repo_root, path, ledger)
@@ -339,18 +360,32 @@ def _recovery_banner(mode: str, unrun: list[str]) -> list[str]:
     ]
 
 
-def _resolve_base(repo_root: Path, base: str | None, head: str) -> str:
+def _resolve_base(repo_root: Path, base: str | None, head: str, *, ledger_base_ref: str | None = None) -> str:
     """Resolve the diff base (Fix D / §7.5).
 
-    An explicit ``--base`` is honored verbatim. When omitted, default to
-    ``git merge-base origin/main HEAD`` so a branch's delta is its own commits
-    (correct for normal branches; better for stacked branches). Falls back to
-    raw ``origin/main`` when the merge-base cannot be computed.
+    Precedence, most specific first:
+
+    1. an explicit ``--base``, honored verbatim (one invocation);
+    2. ``SCISTUDIO_GATE_BASE`` in the environment (one shell);
+    3. the ledger's recorded ``base_ref`` (the branch's own fact);
+    4. ``origin/main``.
+
+    The chosen upstream is then reduced to ``git merge-base <upstream> HEAD`` so
+    a branch's delta is its own commits, falling back to the raw ref when the
+    merge-base cannot be computed.
+
+    Level 3 is what makes a stacked branch measurable. Before #2143 the only
+    non-default channel was the environment variable, which nothing in the
+    repository ever set, so every local run outside the PR wrappers diffed
+    against ``origin/main`` and read the parent branch's commits as this
+    branch's work.
     """
 
     if base:
         return base
-    return io.resolve_default_base(repo_root, head=head)
+    env_base = os.environ.get(io.GATE_BASE_ENV_VAR, "").strip()
+    upstream = env_base or (ledger_base_ref or "").strip() or None
+    return io.resolve_default_base(repo_root, upstream=upstream, head=head)
 
 
 def _changed_record_paths(repo_root: Path, *, base: str, head: str, mode: str) -> list[Path]:
@@ -410,8 +445,12 @@ def _read_pr_context(repo_root: Path, pr_context_file: str | None) -> dict[str, 
 def run_check(repo_root: Path, args: Any, *, mode: str | None = None) -> int:
     effective_mode = mode or getattr(args, "mode", "local") or "local"
     head = getattr(args, "head", "HEAD") or "HEAD"
-    base = _resolve_base(repo_root, getattr(args, "base", None), head)
-    changed_record_paths = _changed_record_paths(repo_root, base=base, head=head, mode=effective_mode)
+    # Ledger discovery needs a base before the ledger exists to be read, so this
+    # first pass cannot consult the recorded ``base_ref``. It only feeds
+    # finalized-record discovery, which ``pre-commit`` answers from the staged
+    # index anyway; the authoritative base is re-resolved with the ledger below.
+    discovery_base = _resolve_base(repo_root, getattr(args, "base", None), head)
+    changed_record_paths = _changed_record_paths(repo_root, base=discovery_base, head=head, mode=effective_mode)
     path, err = _resolve_ledger_path(
         repo_root,
         args.record,
@@ -432,9 +471,10 @@ def run_check(repo_root: Path, args: Any, *, mode: str | None = None) -> int:
         return _print_outcome(load_err)
     assert ledger is not None
     try:
-        _apply_fields(ledger, args, reason="check")
+        _apply_fields(ledger, args, repo_root=repo_root, reason="check")
     except ValueError as exc:
         return _print_outcome(CommandOutcome(EXIT_USAGE, [str(exc)]))
+    base = _resolve_base(repo_root, getattr(args, "base", None), head, ledger_base_ref=ledger.base_ref)
 
     pr_body = _read_pr_body(repo_root, getattr(args, "pr_body_file", None))
     pr_context = _read_pr_context(repo_root, getattr(args, "pr_context_file", None))
@@ -538,7 +578,7 @@ def run_finalize(repo_root: Path, args: Any) -> int:
         return _print_outcome(CommandOutcome(EXIT_USAGE, ["pre-PR finalize requires --pr-body-file"]))
 
     try:
-        _apply_fields(ledger, args, reason="finalize")
+        _apply_fields(ledger, args, repo_root=repo_root, reason="finalize")
     except ValueError as exc:
         return _print_outcome(CommandOutcome(EXIT_USAGE, [str(exc)]))
 
@@ -565,7 +605,7 @@ def run_finalize(repo_root: Path, args: Any) -> int:
     mode = "ci" if is_post_pr and pr_context is not None else "pre-pr"
     pr_body = _read_pr_body(repo_root, getattr(args, "pr_body_file", None))
     head = getattr(args, "head", "HEAD") or "HEAD"
-    base = _resolve_base(repo_root, getattr(args, "base", None), head)
+    base = _resolve_base(repo_root, getattr(args, "base", None), head, ledger_base_ref=ledger.base_ref)
     force_checks = bool(getattr(args, "force_checks", False))
     result = evaluator.reconcile(
         ledger=ledger,

--- a/tests/qa/test_gate_record.py
+++ b/tests/qa/test_gate_record.py
@@ -1141,7 +1141,12 @@ def test_failed_check_excerpt_surfaces_log_tail(tmp_path: Path) -> None:
     out = evaluator._failed_check_excerpt(tmp_path, event)
     assert "ERROR: thing A" in out
     assert "FAILED test_b" in out
-    assert out.lstrip().startswith("|")  # indented excerpt lines
+    # The block leads with a header naming the log and how much of it is shown,
+    # so nothing is dropped without saying so (#2143); the excerpt lines under
+    # it stay indented and prefixed.
+    assert out.lstrip().startswith("--- full_audit output (")
+    assert ".workflow/local/logs/full_audit.log" in out
+    assert any(line.lstrip().startswith("|") for line in out.splitlines())
     assert "�" not in out
     out.encode("ascii")  # printable on any console; raises if not ASCII-clean
 

--- a/tests/qa/test_gate_record_bugfixes.py
+++ b/tests/qa/test_gate_record_bugfixes.py
@@ -13,6 +13,7 @@ with a "still blocks" assertion proving enforcement is intact.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -20,7 +21,13 @@ from pathlib import Path
 import pytest
 
 from scistudio.qa.governance.gate_record import cli, evaluator, io, workflow
-from scistudio.qa.governance.gate_record.ledger import DeclaredScope, DocsEvent, GateLedger, IssueRef
+from scistudio.qa.governance.gate_record.ledger import (
+    CheckEvent,
+    DeclaredScope,
+    DocsEvent,
+    GateLedger,
+    IssueRef,
+)
 from scistudio.qa.schemas.report import Severity
 
 # ---------------------------------------------------------------------------
@@ -627,3 +634,356 @@ def test_1283_worker_record_still_enforces_scope(git_repo: Path) -> None:
     blocking = [f for f in result.report.findings if f.rule_id == "scope.out-of-scope" and f.severity == Severity.ERROR]
     assert any(f.file == "src/scistudio/b.py" for f in blocking)
     assert "scope.out-of-scope" in result.unsatisfied
+
+
+# ---------------------------------------------------------------------------
+# #2143 — the gate under-reported failed checks and measured local diffs
+# against origin/main, so each round of fixes saw a fraction of the problem
+# and paid the full check cost again.
+#
+# Every assertion below is about the gate telling MORE truth, never about it
+# blocking less: the disclosure tests pair "what is shown" with "what is said
+# to be hidden", and the base tests pair "the parent's commits are excluded"
+# with "the branch's own commits still are not".
+# ---------------------------------------------------------------------------
+
+
+def _fail_event(name: str, *, raw_log_ref: str | None) -> CheckEvent:
+    return CheckEvent(
+        name=name,
+        command="cmd",
+        covered_surface="governance",
+        status="fail",
+        raw_log_ref=raw_log_ref,
+    )
+
+
+def _write_log(root: Path, name: str, body: str) -> str:
+    rel = f".workflow/local/logs/{name}.log"
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"# {name} (exit 1)\n--- stdout ---\n{body}\n--- stderr ---\n", encoding="utf-8")
+    return rel
+
+
+def _write_report(root: Path, rel: str, document: dict[str, object]) -> None:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def _audit_report(children: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "tool": "full_audit",
+        "status": "fail",
+        "source_sha": "abc1234",
+        "findings": [],
+        "child_reports": children,
+    }
+
+
+def _child(tool: str, findings: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "tool": tool,
+        "status": "fail",
+        "source_sha": "abc1234",
+        "findings": findings,
+        "child_reports": [],
+    }
+
+
+def _finding(severity: str, file: str, message: str) -> dict[str, object]:
+    return {"rule_id": f"{severity}.rule", "severity": severity, "file": file, "message": message}
+
+
+def test_2143_long_log_says_how_much_of_it_is_hidden(tmp_path: Path) -> None:
+    """A truncated transcript must name what it left out and where to read it.
+
+    The excerpt was a fixed 50-line tail with no header. On a line-oriented tool
+    that emits a block per violation it showed the last few of many -- measured
+    at 5 of 17 ruff violations -- and said nothing about the rest, so a fix round
+    addressed what was visible and the next round paid for the check again.
+    """
+
+    body = "\n".join(f"violation {i}" for i in range(500))
+    ref = _write_log(tmp_path, "lint_format", body)
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("lint_format", raw_log_ref=ref))
+
+    assert "last 200 of 503 lines" in out
+    assert ref in out
+    assert "violation 499" in out
+    # Enforcing the disclosure only matters if truncation actually happened.
+    assert "violation 0" not in out
+
+
+def test_2143_short_log_states_its_full_extent(tmp_path: Path) -> None:
+    """An untruncated transcript says so, instead of leaving the reader guessing."""
+
+    ref = _write_log(tmp_path, "lint_format", "only problem\n")
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("lint_format", raw_log_ref=ref))
+
+    assert "only problem" in out
+    assert "last " not in out
+    assert ref in out
+
+
+def test_2143_report_only_check_renders_the_findings_it_wrote_to_json(tmp_path: Path) -> None:
+    """The exact #2143 failure: ``full_audit`` prints nothing and fails.
+
+    It reports solely into ``.audit/full-audit.json``, so its transcript held
+    only the writer's own section markers and the tail excerpt came back empty.
+    A real run produced 58 findings and the console showed the reader none of
+    them.
+    """
+
+    ref = _write_log(tmp_path, "full_audit", "")
+    _write_report(
+        tmp_path,
+        ".audit/full-audit.json",
+        _audit_report(
+            [
+                _child("doc_drift", [_finding("error", "docs/adr/ADR-049.md", "governed glob already resolves")]),
+                _child("closure", [_finding("error", "docs/adr/ADR-052.md", "unclosed governed contract")]),
+            ]
+        ),
+    )
+
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref))
+
+    assert "doc_drift: fail (1 findings)" in out
+    assert "closure: fail (1 findings)" in out
+    assert "governed glob already resolves" in out
+    assert "unclosed governed contract" in out
+    assert ".audit/full-audit.json" in out
+    # The transcript carried no tool output, so no empty output block is offered.
+    assert "output (" not in out
+
+
+def test_2143_report_findings_lead_with_the_blocking_ones(tmp_path: Path) -> None:
+    """Advisory findings must not push blocking ones past the display cap.
+
+    A real ``doc_drift`` report opens with a run of ``info`` findings and hides
+    its handful of ``error`` findings further down. Rendering in file order
+    would reproduce, inside the summary, the same hiding this renderer exists to
+    end.
+    """
+
+    ref = _write_log(tmp_path, "full_audit", "")
+    findings = [_finding("info", f"docs/note-{i}.md", f"advisory {i}") for i in range(12)]
+    findings.append(_finding("error", "docs/adr/ADR-049.md", "the blocking one"))
+    _write_report(tmp_path, ".audit/full-audit.json", _audit_report([_child("doc_drift", findings)]))
+
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref))
+    lines = out.splitlines()
+    error_index = next(i for i, line in enumerate(lines) if "the blocking one" in line)
+    first_info_index = next(i for i, line in enumerate(lines) if "advisory" in line)
+
+    assert error_index < first_info_index
+    assert "... 3 more findings in doc_drift" in out
+
+
+def test_2143_report_summary_counts_off_what_it_did_not_show(tmp_path: Path) -> None:
+    """Over the cap, the remainder is counted and the report file is named."""
+
+    ref = _write_log(tmp_path, "full_audit", "")
+    findings = [_finding("error", f"docs/f-{i}.md", f"problem {i}") for i in range(25)]
+    _write_report(tmp_path, ".audit/full-audit.json", _audit_report([_child("doc_drift", findings)]))
+
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref))
+
+    assert "doc_drift: fail (25 findings)" in out
+    assert "... 15 more findings in doc_drift (see .audit/full-audit.json)" in out
+
+
+def test_2143_unreadable_report_degrades_instead_of_raising(tmp_path: Path) -> None:
+    """Failure reporting must never itself fail on a malformed report file."""
+
+    ref = _write_log(tmp_path, "full_audit", "")
+    (tmp_path / ".audit").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".audit/full-audit.json").write_text("{ not json", encoding="utf-8")
+
+    assert evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref)) == ""
+    # Absent file: same outcome, still no exception.
+    (tmp_path / ".audit/full-audit.json").unlink()
+    assert evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref)) == ""
+
+
+def test_2143_a_report_only_check_still_shows_a_transcript_when_it_has_one(tmp_path: Path) -> None:
+    """Rendering the report does not suppress output the tool did print."""
+
+    ref = _write_log(tmp_path, "full_audit", "Traceback: the audit itself crashed\n")
+    _write_report(
+        tmp_path,
+        ".audit/full-audit.json",
+        _audit_report([_child("doc_drift", [_finding("error", "docs/a.md", "drifted")])]),
+    )
+
+    out = evaluator._failed_check_excerpt(tmp_path, _fail_event("full_audit", raw_log_ref=ref))
+
+    assert "drifted" in out
+    assert "the audit itself crashed" in out
+
+
+# --- the recorded diff base ------------------------------------------------
+
+
+def test_2143_ledger_records_a_base_ref_and_older_records_load_without_one() -> None:
+    """``base_ref`` is optional, so ledgers written before #2143 still load."""
+
+    assert _ledger().base_ref is None
+    assert _ledger(base_ref="origin/track/parent").base_ref == "origin/track/parent"
+
+
+def test_2143_base_ref_normalizes_a_branch_name_to_the_ref_the_pr_merges_into(git_repo: Path) -> None:
+    """A plain branch name means the remote branch; a revision means itself."""
+
+    _git(git_repo, "checkout", "-q", "-b", "track/parent")
+    _git(git_repo, "checkout", "-q", "main")
+    _add_commit(git_repo, "second.txt", message="second")
+
+    assert io.normalize_base_ref(git_repo, "track/parent") == "track/parent"
+    assert io.normalize_base_ref(git_repo, "refs/heads/main") == "refs/heads/main"
+    # `origin/HEAD` would make `origin/HEAD~1` resolve; a revision must not be
+    # quietly rewritten into a different commit.
+    assert io.normalize_base_ref(git_repo, "HEAD~1") == "HEAD~1"
+    assert io.normalize_base_ref(git_repo, "no-such-branch") is None
+    assert io.normalize_base_ref(git_repo, "   ") is None
+
+
+def test_2143_resolve_base_precedence(git_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """--base beats the environment, which beats the ledger, which beats main."""
+
+    monkeypatch.delenv(io.GATE_BASE_ENV_VAR, raising=False)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=git_repo, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+    assert workflow._resolve_base(git_repo, "explicit/ref", "HEAD", ledger_base_ref="main") == "explicit/ref"
+    assert workflow._resolve_base(git_repo, None, "HEAD", ledger_base_ref="main") == head_sha
+
+    monkeypatch.setenv(io.GATE_BASE_ENV_VAR, "main")
+    assert workflow._resolve_base(git_repo, None, "HEAD", ledger_base_ref="no-such-ref") == head_sha
+
+    # With no signal at all the default is still origin/main, which this remote-
+    # less fixture cannot reduce to a merge-base, so the raw ref comes back.
+    monkeypatch.delenv(io.GATE_BASE_ENV_VAR, raising=False)
+    assert workflow._resolve_base(git_repo, None, "HEAD", ledger_base_ref=None) == "origin/main"
+
+
+def test_2143_stacked_branch_measures_its_own_commits_not_its_parents(git_repo: Path) -> None:
+    """The payoff: a recorded base keeps the parent branch's work out of the diff.
+
+    Without it the only non-default channel was ``SCISTUDIO_GATE_BASE``, which
+    nothing in the repository ever set, so a branch stacked on a track branch
+    was measured against ``origin/main`` and the parent's commits were read as
+    this branch's work -- false out-of-scope findings, a wrong tier, and guard
+    hits on files it never touched.
+    """
+
+    _git(git_repo, "checkout", "-q", "-b", "track/parent")
+    _add_commit(git_repo, "src/scistudio/parent_only.py", message="parent work")
+    _git(git_repo, "checkout", "-q", "-b", "feat/child")
+    _add_commit(git_repo, "src/scistudio/child_only.py", message="child work")
+
+    measured_against_main = io.changed_files(git_repo, "main", "HEAD")
+    assert "src/scistudio/parent_only.py" in measured_against_main
+    assert "src/scistudio/child_only.py" in measured_against_main
+
+    base = workflow._resolve_base(git_repo, None, "HEAD", ledger_base_ref="track/parent")
+    measured_against_parent = io.changed_files(git_repo, base, "HEAD")
+    assert "src/scistudio/parent_only.py" not in measured_against_parent
+    # The branch's own commit is still observed: this narrows attribution, it
+    # does not narrow enforcement.
+    assert "src/scistudio/child_only.py" in measured_against_parent
+
+
+def test_2143_check_uses_the_recorded_base_end_to_end(git_repo: Path) -> None:
+    """The recorded base reaches the observed diff through the real CLI path."""
+
+    _git(git_repo, "checkout", "-q", "-b", "track/parent")
+    _add_commit(git_repo, "src/scistudio/parent_only.py", message="parent work")
+    _git(git_repo, "checkout", "-q", "-b", "feat/child")
+    _add_commit(git_repo, "src/scistudio/child_only.py", message="child work")
+
+    assert (
+        cli.main(
+            [
+                "--repo-root",
+                str(git_repo),
+                "init",
+                "--task-kind",
+                "bugfix",
+                "--persona",
+                "implementer",
+                "--runtime",
+                "claude-code",
+                "--branch",
+                "feat/child",
+                "--owner-directive",
+                "stacked work",
+                "--base-ref",
+                "track/parent",
+                "--print-instructions",
+                "false",
+            ]
+        )
+        == workflow.EXIT_OK
+    )
+
+    record = next((git_repo / ".workflow/records").glob("*.json"))
+    assert json.loads(record.read_text(encoding="utf-8"))["base_ref"] == "track/parent"
+
+    cli.main(["--repo-root", str(git_repo), "check", "--mode", "local", "--skip-execution"])
+    observed = json.loads(record.read_text(encoding="utf-8"))["observed_diff"]["changed_files"]
+    assert "src/scistudio/child_only.py" in observed
+    assert "src/scistudio/parent_only.py" not in observed
+
+
+def test_2143_unresolvable_base_ref_is_refused_not_silently_accepted(git_repo: Path) -> None:
+    """A base git cannot resolve would observe nothing and read as a pass."""
+
+    assert (
+        cli.main(
+            [
+                "--repo-root",
+                str(git_repo),
+                "init",
+                "--task-kind",
+                "bugfix",
+                "--persona",
+                "implementer",
+                "--runtime",
+                "claude-code",
+                "--branch",
+                "feat/child",
+                "--owner-directive",
+                "stacked work",
+                "--base-ref",
+                "no-such-branch",
+                "--print-instructions",
+                "false",
+            ]
+        )
+        == workflow.EXIT_USAGE
+    )
+    # Validate before persist: a refused base leaves no ledger behind at all,
+    # so a later run cannot inherit a base nobody accepted.
+    assert list((git_repo / ".workflow/records").glob("*.json")) == []
+
+
+def test_2143_worktrees_directory_is_ignored_by_the_repository() -> None:
+    """Repo-scoped checks must not read a sibling agent's linked worktree.
+
+    ``.worktrees/`` holds linked worktrees for parallel agents. Untracked and
+    unignored, it was visible to the ``ruff check .`` fallback, which failed a
+    commit in the main checkout on a file in another agent's worktree.
+    """
+
+    repo_root = Path(__file__).resolve().parents[2]
+    completed = subprocess.run(
+        ["git", "check-ignore", "-q", ".worktrees/some-agent/module.py"],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, ".worktrees/ must be gitignored so ruff skips it"


### PR DESCRIPTION
## What this fixes

Four defects in the gate's local feedback path. They shared one shape — the gate
observed more than it reported — and together they meant an agent fixed a
fraction of the real problems per round and paid the full check cost again on
every retry.

### 1. A failed check's excerpt was a silent 50-line tail

`_failed_check_excerpt` tailed the raw log at a fixed 50 lines with no header.
Line-oriented tools emit a block per violation, so the tail showed the last few
of many and said nothing about the rest. Measured on a real run: 173 log lines,
17 ruff violations, **5** rendered.

The block now leads with a header naming the log file and stating how much of it
is shown (`last 200 of 503 lines; full log: ...`), and the cap is 200 lines.

### 2. `full_audit` reported nothing at all

Its command is `--format json --output .audit/full-audit.json`. It prints
nothing, so its transcript held only the writer's section markers and the tail
excerpt came back empty — the failure reached the reader as `checks.full_audit`
with no reason. The same run had **58 findings** sitting unread in the JSON.

`CheckSpec` gains `report_json`, and a check that reports into a file has that
file rendered into its repair hint: failing sub-reports, their findings,
blocking severities first, and a count of any it did not show. Advisory findings
can no longer push blocking ones past the display cap.

### 3. The local diff base was always `origin/main`

`resolve_default_base` read `SCISTUDIO_GATE_BASE` and fell back to
`origin/main`. Nothing in the repository ever set that variable —
`check-gate-before-pr.sh` only reads it and the docs asked the agent to export
it by hand. So local `check` (manual and `--mode pre-push`) and `finalize`
measured a stacked branch against `origin/main` and read its parent branch's
commits as work authored here: false `scope.out-of-scope` findings, wrong tier
escalation, spurious `mod_guard` / `core_change_guard` hits.

The base becomes a recorded ledger fact. `GateLedger` gains `base_ref`, set by
`--base-ref` on `init` / `plan` / `amend`, and `_resolve_base` resolves in
order: `--base` (one invocation) → `SCISTUDIO_GATE_BASE` (one shell) →
`ledger.base_ref` (the branch's own fact) → `origin/main`. A plain branch name
resolves to its `origin/` form (the ref a PR merges into); a revision expression
is taken as written; a ref git cannot resolve is refused with exit 2 and nothing
is persisted, rather than silently observing an empty diff that would read as a
clean gate.

CI was never affected: `workflow-gate.yml` passes `--base origin/$BASE_REF`, and
`check-gate-before-pr.sh` and `scistudio_pr_create.py` parse `--base` out of the
`gh pr create` argv. This PR's own ledger records `base_ref` and exercises the
path.

### 4. `.worktrees/` was linted as part of the repository

It holds linked worktrees for parallel agents, untracked and unignored, so the
repo-scoped `ruff check .` fallback linted other agents' checkouts. A real
pre-commit run in the main checkout failed on
`.worktrees/pr-2072-audit/smoke_audit_pr2072.py`, a file the commit never
touched. Ruff respects `.gitignore`, so ignoring the directory is the fix.

## Tests

14 regression tests in `tests/qa/test_gate_record_bugfixes.py`, and the one test
whose contract changed updated in `tests/qa/test_gate_record.py`. Each
disclosure test pairs what is shown with what is stated to be hidden; each base
test pairs "the parent's commits are excluded" with "the branch's own commits
still are not", so nothing here narrows enforcement.

Negative coverage: an unresolvable `--base-ref` exits 2 and writes no ledger; a
malformed or absent report file degrades to no summary instead of raising inside
failure reporting.

## Docs

`docs/specs/adr-042-gate-ledger-runtime.md` (§5.5 base resolution, `base_ref` in
the ledger schema example), `docs/ai-developer/gate-cli-command-set.md`
(`--base-ref` rows, rewritten `--base` row),
`docs/ai-developer/specific_rules/gated-workflow.md` (§2.1–2.4), and
`docs/ai-developer/rules.md` (§5 command index plus the stacked-branch rule).

Gate record: .workflow/records/2143-gate-failure-reporting-and-base.json

Closes #2143