### PR TITLE
guided(#2157): make the Learning Center's Reading tab a reader for the shipped user documentation

### DIFF
--- a/.workflow/records/2157-guided-reading-doc-viewer.json
+++ b/.workflow/records/2157-guided-reading-doc-viewer.json
@@ -1,0 +1,482 @@
+{
+  "base_ref": null,
+  "branch": "guided/reading-doc-viewer",
+  "check_events": [
+    {
+      "at": "2026-08-25T06:02:35.893915Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:02:48.869334Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:02:48.948251Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:03:15.768088Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:03:15.806092Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/components/LearningCenter.parts/**",
+      "frontend/src/components/LearningCenter.tsx",
+      "frontend/src/store/learningCenterSlice.ts",
+      "frontend/src/lib/api/**",
+      "frontend/package.json",
+      "frontend/package-lock.json",
+      "src/scistudio/api/routes/**",
+      "docs/specs/adr-053-learning-center.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-25T05:42:35.201115Z",
+      "owner_directive": "Render the docs with react-markdown + remark-gfm (new frontend dependencies), so tables, fenced code blocks and links match the web version. Keep the reading tutorial machinery: reading tutorials move into their source tabs alongside every other tutorial and are no longer lifted into the Reading tab; the Reading tab becomes purely a place to read documentation. Put the viewer inside the Learning Center panel's Reading tab.",
+      "reason": "owner settled the three design questions before implementation"
+    },
+    {
+      "at": "2026-08-25T06:01:45.468858Z",
+      "owner_directive": "Reading tab becomes a viewer for the shipped user documentation; entry page is the user guide; the left menu matches the published site; the API reference is included and the package-development guide is not.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-25T06:01:45.468905Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-053-learning-center.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468910Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468916Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no architectural decision changes; ADR-053's Learning Center decision stands and the spec carries the revised requirement (FR-084a superseded by FR-084b)",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-25T06:02:48.990502Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.005566Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.020174Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.034836Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.049802Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.095657Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.114719Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.132010Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.147722Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.169804Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:02:49.185701Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.846358Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.863190Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.881516Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.896094Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.910421Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.929153Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.946011Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.960958Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.975908Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:15.991130Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:03:16.006386Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2157,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "01d391434",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "01d391434",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Redesign the Learning Center's Reading page as a viewer for the shipped user documentation: everything on the docs site except the package-development guide, including the API reference. Entry page is the SciStudio user guide; clicking navigates; the left nav matches the web version. The reading tutorial from PR #2087 is scrapped. Open the PR directly; do not start the frontend/backend for live testing.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T06:02:49.185745Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.format_check",
+        "checks.lint_format"
+      ]
+    },
+    {
+      "at": "2026-08-25T06:03:16.006442Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2157-guided-reading-doc-viewer",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468876Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468883Z",
+      "pattern": "docs/specs/adr-053-learning-center.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468885Z",
+      "pattern": "frontend/package.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468886Z",
+      "pattern": "frontend/package-lock.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468888Z",
+      "pattern": "frontend/src/components/LearningCenter.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468889Z",
+      "pattern": "frontend/src/components/LearningCenter.parts/**",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468891Z",
+      "pattern": "frontend/src/components/__tests__/LearningCenter.test.tsx",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468892Z",
+      "pattern": "frontend/src/lib/api/userDocs.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468894Z",
+      "pattern": "frontend/src/store/learningCenterSlice.ts",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468895Z",
+      "pattern": "src/scistudio/api/app.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468896Z",
+      "pattern": "src/scistudio/api/routes/user_docs.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:01:45.468898Z",
+      "pattern": "tests/api/test_user_docs.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "e2a09caa-50d9-4359-a546-32391cfbed79",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-25T06:01:45.468920Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_user_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468924Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468926Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/LearningCenter.parts/__tests__/DocMarkdown.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468927Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:01:45.468928Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/LearningCenter.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2157-guided-reading-doc-viewer.json
+++ b/.workflow/records/2157-guided-reading-doc-viewer.json
@@ -207,6 +207,38 @@
       "tool_versions": {
         "mypy": "2.1.0"
       }
+    },
+    {
+      "at": "2026-08-25T06:08:15.594000Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:fd4831fa609d2120a767b50bbea7cc61e47e9c9fd0c7339bd10465b9b0fd6ff4",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:11:32.538180Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api tests/api/routes tests/api/test_user_docs.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9727855eca64c772cdaef130fa8643d694af8f787c5f78714b9c77fcca21fe1a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -483,6 +515,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.594780Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.608850Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.623311Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.637444Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.652272Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.666600Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.683250Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.699167Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.714408Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.730326Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:11:32.755517Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -517,9 +637,9 @@
       "src/scistudio/api/routes/user_docs.py",
       "tests/api/test_user_docs.py"
     ],
-    "diff_fingerprint": "sha256:c37c1384e3b0971ac5f18b2d6886839fd9d3c09f1e1800b0f2b09c310706a57b",
+    "diff_fingerprint": "sha256:6c72bc944f5c87b035ecad35e28b52dbad634bd2818ba3818b0162707f8f8698",
     "head": "HEAD",
-    "head_sha": "0c200bffb",
+    "head_sha": "60d2afebb",
     "surfaces": {
       "docs": 1,
       "frontend": 12,
@@ -566,6 +686,16 @@
       "unsatisfied": [
         "checks.frontend",
         "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T06:11:32.755547Z",
+      "diff_fingerprint": "sha256:6c72bc944f5c87b035ecad35e28b52dbad634bd2818ba3818b0162707f8f8698",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
       ]
     }
   ],

--- a/.workflow/records/2157-guided-reading-doc-viewer.json
+++ b/.workflow/records/2157-guided-reading-doc-viewer.json
@@ -89,6 +89,124 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-25T06:04:00.574511Z",
+      "command": "ruff format src/scistudio/api/app.py src/scistudio/api/routes/user_docs.py tests/api/test_user_docs.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:701359c935599755bd90f94b705950250c7b1dab2685367379a095297a546fe0",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:04:25.817521Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c2445616c75aa0b50bad9ae5fc8fbf18a86b5ba696a938abd5eb61ce304578a",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:04:36.104522Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b61dc6cd68be0c991b8f0c8b897cb64e4cca12c1f367740a73c15b67acfe99ad",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:04:36.583660Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ee84b8ba982a961bdbfb9038400acae6753872029e8dcc270c9df8e9c1c1046c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:04:36.607206Z",
+      "command": "ruff check src/scistudio/api/app.py src/scistudio/api/routes/user_docs.py tests/api/test_user_docs.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b84716506c96bef09e00627c6941104e0dbd9e674ce85811b9198aa8ac1cb2a6",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:05:33.746832Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api tests/api/routes tests/api/test_user_docs.py",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:9727855eca64c772cdaef130fa8643d694af8f787c5f78714b9c77fcca21fe1a",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:05:42.405425Z",
+      "command": "mypy src/scistudio/api/app.py src/scistudio/api/routes/user_docs.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6e1ca38e1ed1c7e36aa752744c841786ba878c9a339064f8c451673aebfeacb5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
     }
   ],
   "check_na": [],
@@ -277,6 +395,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.460497Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.474263Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.487865Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.501828Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.516237Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.529989Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.544502Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.557837Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.572313Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.587507Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:05:42.615399Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -291,21 +497,40 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "01d391434",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2157-guided-reading-doc-viewer.json",
+      "CHANGELOG.md",
+      "docs/specs/adr-053-learning-center.md",
+      "frontend/package-lock.json",
+      "frontend/package.json",
+      "frontend/src/components/LearningCenter.parts/DocMarkdown.tsx",
+      "frontend/src/components/LearningCenter.parts/DocsBrowser.tsx",
+      "frontend/src/components/LearningCenter.parts/__tests__/DocMarkdown.test.tsx",
+      "frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx",
+      "frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts",
+      "frontend/src/components/LearningCenter.parts/docsNav.ts",
+      "frontend/src/components/LearningCenter.tsx",
+      "frontend/src/components/__tests__/LearningCenter.test.tsx",
+      "frontend/src/lib/api/userDocs.ts",
+      "frontend/src/store/learningCenterSlice.ts",
+      "src/scistudio/api/app.py",
+      "src/scistudio/api/routes/user_docs.py",
+      "tests/api/test_user_docs.py"
+    ],
+    "diff_fingerprint": "sha256:c37c1384e3b0971ac5f18b2d6886839fd9d3c09f1e1800b0f2b09c310706a57b",
     "head": "HEAD",
-    "head_sha": "01d391434",
+    "head_sha": "0c200bffb",
     "surfaces": {
-      "docs": 0,
-      "frontend": 0,
+      "docs": 1,
+      "frontend": 12,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 14,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "sentrux": 16,
+      "test": 5,
       "workflow_ci": 0
     }
   },
@@ -331,6 +556,17 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:05:42.615445Z",
+      "diff_fingerprint": "sha256:c37c1384e3b0971ac5f18b2d6886839fd9d3c09f1e1800b0f2b09c310706a57b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "2157-guided-reading-doc-viewer",
@@ -339,10 +575,16 @@
     "admin_labels": [],
     "checks": [
       "format_check",
+      "frontend",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -356,7 +598,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,

--- a/.workflow/records/2157-guided-reading-doc-viewer.json
+++ b/.workflow/records/2157-guided-reading-doc-viewer.json
@@ -239,10 +239,32 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:15:15.631045Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d228db97c434eb3c049d060e5a3b2563c1af3648db08a7885718e82e9a193257",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "4ea7f69020119320994fd784d63c6c3de50c7996",
+    "shas": [
+      "4ea7f69020119320994fd784d63c6c3de50c7996"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -603,6 +625,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.690055Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.704724Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.719631Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.734787Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.750299Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.766400Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.782924Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.797948Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.813348Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.857417Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:15.883945Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.341166Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.357957Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.376306Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.392215Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.407709Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.423102Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.437394Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.468623Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.483437Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.498748Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:26.528508Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -637,9 +835,9 @@
       "src/scistudio/api/routes/user_docs.py",
       "tests/api/test_user_docs.py"
     ],
-    "diff_fingerprint": "sha256:6c72bc944f5c87b035ecad35e28b52dbad634bd2818ba3818b0162707f8f8698",
+    "diff_fingerprint": "sha256:723c54c8d4608df99fe964f2eaf5fbd0d34e31dceb6f93b15dde864bddf9fd8a",
     "head": "HEAD",
-    "head_sha": "60d2afebb",
+    "head_sha": "4ea7f6902",
     "surfaces": {
       "docs": 1,
       "frontend": 12,
@@ -656,7 +854,14 @@
   },
   "owner_directive": "Redesign the Learning Center's Reading page as a viewer for the shipped user documentation: everything on the docs site except the package-development guide, including the API reference. Entry page is the SciStudio user guide; clicking navigates; the left nav matches the web version. The reading tutorial from PR #2087 is scrapped. Open the PR directly; do not start the frontend/backend for live testing.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2157
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-25T06:02:49.185745Z",
@@ -697,6 +902,22 @@
       "unsatisfied": [
         "checks.frontend"
       ]
+    },
+    {
+      "at": "2026-08-25T06:15:15.883980Z",
+      "diff_fingerprint": "sha256:723c54c8d4608df99fe964f2eaf5fbd0d34e31dceb6f93b15dde864bddf9fd8a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:15:26.528546Z",
+      "diff_fingerprint": "sha256:723c54c8d4608df99fe964f2eaf5fbd0d34e31dceb6f93b15dde864bddf9fd8a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "2157-guided-reading-doc-viewer",

--- a/.workflow/records/2157-guided-reading-doc-viewer.json
+++ b/.workflow/records/2157-guided-reading-doc-viewer.json
@@ -259,9 +259,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "4ea7f69020119320994fd784d63c6c3de50c7996",
+    "sha": "c6c228cf539dac0e2cd38c43291f4ba375785ca4",
     "shas": [
-      "4ea7f69020119320994fd784d63c6c3de50c7996"
+      "c6c228cf539dac0e2cd38c43291f4ba375785ca4"
     ],
     "trailers": []
   },
@@ -801,6 +801,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:39.946417Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:39.960461Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:39.974527Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:39.989661Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.005006Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.020089Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.034150Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.048666Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.063181Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.109205Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:40.136814Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.863660Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.880105Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.895717Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.911757Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.926625Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.942002Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.957714Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.973757Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:48.989432Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:49.004590Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:15:49.034776Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -813,7 +989,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "01d391434350cfae1ca964d0f346e78122bd7710",
     "base_sha": "01d391434",
     "changed_files": [
       ".workflow/records/2157-guided-reading-doc-viewer.json",
@@ -835,9 +1011,9 @@
       "src/scistudio/api/routes/user_docs.py",
       "tests/api/test_user_docs.py"
     ],
-    "diff_fingerprint": "sha256:723c54c8d4608df99fe964f2eaf5fbd0d34e31dceb6f93b15dde864bddf9fd8a",
+    "diff_fingerprint": "sha256:b724c3682aa9fe51de42e974781dfd8dd8d251cad1a22d1e113f0c709431bdf3",
     "head": "HEAD",
-    "head_sha": "4ea7f6902",
+    "head_sha": "c6c228cf5",
     "surfaces": {
       "docs": 1,
       "frontend": 12,
@@ -859,7 +1035,7 @@
     "closes": [
       2157
     ],
-    "number": null,
+    "number": 2158,
     "url": null
   },
   "reconcile_events": [
@@ -914,6 +1090,22 @@
     {
       "at": "2026-08-25T06:15:26.528546Z",
       "diff_fingerprint": "sha256:723c54c8d4608df99fe964f2eaf5fbd0d34e31dceb6f93b15dde864bddf9fd8a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:15:40.136848Z",
+      "diff_fingerprint": "sha256:b724c3682aa9fe51de42e974781dfd8dd8d251cad1a22d1e113f0c709431bdf3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:15:49.034811Z",
+      "diff_fingerprint": "sha256:b724c3682aa9fe51de42e974781dfd8dd8d251cad1a22d1e113f0c709431bdf3",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2157] **The Learning Center's Reading tab is now a reader for the shipped
+  user documentation.** SciStudio already writes a complete user guide and
+  generates a self-contained API reference from its own code; both ship in the
+  wheel, both are copied into every project, and both are what the published
+  documentation site serves. The product gave a reader no way to open any of it
+  without leaving for a browser. The Reading tab — which held reading tutorials,
+  of which none existed, so it held nothing — now opens on the user guide's
+  front page with the documentation's menu beside it, and a link inside a page
+  goes to the page it names rather than out of the product. The menu is not a
+  second, hand-kept listing: the backend derives it from the packaged tree by
+  the same rules that generate the site's navigation, so the two cannot drift.
+  The package development guide is not included; it is a developer document
+  that lives in the repository rather than in the shipped tree. Reading
+  tutorials are unaffected in how they run — they are simply listed in their own
+  source's tab now, alongside every other tutorial.
+
 - [#2082] **Core tutorial 3 — *Two modalities, one answer*.** The multimodal
   level, and the git level. A scanner and a sequencer looked at the same three
   tissue sections and neither file can answer alone — the only thing joining

--- a/docs/specs/adr-053-learning-center.md
+++ b/docs/specs/adr-053-learning-center.md
@@ -1366,22 +1366,50 @@ tutorial's detail, and that source's progress occupy separate regions, so
 selecting a tutorial and starting it are distinct gestures. Selecting MUST NOT
 start a tutorial, because starting one can create or delete a project on disk.
 
-**FR-084a.** Tutorials that only ever ask the reader to read on MUST be listed
-in a Reading tab of their own rather than in their source's tab, and that tab
-MUST be present regardless of whether any such tutorial is installed. Which tutorials
-those are MUST be derived from their declared steps, not from a manifest field:
-the manifest already declares what each step waits on, and a second
-classification could contradict it. A tutorial is a reading one when every step
-either waits on an explicit continue or waits on a term that judges only the
-reader's own progress through the material. The Reading tab MUST NOT carry a
-count of its own, because its tutorials may come from several sources at once
-and FR-076 forbids reporting a count across them.
+**FR-084a (revised by FR-084b).** Tutorials that only ever ask the reader to
+read on were originally listed in a Reading tab of their own rather than in
+their source's tab. FR-084b gave that tab to the shipped documentation, so a
+reading tutorial is now listed in its source's tab alongside every other
+tutorial. What survives of this requirement is the classification and the
+surface: which tutorials are reading ones MUST be derived from their declared
+steps, not from a manifest field, because the manifest already declares what
+each step waits on and a second classification could contradict it. A tutorial
+is a reading one when every step either waits on an explicit continue or waits
+on a term that judges only the reader's own progress through the material.
 
 The reading surface itself is core-owned, like every step surface (FR-041): a
 reading step is rendered as a card presenting its declared `pages` in order,
 with each page's content served by the existing pages route — the same route
 whose serving records `page_reached` — so what a manifest contributes is names
 and prose, never markup or a rendering primitive of its own.
+
+**FR-084b (#2157).** The Reading tab MUST present the shipped user
+documentation — the packaged `scistudio/_user_guide/` tree, which is the guide
+pages together with the generated API reference — and MUST NOT list tutorials.
+SciStudio publishes that tree as its documentation site and provisions it into
+every project; a reader had no way to open it without leaving the product.
+
+The tab MUST open on the user guide's front page, MUST present the
+documentation's navigation beside it, and MUST follow a link inside a page to
+the page it names rather than out of the product.
+
+The navigation MUST be derived from the packaged tree by the rules that
+generate the published site's navigation, rather than declared separately.
+Ordering, titles, and which directories become sections all follow from those
+rules, so the menu in the product and the menu on the site cannot drift as the
+documentation changes — including where the rules produce an unflattering
+result. A second, hand-maintained listing would be a second source of truth for
+something that already has one.
+
+The documentation MUST be served from the packaged tree rather than from a
+project's provisioned copy, so that it opens with no project on screen and
+cannot disagree with the code it was generated from.
+
+The package development guide is out of scope: it is a developer document that
+lives in the repository, not in the shipped tree.
+
+The Reading tab MUST NOT carry a count of its own: it lists no tutorials, so
+there is no source whose count it could report (FR-076).
 
 **FR-085.** Each entry MUST show its title, summary, cover if declared, and
 state: not started, in progress, complete, or unavailable with the reason. An
@@ -1710,6 +1738,7 @@ an evaluation (FR-053).
 | `src/scistudio/tutorials/progress.py` | Progress storage, grouping, unlock (FR-074..FR-081) |
 | `src/scistudio/tutorials/schema/tutorial.schema.json` | Published manifest schema (FR-013) |
 | `src/scistudio/core/entry_points.py` | Shared enumeration, error containment, diagnostics, and import-root preparation for every `scistudio.*` group (FR-025..FR-030) |
+| `src/scistudio/api/routes/user_docs.py` | `/api/user-docs`: the packaged documentation's navigation and its pages (FR-084b) |
 
 The shared helper lives under `core/`. Three things decide the location. It is
 imported by the block, type, and previewer registries, so it has to sit where all
@@ -1776,8 +1805,12 @@ a file the change happens to touch.
 | `src/components/LearningCenter.parts/TutorialProblemBanner.tsx` | A stopped session, said unconditionally (FR-044) |
 | `src/components/LearningCenter.parts/mio.ts` | The character's sprites, avatars, authored expressions, and measured insets (FR-011f, FR-089d) |
 | `src/components/LearningCenter.parts/StepProgressRing.tsx` | The step's position, drawn rather than counted |
+| `src/components/LearningCenter.parts/DocsBrowser.tsx` | The Reading tab: the shipped documentation, its menu, and the page (FR-084b) |
+| `src/components/LearningCenter.parts/DocMarkdown.tsx` | Rendering the guide's markdown, and dispatching the links inside it (FR-084b) |
+| `src/components/LearningCenter.parts/docsNav.ts` | Resolving a link against the open page, and the heading slug (FR-084b) |
 | `src/store/learningCenterSlice.ts` | Session view state and the tab split; no judging, no content |
 | `src/lib/api/learningCenter.ts` | API client |
+| `src/lib/api/userDocs.ts` | Client for `/api/user-docs` (FR-084b) |
 
 **Modified — frontend**
 
@@ -1848,7 +1881,11 @@ vocabulary term and every action type is part of this spec's test material.
 | Library | `tests/tutorials/test_scoped_library.py` | A tutorial project sees the scoped library; a real project does not (FR-071); clearing removes it (FR-073) |
 | Progress | `tests/tutorials/test_progress.py` | Grouped counts; a growing total is not compensated (FR-077); package uninstall removes its group (FR-078); only the core group drives the unlock (FR-080) |
 | Routes | `tests/api/test_tutorial_routes.py` | Catalogue, start, resume, evaluate, user-interface event, leave, clear; the removed route returns 404 (FR-003) |
-| Frontend | `frontend/src/components/__tests__/LearningCenter.test.tsx` | Per-source tabs and their own counts; the Reading tab and its lack of one (FR-084a); entry states; selecting does not start; the dot appears and clears per FR-086; the clear confirmation names directories (FR-088) |
+| Frontend | `frontend/src/components/__tests__/LearningCenter.test.tsx` | Per-source tabs and their own counts; the Reading tab opening the documentation rather than a tutorial list (FR-084b); entry states; selecting does not start; the dot appears and clears per FR-086; the clear confirmation names directories (FR-088) |
+| Frontend | `frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx` | The documentation reader: opening on the front page, the menu's order and its sections, following a link, a linked source file, the way back, and both failure reports (FR-084b) |
+| Frontend | `frontend/src/components/LearningCenter.parts/__tests__/DocMarkdown.test.tsx` | Tables, fenced blocks, ordered lists, heading anchors, no raw HTML, and every link disposition (FR-084b) |
+| Frontend | `frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts` | Link resolution against the open page's directory, refusals, and the heading slug the guide's anchors were written against (FR-084b) |
+| Backend | `tests/api/test_user_docs.py` | `/api/user-docs` — the navigation matching the published sidebar row for row, page and source delivery, directory indexing, and containment (FR-084b) |
 
 Manual verification before the PR: a full pass of a fixture tutorial exercising
 every action type and every vocabulary term, a backend restart mid-tutorial, a

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,8 +27,10 @@
         "plotly.js": "^2.35.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
+        "react-markdown": "^10.1.0",
         "react-plotly.js": "^2.6.0",
         "react-resizable-panels": "^4.9.0",
+        "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss-animate": "^1.0.7",
         "zustand": "^5.0.0"
@@ -1748,9 +1750,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1768,9 +1767,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1788,9 +1784,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,9 +1801,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1828,9 +1818,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1848,9 +1835,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2185,6 +2169,15 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2220,6 +2213,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -2233,6 +2235,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/json-schema": {
@@ -2257,6 +2268,21 @@
         "@types/mapbox__point-geometry": "*",
         "@types/pbf": "*"
       }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.9.5",
@@ -2284,14 +2310,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2335,6 +2359,12 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.4",
@@ -2630,6 +2660,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
@@ -3465,6 +3501,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3693,6 +3739,16 @@
         "element-size": "^1.1.1"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -3747,6 +3803,46 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -3922,6 +4018,16 @@
       "dependencies": {
         "hsluv": "^0.0.3",
         "mumath": "^3.3.4"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -4152,7 +4258,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d": {
@@ -4457,7 +4562,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -4477,6 +4581,19 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4534,7 +4651,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4561,6 +4677,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -5328,6 +5457,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -5384,6 +5523,12 @@
       "dependencies": {
         "type": "^2.7.2"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/falafel": {
       "version": "2.2.5",
@@ -6216,6 +6361,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hsluv": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
@@ -6233,6 +6418,16 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6369,6 +6564,12 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6382,6 +6583,30 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6536,6 +6761,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -6612,6 +6847,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/is-iexplorer": {
@@ -7221,9 +7466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7245,9 +7487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7269,9 +7508,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7293,9 +7529,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7404,6 +7637,16 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "license": "MIT"
+    },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -7591,6 +7834,16 @@
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
       "license": "ISC"
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -7623,6 +7876,288 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7638,6 +8173,569 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -8136,6 +9234,31 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
       "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
+      "license": "MIT"
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
     "node_modules/parse-rect": {
@@ -8705,6 +9828,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
@@ -8788,6 +9921,33 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-plotly.js": {
       "version": "2.6.0",
@@ -9065,6 +10225,72 @@
         "pick-by-alias": "^1.2.0",
         "raf": "^3.4.1",
         "regl-scatter2d": "^3.2.3"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -9540,6 +10766,16 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stack-trace": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
@@ -9743,6 +10979,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -9789,6 +11039,24 @@
       },
       "peerDependencies": {
         "webpack": "^5.27.0"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -10269,6 +11537,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -10470,6 +11758,105 @@
       "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
@@ -10579,6 +11966,34 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.5",
@@ -11207,6 +12622,16 @@
         "use-sync-external-store": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -37,8 +37,10 @@
     "plotly.js": "^2.35.0",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
+    "react-markdown": "^10.1.0",
     "react-plotly.js": "^2.6.0",
     "react-resizable-panels": "^4.9.0",
+    "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss-animate": "^1.0.7",
     "zustand": "^5.0.0"

--- a/frontend/src/components/LearningCenter.parts/DocMarkdown.tsx
+++ b/frontend/src/components/LearningCenter.parts/DocMarkdown.tsx
@@ -1,0 +1,166 @@
+/**
+ * The documentation reader's markdown rendering (#2157).
+ *
+ * The user guide is written for the web: 158 fenced code blocks, 132 rows of
+ * table, and a web of relative links between its pages. `PageMarkdown` — the
+ * deliberately tiny renderer a tutorial's own reading pages use — renders none
+ * of those, and a guide whose tables and code samples came out as raw pipes and
+ * backticks would not be the documentation, it would be a picture of it. So
+ * this surface renders real markdown, through `react-markdown` + `remark-gfm`.
+ *
+ * Raw HTML in a document is *not* rendered: `react-markdown` requires
+ * `rehype-raw` to parse it, and that plugin is deliberately absent. The guide
+ * contains no HTML today, and the reader is not the place to acquire an
+ * injection surface.
+ *
+ * Two things are done here that the plain library does not do:
+ *
+ * - **Headings carry ids.** `using-the-gui.md#previewing-data` is a link the
+ *   guide actually uses, so a heading has to be addressable. The slug matches
+ *   Python-Markdown's `toc` slugify, which is what generated the anchors those
+ *   links were written against.
+ * - **Links are handed to the reader, not to the browser.** An in-guide link
+ *   navigates the reader; an `http(s)` link opens outside; anything else — an
+ *   absolute path, a foreign scheme, a target that leaves the guide — renders
+ *   as its own text rather than as a link that goes nowhere.
+ */
+
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { isValidElement } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+import { headingSlug, resolveDocsLink, type DocsLinkTarget } from "./docsNav";
+
+interface DocMarkdownProps {
+  /** The markdown source. */
+  source: string;
+  /** The tree-relative path of the page, which relative links resolve against. */
+  path: string;
+  /** Follow an in-guide link. */
+  onNavigate: (path: string, anchor: string | null) => void;
+  /** Jump to a heading on this page. */
+  onAnchor: (anchor: string) => void;
+  /** Open a link outside the product. */
+  onExternal: (href: string) => void;
+}
+
+/** The visible text of a rendered node, for slugging a heading. */
+function textOf(node: ReactNode): string {
+  if (node === null || node === undefined || typeof node === "boolean") return "";
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textOf).join("");
+  if (isValidElement(node)) {
+    return textOf((node.props as { children?: ReactNode }).children);
+  }
+  return "";
+}
+
+const HEADING_CLASS: Record<number, string> = {
+  1: "mt-1 font-display text-2xl text-ink",
+  2: "mt-5 font-display text-xl text-ink",
+  3: "mt-4 text-base font-semibold text-ink",
+  4: "mt-3 text-sm font-semibold text-ink",
+  5: "mt-3 text-sm font-semibold text-stone-700",
+  6: "mt-3 text-xs font-semibold uppercase tracking-wide text-stone-500",
+};
+
+function heading(level: number) {
+  const Tag = `h${level}` as "h1";
+  return function Heading({ children }: ComponentPropsWithoutRef<"h1">) {
+    return (
+      <Tag className={HEADING_CLASS[level]} id={headingSlug(textOf(children))}>
+        {children}
+      </Tag>
+    );
+  };
+}
+
+export function DocMarkdown({ source, path, onNavigate, onAnchor, onExternal }: DocMarkdownProps) {
+  const follow = (target: DocsLinkTarget) => {
+    if (target.kind === "page") onNavigate(target.path, target.anchor);
+    else if (target.kind === "anchor") onAnchor(target.anchor);
+    else if (target.kind === "external") onExternal(target.href);
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-3 text-sm leading-6 text-stone-700"
+      data-testid="doc-markdown"
+    >
+      <Markdown
+        components={{
+          h1: heading(1),
+          h2: heading(2),
+          h3: heading(3),
+          h4: heading(4),
+          h5: heading(5),
+          h6: heading(6),
+          p: ({ children }) => <p className="leading-6">{children}</p>,
+          a: ({ href, children }) => {
+            const target = resolveDocsLink(path, href ?? "");
+            if (target.kind === "none") return <>{children}</>;
+            return (
+              <a
+                className="text-pine underline decoration-pine/40 underline-offset-2 transition hover:decoration-pine"
+                data-doc-link={target.kind}
+                href={href}
+                onClick={(event) => {
+                  event.preventDefault();
+                  follow(target);
+                }}
+              >
+                {children}
+              </a>
+            );
+          },
+          ul: ({ children }) => (
+            <ul className="flex list-disc flex-col gap-1.5 pl-5">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="flex list-decimal flex-col gap-1.5 pl-5">{children}</ol>
+          ),
+          li: ({ children }) => <li className="leading-6">{children}</li>,
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-2 border-stone-300 pl-4 text-stone-600">
+              {children}
+            </blockquote>
+          ),
+          hr: () => <hr className="border-stone-200" />,
+          /*
+           * Inline code is a pill; a fenced block is a slab. Both arrive as
+           * `<code>`, and a fenced block is *not* reliably told apart by its
+           * className — four of the guide's fences open bare and so carry
+           * none. The `pre` cancels the pill for whatever it wraps, which no
+           * missing language can defeat.
+           */
+          pre: ({ children }) => (
+            <pre className="overflow-x-auto rounded-xl border border-stone-200 bg-stone-50 p-4 font-mono text-xs leading-5 text-ink [&_code]:bg-transparent [&_code]:p-0 [&_code]:text-[1em]">
+              {children}
+            </pre>
+          ),
+          code: ({ children }) => (
+            <code className="rounded bg-stone-100 px-1 py-0.5 font-mono text-[0.85em] text-ink">
+              {children}
+            </code>
+          ),
+          /* GFM tables. The guide leans on them; they scroll rather than clip. */
+          table: ({ children }) => (
+            <div className="overflow-x-auto">
+              <table className="w-full border-collapse text-left text-xs">{children}</table>
+            </div>
+          ),
+          thead: ({ children }) => <thead className="border-b border-stone-300">{children}</thead>,
+          th: ({ children }) => (
+            <th className="px-2 py-1.5 align-top font-semibold text-ink">{children}</th>
+          ),
+          tr: ({ children }) => <tr className="border-b border-stone-100">{children}</tr>,
+          td: ({ children }) => <td className="px-2 py-1.5 align-top">{children}</td>,
+        }}
+        remarkPlugins={[remarkGfm]}
+      >
+        {source}
+      </Markdown>
+    </div>
+  );
+}

--- a/frontend/src/components/LearningCenter.parts/DocsBrowser.tsx
+++ b/frontend/src/components/LearningCenter.parts/DocsBrowser.tsx
@@ -34,7 +34,7 @@ import {
 } from "../../lib/api/userDocs";
 
 import { DocMarkdown } from "./DocMarkdown";
-import { docsNavPathOf, docsPages } from "./docsNav";
+import { docsNavItems, docsNavPathOf, docsPages } from "./docsNav";
 
 /** Where the reader is: a path, and a heading on it to land on. */
 interface DocsLocation {
@@ -58,7 +58,7 @@ interface DocsNavListProps {
 function DocsNavList({ items, depth, current, onOpen }: DocsNavListProps) {
   return (
     <ul className="flex flex-col gap-0.5">
-      {items.map((item) => {
+      {docsNavItems(items).map((item) => {
         if (item.kind === "section") {
           /*
            * A section has no path of its own, so it is keyed by the first page
@@ -127,7 +127,16 @@ export function DocsBrowser() {
         const tree = await fetchUserDocsNav();
         if (stale) return;
         setNav(tree);
-        setLocation((current) => current ?? { path: tree.root, anchor: null });
+        /*
+         * The entry page is the tree's own answer; a body that arrives without
+         * one falls back to its first page rather than to a pane that loads
+         * forever.
+         */
+        const root =
+          typeof tree.root === "string" && tree.root.length > 0
+            ? tree.root
+            : (docsPages(tree.items)[0]?.path ?? null);
+        if (root !== null) setLocation((current) => current ?? { path: root, anchor: null });
       } catch (error) {
         if (stale) return;
         setNavError(error instanceof Error ? error.message : String(error));
@@ -264,7 +273,7 @@ export function DocsBrowser() {
               <Loader2 aria-hidden="true" className="size-4 animate-spin" />
               Loading…
             </p>
-          ) : page.kind === "markdown" ? (
+          ) : page.kind === "markdown" && typeof page.text === "string" ? (
             <DocMarkdown
               onAnchor={onAnchor}
               onExternal={onExternal}

--- a/frontend/src/components/LearningCenter.parts/DocsBrowser.tsx
+++ b/frontend/src/components/LearningCenter.parts/DocsBrowser.tsx
@@ -1,0 +1,296 @@
+/**
+ * The Learning Center's Reading tab: a reader for the shipped documentation (#2157).
+ *
+ * SciStudio ships its whole user documentation set inside the wheel —
+ * `scistudio/_user_guide/`, the guide pages plus the generated API reference —
+ * and publishes that same tree as the documentation site. Until now the product
+ * gave a reader no way in: the Reading tab held reading *tutorials*, of which
+ * there are none, so it said "Reading tutorials will appear here" and stopped.
+ *
+ * It now holds the documentation, laid out the way the site lays it out: the
+ * menu on the left, the page on the right, opening on the user guide's front
+ * page. The menu is not an editorial re-listing — the backend reproduces
+ * MkDocs' own nav rules, so the order, the titles, and the two sections that
+ * expand are the published sidebar's, down to its quirks.
+ *
+ * Package Development is not here. It is a developer document that lives in the
+ * repository rather than in the shipped tree, and was never part of what a user
+ * gets.
+ *
+ * Reading tutorials did not go away — they are simply listed in their own
+ * source's tab now, alongside every other tutorial, and still run in
+ * `ReadingSurface`.
+ */
+
+import { ArrowLeft, FileCode2, Loader2 } from "lucide-react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+
+import {
+  fetchUserDocPage,
+  fetchUserDocsNav,
+  type DocsNavItem,
+  type DocsNavResponse,
+  type DocsPageResponse,
+} from "../../lib/api/userDocs";
+
+import { DocMarkdown } from "./DocMarkdown";
+import { docsNavPathOf, docsPages } from "./docsNav";
+
+/** Where the reader is: a path, and a heading on it to land on. */
+interface DocsLocation {
+  path: string;
+  anchor: string | null;
+}
+
+interface DocsNavListProps {
+  items: DocsNavItem[];
+  depth: number;
+  current: string | null;
+  onOpen: (path: string) => void;
+}
+
+/**
+ * One level of the menu.
+ *
+ * A section is a heading, not a link — that is what it is on the site, where
+ * MkDocs generates it from a directory name and gives it nothing to open.
+ */
+function DocsNavList({ items, depth, current, onOpen }: DocsNavListProps) {
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {items.map((item) => {
+        if (item.kind === "section") {
+          /*
+           * A section has no path of its own, so it is keyed by the first page
+           * under it — the one thing about a section that is unique in a tree
+           * where two directories may share a title.
+           */
+          const key = `section:${docsPages(item.children)[0]?.path ?? item.title}`;
+          return (
+            <li key={key}>
+              <p
+                className="px-2 pb-0.5 pt-3 text-[0.7rem] font-semibold uppercase tracking-wide text-stone-400"
+                data-testid={`docs-nav-section-${item.title}`}
+                style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+              >
+                {item.title}
+              </p>
+              <DocsNavList
+                current={current}
+                depth={depth + 1}
+                items={item.children}
+                onOpen={onOpen}
+              />
+            </li>
+          );
+        }
+        const path = item.path ?? "";
+        const selected = path === current;
+        return (
+          <li key={`page:${path}`}>
+            <button
+              aria-current={selected ? "page" : undefined}
+              className={`w-full rounded-lg py-1.5 pr-2 text-left text-xs leading-5 transition ${
+                selected
+                  ? "bg-ember/10 font-semibold text-ink"
+                  : "text-stone-600 hover:bg-stone-100 hover:text-ink"
+              }`}
+              data-testid={`docs-nav-page-${path}`}
+              onClick={() => onOpen(path)}
+              style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
+              type="button"
+            >
+              {item.title}
+            </button>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export function DocsBrowser() {
+  const [nav, setNav] = useState<DocsNavResponse | null>(null);
+  const [navError, setNavError] = useState<string | null>(null);
+  const [location, setLocation] = useState<DocsLocation | null>(null);
+  /* Where the reader came from, so an inline link is never a one-way door. */
+  const [trail, setTrail] = useState<DocsLocation[]>([]);
+  const [page, setPage] = useState<DocsPageResponse | null>(null);
+  const [pageError, setPageError] = useState<string | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  /* The tree, and the page it says to start on. */
+  useEffect(() => {
+    let stale = false;
+    void (async () => {
+      try {
+        const tree = await fetchUserDocsNav();
+        if (stale) return;
+        setNav(tree);
+        setLocation((current) => current ?? { path: tree.root, anchor: null });
+      } catch (error) {
+        if (stale) return;
+        setNavError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+    return () => {
+      stale = true;
+    };
+  }, []);
+
+  /* The open page. */
+  const path = location?.path ?? null;
+  useEffect(() => {
+    if (path === null) return;
+    let stale = false;
+    setPage(null);
+    setPageError(null);
+    void (async () => {
+      try {
+        const loaded = await fetchUserDocPage(path);
+        if (!stale) setPage(loaded);
+      } catch (error) {
+        if (!stale) setPageError(error instanceof Error ? error.message : String(error));
+      }
+    })();
+    return () => {
+      stale = true;
+    };
+  }, [path]);
+
+  /*
+   * Land on the heading a link named, or at the top of a fresh page. Layout
+   * effect rather than effect: the pane is already scrolled where the previous
+   * page left it, and correcting that after paint is a visible jump.
+   */
+  const anchor = location?.anchor ?? null;
+  useLayoutEffect(() => {
+    const pane = contentRef.current;
+    if (!pane || page === null) return;
+    if (anchor !== null) {
+      const heading = pane.querySelector(`#${CSS.escape(anchor)}`);
+      if (heading instanceof HTMLElement) {
+        pane.scrollTop = heading.offsetTop - pane.offsetTop;
+        return;
+      }
+    }
+    pane.scrollTop = 0;
+  }, [page, anchor]);
+
+  const go = useCallback((next: DocsLocation) => {
+    setLocation((current) => {
+      if (current && current.path === next.path && current.anchor === next.anchor) return current;
+      if (current) setTrail((previous) => [...previous, current]);
+      return next;
+    });
+  }, []);
+
+  const back = useCallback(() => {
+    setTrail((previous) => {
+      const last = previous[previous.length - 1];
+      if (!last) return previous;
+      setLocation(last);
+      return previous.slice(0, -1);
+    });
+  }, []);
+
+  const onAnchor = useCallback((target: string) => {
+    setLocation((current) => (current ? { path: current.path, anchor: target } : current));
+  }, []);
+
+  const onExternal = useCallback((href: string) => {
+    window.open(href, "_blank", "noopener,noreferrer");
+  }, []);
+
+  if (navError !== null) {
+    return (
+      <p className="px-6 py-6 text-sm text-red-700" data-testid="docs-nav-error">
+        {navError}
+      </p>
+    );
+  }
+
+  if (nav === null) {
+    return (
+      <p className="inline-flex items-center gap-2 px-6 py-6 text-sm text-stone-500">
+        <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+        Loading the documentation…
+      </p>
+    );
+  }
+
+  const navPath = path === null ? null : docsNavPathOf(nav.items, path);
+
+  return (
+    <div className="flex min-h-0 flex-1" data-testid="docs-browser">
+      {/* The left menu, as the site lays it out. */}
+      <nav
+        aria-label="Documentation"
+        className="w-60 shrink-0 overflow-y-auto border-r border-stone-200 py-3 pl-3 pr-2"
+      >
+        <p className="px-2 pb-1 text-[0.7rem] font-semibold uppercase tracking-wide text-stone-400">
+          {nav.title}
+        </p>
+        <DocsNavList
+          current={navPath}
+          depth={0}
+          items={nav.items}
+          onOpen={(next) => go({ path: next, anchor: null })}
+        />
+      </nav>
+
+      <div className="flex min-w-0 flex-1 flex-col">
+        {trail.length > 0 ? (
+          <div className="shrink-0 px-6 pt-3">
+            <button
+              className="inline-flex items-center gap-1.5 text-xs font-medium text-stone-500 transition hover:text-ink"
+              data-testid="docs-back"
+              onClick={back}
+              type="button"
+            >
+              <ArrowLeft aria-hidden="true" className="size-3.5" />
+              Back
+            </button>
+          </div>
+        ) : null}
+
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-4" ref={contentRef}>
+          {pageError !== null ? (
+            <p className="text-sm text-red-700" data-testid="docs-page-error">
+              {pageError}
+            </p>
+          ) : page === null ? (
+            <p className="inline-flex items-center gap-2 text-sm text-stone-500">
+              <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+              Loading…
+            </p>
+          ) : page.kind === "markdown" ? (
+            <DocMarkdown
+              onAnchor={onAnchor}
+              onExternal={onExternal}
+              onNavigate={(next, target) => go({ path: next, anchor: target })}
+              path={page.path}
+              source={page.text}
+            />
+          ) : (
+            /*
+             * A worked example's source file. The guide links to `block.py` and
+             * `accucor.R` the way the site serves them — verbatim, beside the
+             * page that links them — so the reader shows the file, not a
+             * rendering of it.
+             */
+            <div data-testid="docs-source">
+              <p className="mb-2 inline-flex items-center gap-2 font-mono text-xs text-stone-500">
+                <FileCode2 aria-hidden="true" className="size-4" />
+                {page.path}
+              </p>
+              <pre className="overflow-x-auto rounded-xl border border-stone-200 bg-stone-50 p-4 font-mono text-xs leading-5 text-ink">
+                {page.text}
+              </pre>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/LearningCenter.parts/__tests__/DocMarkdown.test.tsx
+++ b/frontend/src/components/LearningCenter.parts/__tests__/DocMarkdown.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * #2157 — the documentation reader renders the guide, not a picture of it.
+ *
+ * The reason this component exists at all is that the shipped guide contains
+ * 158 fenced code blocks and 132 rows of table, and the tutorial reading pane's
+ * tiny renderer produces neither. So the assertions below are about those two
+ * shapes first, then about the link handling that turns a page into a guide:
+ * an in-guide link navigates, an external one leaves, and anything the reader
+ * cannot honestly follow is not offered as a link.
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DocMarkdown } from "../DocMarkdown";
+
+afterEach(cleanup);
+
+function renderDoc(source: string, path = "README.md") {
+  const onNavigate = vi.fn();
+  const onAnchor = vi.fn();
+  const onExternal = vi.fn();
+  const { container } = render(
+    <DocMarkdown
+      onAnchor={onAnchor}
+      onExternal={onExternal}
+      onNavigate={onNavigate}
+      path={path}
+      source={source}
+    />,
+  );
+  return { container, onNavigate, onAnchor, onExternal };
+}
+
+describe("DocMarkdown — what the guide is written in", () => {
+  it("renders a GFM table as a table", () => {
+    renderDoc(
+      ["| Page | What it covers |", "|---|---|", "| `data-types.md` | The types |"].join("\n"),
+    );
+
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "What it covers" })).toBeInTheDocument();
+    expect(screen.getByRole("cell", { name: "The types" })).toBeInTheDocument();
+  });
+
+  it("renders a fenced block as a code slab, language or not", () => {
+    const { container } = render(
+      <DocMarkdown
+        onAnchor={vi.fn()}
+        onExternal={vi.fn()}
+        onNavigate={vi.fn()}
+        path="README.md"
+        source={"```python\nfrom scistudio.blocks.base import InputPort\n```\n\n```\nplain\n```\n"}
+      />,
+    );
+
+    const slabs = container.querySelectorAll("pre");
+    expect(slabs).toHaveLength(2);
+    expect(slabs[0].textContent).toContain("from scistudio.blocks.base import InputPort");
+    expect(slabs[1].textContent).toContain("plain");
+  });
+
+  it("renders an ordered list, which the tutorial renderer cannot", () => {
+    const { container } = renderDoc("1. Make a project\n2. Add a block\n");
+
+    expect(container.querySelector("ol")).not.toBeNull();
+    expect(container.querySelectorAll("ol > li")).toHaveLength(2);
+  });
+
+  it("does not render raw HTML in a document", () => {
+    const { container } = renderDoc("<img src=x onerror=alert(1)>\n");
+
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("gives a heading the anchor its cross-page links name", () => {
+    const { container } = renderDoc("## Previewing data\n");
+
+    expect(container.querySelector("#previewing-data")).not.toBeNull();
+  });
+});
+
+describe("DocMarkdown — following a link", () => {
+  it("navigates an in-guide link instead of leaving the app", () => {
+    const { onNavigate } = renderDoc("See [the assistant](ai-assistant.md).");
+
+    fireEvent.click(screen.getByRole("link", { name: "the assistant" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("ai-assistant.md", null);
+  });
+
+  it("carries a link's anchor through to the reader", () => {
+    const { onNavigate } = renderDoc("See [previewing](using-the-gui.md#previewing-data).");
+
+    fireEvent.click(screen.getByRole("link", { name: "previewing" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("using-the-gui.md", "previewing-data");
+  });
+
+  it("resolves a relative link against the page it is written on", () => {
+    const { onNavigate } = renderDoc("See [the example](app-fiji/).", "examples/README.md");
+
+    fireEvent.click(screen.getByRole("link", { name: "the example" }));
+
+    expect(onNavigate).toHaveBeenCalledWith("examples/app-fiji/", null);
+  });
+
+  it("jumps within the page for a bare fragment", () => {
+    const { onAnchor, onNavigate } = renderDoc("See [below](#the-chat-assistant).");
+
+    fireEvent.click(screen.getByRole("link", { name: "below" }));
+
+    expect(onAnchor).toHaveBeenCalledWith("the-chat-assistant");
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("sends an http link outside", () => {
+    const { onExternal } = renderDoc("See [pydantic](https://docs.pydantic.dev/).");
+
+    fireEvent.click(screen.getByRole("link", { name: "pydantic" }));
+
+    expect(onExternal).toHaveBeenCalledWith("https://docs.pydantic.dev/");
+  });
+
+  it("renders a link it cannot follow as its own text, not as a dead link", () => {
+    renderDoc("Run [this](javascript:alert(1)) now.");
+
+    expect(screen.queryByRole("link")).toBeNull();
+    expect(screen.getByText(/this/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx
+++ b/frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx
@@ -206,6 +206,21 @@ describe("DocsBrowser — reading", () => {
     );
   });
 
+  /*
+   * Found by the frontend CI mirror, not by design: with no catalogue the
+   * Reading tab is the *only* tab, so it is what the Learning Center opens on
+   * — and a tree that arrived without its `items` threw inside a render, which
+   * is not a caught error but a blank application. `App.test.tsx` went down
+   * whole.
+   */
+  it("survives a tree that arrives without its rows", async () => {
+    navMock.mockResolvedValueOnce({ title: "User guide", root: "" } as DocsNavResponse);
+    render(<DocsBrowser />);
+
+    expect(await screen.findByTestId("docs-browser")).toBeInTheDocument();
+    expect(screen.queryByTestId("docs-nav-page-README.md")).toBeNull();
+  });
+
   it("reports a tree that will not load rather than an empty menu", async () => {
     navMock.mockRejectedValueOnce(new Error("documentation unavailable"));
     render(<DocsBrowser />);

--- a/frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx
+++ b/frontend/src/components/LearningCenter.parts/__tests__/DocsBrowser.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * #2157 — the Reading tab's documentation reader.
+ *
+ * The fixture below is the shipped tree's real shape, trimmed: the guide's
+ * front page first, the flat guide pages after it, then the two directories
+ * MkDocs turns into sections. It is deliberately not invented — the ordering
+ * and the titles (including "Index", which the site really does print for the
+ * generated reference's front page) are what `GET /api/user-docs/nav` returns,
+ * and a reader tested against a tidier tree would be tested against a tree it
+ * will never be given.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DocsNavResponse, DocsPageResponse } from "../../../lib/api/userDocs";
+import { fetchUserDocPage, fetchUserDocsNav } from "../../../lib/api/userDocs";
+import { DocsBrowser } from "../DocsBrowser";
+
+vi.mock("../../../lib/api/userDocs", () => ({
+  fetchUserDocsNav: vi.fn(),
+  fetchUserDocPage: vi.fn(),
+}));
+
+const NAV: DocsNavResponse = {
+  title: "User guide",
+  root: "README.md",
+  items: [
+    { kind: "page", title: "SciStudio user guide", path: "README.md", children: [] },
+    { kind: "page", title: "The AI assistant", path: "ai-assistant.md", children: [] },
+    {
+      kind: "section",
+      title: "Api reference",
+      path: null,
+      children: [{ kind: "page", title: "Index", path: "api-reference/index.md", children: [] }],
+    },
+    {
+      kind: "section",
+      title: "Examples",
+      path: null,
+      children: [
+        { kind: "page", title: "Examples", path: "examples/README.md", children: [] },
+        {
+          kind: "section",
+          title: "App fiji",
+          path: null,
+          children: [
+            {
+              kind: "page",
+              title: "AppBlock example — run a Fiji macro",
+              path: "examples/app-fiji/README.md",
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const PAGES: Record<string, DocsPageResponse> = {
+  "README.md": {
+    path: "README.md",
+    title: "SciStudio user guide",
+    kind: "markdown",
+    text: "# SciStudio user guide\n\nWelcome. Ask the [AI assistant](ai-assistant.md).\n",
+  },
+  "ai-assistant.md": {
+    path: "ai-assistant.md",
+    title: "The AI assistant",
+    kind: "markdown",
+    text: "# The AI assistant\n\nWhat it can do for you.\n",
+  },
+  "examples/README.md": {
+    path: "examples/README.md",
+    title: "Examples",
+    kind: "markdown",
+    text: "# Examples\n\nA worked [AppBlock](app-fiji/) example.\n",
+  },
+  "examples/app-fiji/README.md": {
+    path: "examples/app-fiji/README.md",
+    title: "AppBlock example — run a Fiji macro",
+    kind: "markdown",
+    text: "# AppBlock example\n\nThe source is in [block.py](block.py).\n",
+  },
+  "examples/app-fiji/block.py": {
+    path: "examples/app-fiji/block.py",
+    title: "block.py",
+    kind: "source",
+    text: "class FijiBlock(AppBlock):\n    pass\n",
+  },
+};
+
+const navMock = vi.mocked(fetchUserDocsNav);
+const pageMock = vi.mocked(fetchUserDocPage);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  navMock.mockResolvedValue(NAV);
+  pageMock.mockImplementation(async (path: string) => {
+    const page = PAGES[path] ?? PAGES[`${path}README.md`];
+    if (!page) throw new Error(`No such documentation page: '${path}'`);
+    return page;
+  });
+});
+
+afterEach(cleanup);
+
+describe("DocsBrowser — the menu", () => {
+  it("opens on the user guide's front page", async () => {
+    render(<DocsBrowser />);
+
+    expect(await screen.findByText("Welcome.", { exact: false })).toBeInTheDocument();
+    expect(pageMock).toHaveBeenCalledWith("README.md");
+  });
+
+  it("lists the tree in the order the site lists it, sections and all", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+
+    const rows = screen.getAllByRole("listitem").map((node) => node.textContent?.split("\n")[0]);
+    expect(rows[0]).toContain("SciStudio user guide");
+    expect(screen.getByTestId("docs-nav-section-Api reference")).toBeInTheDocument();
+    expect(screen.getByTestId("docs-nav-page-api-reference/index.md")).toHaveTextContent("Index");
+  });
+
+  it("marks the open page, and moves the mark when another is chosen", async () => {
+    render(<DocsBrowser />);
+
+    const front = await screen.findByTestId("docs-nav-page-README.md");
+    expect(front).toHaveAttribute("aria-current", "page");
+
+    fireEvent.click(screen.getByTestId("docs-nav-page-ai-assistant.md"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("docs-nav-page-ai-assistant.md")).toHaveAttribute(
+        "aria-current",
+        "page",
+      ),
+    );
+    expect(screen.getByTestId("docs-nav-page-README.md")).not.toHaveAttribute("aria-current");
+  });
+
+  it("gives a section no button of its own, because the site gives it no link", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+
+    expect(screen.getByTestId("docs-nav-section-Examples").tagName).toBe("P");
+  });
+});
+
+describe("DocsBrowser — reading", () => {
+  it("follows a link inside a page", async () => {
+    render(<DocsBrowser />);
+
+    fireEvent.click(await screen.findByRole("link", { name: "AI assistant" }));
+
+    expect(await screen.findByText("What it can do for you.")).toBeInTheDocument();
+  });
+
+  it("resolves a directory link to that directory's index page", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+
+    fireEvent.click(screen.getByTestId("docs-nav-page-examples/README.md"));
+    fireEvent.click(await screen.findByRole("link", { name: "AppBlock" }));
+
+    expect(await screen.findByText("The source is in", { exact: false })).toBeInTheDocument();
+    // A directory path highlights that directory's index row, as the site does.
+    expect(pageMock).toHaveBeenCalledWith("examples/app-fiji/");
+  });
+
+  it("shows a linked source file verbatim, the way the site serves it", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+
+    fireEvent.click(screen.getByTestId("docs-nav-page-examples/app-fiji/README.md"));
+    fireEvent.click(await screen.findByRole("link", { name: "block.py" }));
+
+    const source = await screen.findByTestId("docs-source");
+    expect(source).toHaveTextContent("class FijiBlock(AppBlock)");
+  });
+
+  it("offers a way back once a link has been followed", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+
+    expect(screen.queryByTestId("docs-back")).toBeNull();
+
+    fireEvent.click(await screen.findByRole("link", { name: "AI assistant" }));
+    await screen.findByText("What it can do for you.");
+    fireEvent.click(screen.getByTestId("docs-back"));
+
+    expect(await screen.findByText("Welcome.", { exact: false })).toBeInTheDocument();
+  });
+
+  it("reports a page that will not load rather than showing an empty pane", async () => {
+    render(<DocsBrowser />);
+    await screen.findByTestId("docs-browser");
+    pageMock.mockRejectedValueOnce(new Error("No such documentation page: 'ai-assistant.md'"));
+
+    fireEvent.click(screen.getByTestId("docs-nav-page-ai-assistant.md"));
+
+    expect(await screen.findByTestId("docs-page-error")).toHaveTextContent(
+      "No such documentation page",
+    );
+  });
+
+  it("reports a tree that will not load rather than an empty menu", async () => {
+    navMock.mockRejectedValueOnce(new Error("documentation unavailable"));
+    render(<DocsBrowser />);
+
+    expect(await screen.findByTestId("docs-nav-error")).toHaveTextContent(
+      "documentation unavailable",
+    );
+  });
+});

--- a/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
+++ b/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
@@ -1,0 +1,157 @@
+/**
+ * #2157 — the documentation reader's navigation arithmetic.
+ *
+ * Link resolution is the part of the reader that is easy to get subtly wrong
+ * and impossible to notice: a relative link resolved against the guide's root
+ * instead of the open page's directory lands on the right-looking page for the
+ * eleven links written at the top level and on nothing for the ones written
+ * inside `examples/`. So the cases below are the shapes the shipped guide
+ * actually contains, plus the ones that must not resolve at all.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { DocsNavItem } from "../../../lib/api/userDocs";
+import { docsNavPathOf, docsPages, docsTitleOf, headingSlug, resolveDocsLink } from "../docsNav";
+
+function page(title: string, path: string): DocsNavItem {
+  return { kind: "page", title, path, children: [] };
+}
+
+function section(title: string, children: DocsNavItem[]): DocsNavItem {
+  return { kind: "section", title, path: null, children };
+}
+
+/** The shape the backend returns, trimmed to the rows these tests need. */
+const TREE: DocsNavItem[] = [
+  page("SciStudio user guide", "README.md"),
+  page("The AI assistant", "ai-assistant.md"),
+  page("Using the canvas: build, run, preview", "using-the-gui.md"),
+  section("Api reference", [page("Index", "api-reference/index.md")]),
+  section("Examples", [
+    page("Examples", "examples/README.md"),
+    section("App fiji", [page("AppBlock example — run a Fiji macro", "examples/app-fiji/README.md")]),
+  ]),
+];
+
+describe("docsPages", () => {
+  it("flattens every page row and keeps display order", () => {
+    expect(docsPages(TREE).map((row) => row.path)).toEqual([
+      "README.md",
+      "ai-assistant.md",
+      "using-the-gui.md",
+      "api-reference/index.md",
+      "examples/README.md",
+      "examples/app-fiji/README.md",
+    ]);
+  });
+
+  it("does not treat a section as a page", () => {
+    expect(docsPages(TREE).some((row) => row.title === "Api reference")).toBe(false);
+  });
+});
+
+describe("docsTitleOf", () => {
+  it("finds a page nested inside a section", () => {
+    expect(docsTitleOf(TREE, "api-reference/index.md")).toBe("Index");
+  });
+
+  it("returns null for a path the tree does not list", () => {
+    expect(docsTitleOf(TREE, "examples/app-fiji/block.py")).toBeNull();
+  });
+});
+
+describe("resolveDocsLink", () => {
+  it("resolves a sibling link from a top-level page", () => {
+    expect(resolveDocsLink("getting-started.md", "ai-assistant.md")).toEqual({
+      kind: "page",
+      path: "ai-assistant.md",
+      anchor: null,
+    });
+  });
+
+  it("resolves against the open page's directory, not the guide's root", () => {
+    // `examples/README.md` links to its example directories by bare name.
+    expect(resolveDocsLink("examples/README.md", "app-fiji/")).toEqual({
+      kind: "page",
+      path: "examples/app-fiji/",
+      anchor: null,
+    });
+  });
+
+  it("keeps a directory link a directory, for the backend to index", () => {
+    expect(resolveDocsLink("README.md", "examples/")).toEqual({
+      kind: "page",
+      path: "examples/",
+      anchor: null,
+    });
+  });
+
+  it("carries the anchor of a cross-page link", () => {
+    expect(resolveDocsLink("writing-plots.md", "using-the-gui.md#previewing-data")).toEqual({
+      kind: "page",
+      path: "using-the-gui.md",
+      anchor: "previewing-data",
+    });
+  });
+
+  it("treats a bare fragment as a jump within the open page", () => {
+    expect(resolveDocsLink("ai-assistant.md", "#kimi-code-works-in-chat")).toEqual({
+      kind: "anchor",
+      anchor: "kimi-code-works-in-chat",
+    });
+  });
+
+  it("climbs out of a subdirectory", () => {
+    expect(resolveDocsLink("examples/app-fiji/README.md", "../../writing-blocks.md")).toEqual({
+      kind: "page",
+      path: "writing-blocks.md",
+      anchor: null,
+    });
+  });
+
+  it("offers an http link to the world outside", () => {
+    expect(resolveDocsLink("data-types.md", "https://docs.pydantic.dev/")).toEqual({
+      kind: "external",
+      href: "https://docs.pydantic.dev/",
+    });
+  });
+
+  it.each([
+    ["a link that climbs out of the guide", "../../../../pyproject.toml"],
+    ["an absolute path", "/etc/passwd"],
+    ["a script url", "javascript:alert(1)"],
+    ["a data url", "data:text/html,<script>alert(1)</script>"],
+    ["an empty href", "   "],
+  ])("refuses %s", (_what, href) => {
+    expect(resolveDocsLink("README.md", href)).toEqual({ kind: "none" });
+  });
+});
+
+describe("docsNavPathOf", () => {
+  it("marks the page itself when the tree lists it", () => {
+    expect(docsNavPathOf(TREE, "ai-assistant.md")).toBe("ai-assistant.md");
+  });
+
+  it("marks a directory's index row when the reader followed a directory link", () => {
+    expect(docsNavPathOf(TREE, "examples/")).toBe("examples/README.md");
+  });
+
+  it("marks nothing for a file the menu does not list", () => {
+    // `block.py` is reachable by link and absent from the menu, exactly as on
+    // the published site.
+    expect(docsNavPathOf(TREE, "examples/app-fiji/block.py")).toBeNull();
+  });
+});
+
+describe("headingSlug", () => {
+  it("matches the anchor the guide's own cross-page links were written against", () => {
+    expect(headingSlug("Previewing data")).toBe("previewing-data");
+  });
+
+  it("drops punctuation the way Python-Markdown's toc does", () => {
+    expect(headingSlug("Before you start: install a provider")).toBe(
+      "before-you-start-install-a-provider",
+    );
+  });
+});

--- a/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
+++ b/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
@@ -12,7 +12,14 @@
 import { describe, expect, it } from "vitest";
 
 import type { DocsNavItem } from "../../../lib/api/userDocs";
-import { docsNavPathOf, docsPages, docsTitleOf, headingSlug, resolveDocsLink } from "../docsNav";
+import {
+  docsNavItems,
+  docsNavPathOf,
+  docsPages,
+  docsTitleOf,
+  headingSlug,
+  resolveDocsLink,
+} from "../docsNav";
 
 function page(title: string, path: string): DocsNavItem {
   return { kind: "page", title, path, children: [] };
@@ -50,6 +57,19 @@ describe("docsPages", () => {
 
   it("does not treat a section as a page", () => {
     expect(docsPages(TREE).some((row) => row.title === "Api reference")).toBe(false);
+  });
+
+  it("treats a row without children as a leaf rather than throwing", () => {
+    const malformed = [{ kind: "section", title: "Api reference", path: null }] as DocsNavItem[];
+    expect(docsPages(malformed)).toEqual([]);
+  });
+});
+
+describe("docsNavItems", () => {
+  it("treats a body without its rows as empty, not as a crash", () => {
+    expect(docsNavItems(undefined)).toEqual([]);
+    expect(docsNavItems(null)).toEqual([]);
+    expect(docsNavItems({} as unknown as DocsNavItem[])).toEqual([]);
   });
 });
 

--- a/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
+++ b/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
@@ -30,7 +30,9 @@ const TREE: DocsNavItem[] = [
   section("Api reference", [page("Index", "api-reference/index.md")]),
   section("Examples", [
     page("Examples", "examples/README.md"),
-    section("App fiji", [page("AppBlock example — run a Fiji macro", "examples/app-fiji/README.md")]),
+    section("App fiji", [
+      page("AppBlock example — run a Fiji macro", "examples/app-fiji/README.md"),
+    ]),
   ]),
 ];
 

--- a/frontend/src/components/LearningCenter.parts/docsNav.ts
+++ b/frontend/src/components/LearningCenter.parts/docsNav.ts
@@ -1,0 +1,126 @@
+/**
+ * The documentation reader's navigation arithmetic (#2157).
+ *
+ * Two questions, both pure, both testable without a DOM: which nav row is the
+ * open page, and where does a link inside a page go.
+ *
+ * The second is the one that makes the reader a reader rather than a viewer of
+ * one file. The guide is written as a web of relative links — `ai-assistant.md`
+ * appears eleven times, `examples/` twice, `using-the-gui.md#previewing-data`
+ * once — and on the published site every one of them is a click. Here they
+ * resolve against the open page's own directory, exactly as a browser resolves
+ * them, and come back as a target the reader can open.
+ */
+
+import type { DocsNavItem } from "../../lib/api/userDocs";
+
+/** Where a link in a page goes. */
+export type DocsLinkTarget =
+  | { kind: "page"; path: string; anchor: string | null }
+  | { kind: "anchor"; anchor: string }
+  | { kind: "external"; href: string }
+  /** A link this reader cannot follow — rendered as text rather than as a lie. */
+  | { kind: "none" };
+
+/**
+ * Python-Markdown's `toc` slug: strip everything that is not a word character,
+ * whitespace or a dash; lowercase; collapse runs of whitespace and dashes.
+ *
+ * The guide's cross-page anchors — `using-the-gui.md#previewing-data` — were
+ * written against the published site, so matching that slug is what makes them
+ * land on the heading they name.
+ */
+export function headingSlug(text: string): string {
+  return text
+    .normalize("NFKD")
+    .replace(/[^\w\s-]/g, "")
+    .trim()
+    .toLowerCase()
+    .replace(/[-\s]+/g, "-");
+}
+
+/** Every page row of the tree, in display order. */
+export function docsPages(items: DocsNavItem[]): DocsNavItem[] {
+  const pages: DocsNavItem[] = [];
+  for (const item of items) {
+    if (item.kind === "page" && item.path) pages.push(item);
+    if (Array.isArray(item.children)) pages.push(...docsPages(item.children));
+  }
+  return pages;
+}
+
+/** The title of the page at `path`, or null when the tree has no such row. */
+export function docsTitleOf(items: DocsNavItem[], path: string): string | null {
+  return docsPages(items).find((page) => page.path === path)?.title ?? null;
+}
+
+/**
+ * Resolve one `[text](href)` against the page it appears on.
+ *
+ * `from` is the tree-relative path of the open page, so its directory is what a
+ * relative href resolves against — a link to `ai-assistant.md` inside
+ * `examples/README.md` means `examples/ai-assistant.md`, not the guide page of
+ * that name, and getting this wrong is invisible until a reader in a
+ * subdirectory follows a link.
+ *
+ * A directory href (`examples/`) stays a directory: the backend resolves it to
+ * that directory's index page, which is what the site does with it too.
+ */
+export function resolveDocsLink(from: string, href: string): DocsLinkTarget {
+  const trimmed = href.trim();
+  if (trimmed.length === 0) return { kind: "none" };
+  if (trimmed.startsWith("#")) return { kind: "anchor", anchor: trimmed.slice(1) };
+  if (/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) {
+    // A scheme of any kind is somewhere else. Only the web ones are offered;
+    // `javascript:` and friends are refused rather than handed to the browser.
+    return /^https?:$/i.test(trimmed.slice(0, trimmed.indexOf(":") + 1))
+      ? { kind: "external", href: trimmed }
+      : { kind: "none" };
+  }
+  if (trimmed.startsWith("/")) {
+    // The reader is rooted at the user guide; an absolute path is not a path
+    // within it, so there is nothing honest to open.
+    return { kind: "none" };
+  }
+
+  const hash = trimmed.indexOf("#");
+  const target = hash === -1 ? trimmed : trimmed.slice(0, hash);
+  const anchor = hash === -1 ? null : trimmed.slice(hash + 1) || null;
+  if (target.length === 0) return anchor === null ? { kind: "none" } : { kind: "anchor", anchor };
+
+  const base = from.includes("/") ? from.slice(0, from.lastIndexOf("/")) : "";
+  const segments: string[] = [];
+  for (const segment of `${base}/${target}`.split("/")) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") {
+      // Climbing above the guide's root leaves the documentation set; there is
+      // no page there to open.
+      if (segments.length === 0) return { kind: "none" };
+      segments.pop();
+      continue;
+    }
+    segments.push(segment);
+  }
+  if (segments.length === 0) return { kind: "none" };
+
+  // A trailing slash survives the split, so a directory link is rebuilt as one.
+  const path = target.endsWith("/") ? `${segments.join("/")}/` : segments.join("/");
+  return { kind: "page", path, anchor };
+}
+
+/**
+ * The nav path an open page should highlight.
+ *
+ * A directory path (`examples/`) is the row for that directory's index page,
+ * which is the row the site marks current when you land there.
+ */
+export function docsNavPathOf(items: DocsNavItem[], path: string): string | null {
+  if (docsTitleOf(items, path) !== null) return path;
+  if (!path.endsWith("/")) return null;
+  const pages = docsPages(items);
+  for (const stem of ["README.md", "index.md"]) {
+    const candidate = `${path}${stem}`;
+    if (pages.some((page) => page.path === candidate)) return candidate;
+  }
+  return null;
+}

--- a/frontend/src/components/LearningCenter.parts/docsNav.ts
+++ b/frontend/src/components/LearningCenter.parts/docsNav.ts
@@ -39,12 +39,26 @@ export function headingSlug(text: string): string {
     .replace(/[-\s]+/g, "-");
 }
 
+/**
+ * The rows of a tree, or none.
+ *
+ * The tree is remote data and these derivations run inside a render. A body
+ * that arrives without its `items` array — or a row without its `children` —
+ * is treated as empty rather than allowed to throw, which in this surface is
+ * not a caught error but a blank application: with no catalogue the Reading tab
+ * is the *only* tab, so it is what the Learning Center opens on. This follows
+ * `catalogueGroups` in `learningCenterSlice`, which guards for the same reason.
+ */
+export function docsNavItems(items: DocsNavItem[] | undefined | null): DocsNavItem[] {
+  return Array.isArray(items) ? items : [];
+}
+
 /** Every page row of the tree, in display order. */
 export function docsPages(items: DocsNavItem[]): DocsNavItem[] {
   const pages: DocsNavItem[] = [];
-  for (const item of items) {
+  for (const item of docsNavItems(items)) {
     if (item.kind === "page" && item.path) pages.push(item);
-    if (Array.isArray(item.children)) pages.push(...docsPages(item.children));
+    pages.push(...docsPages(item.children));
   }
   return pages;
 }

--- a/frontend/src/components/LearningCenter.tsx
+++ b/frontend/src/components/LearningCenter.tsx
@@ -12,10 +12,9 @@
  * project on disk, so reading what one is before committing to it is worth a
  * column of its own.
  *
- * Reading tutorials sit in their own tab. `learningCenterTabs` builds that
- * split, and the backend decides which tutorials are reading ones by looking
- * at their steps rather than at a declared field — see
- * `TutorialManifest.is_reading_only`.
+ * The Reading tab is not a source: it holds the shipped user documentation,
+ * read in `DocsBrowser` (#2157). Every tutorial, reading ones included, is
+ * listed in its own source's tab.
  *
  * One confirmation in this file names directories rather than describing them,
  * and FR-087's restart confirmation in `TutorialDetail` does the same. That is
@@ -36,6 +35,7 @@ import {
 import { useAppStore } from "../store";
 import { learningCenterTabs, READING_TAB_ID, tutorialEntryKey } from "../store/learningCenterSlice";
 
+import { DocsBrowser } from "./LearningCenter.parts/DocsBrowser";
 import { GroupProgress } from "./LearningCenter.parts/GroupProgress";
 import { findSessionEntry } from "./LearningCenter.parts/readingCards";
 import { ReadingSurface } from "./LearningCenter.parts/ReadingSurface";
@@ -63,11 +63,9 @@ export const LEARNING_CENTER_ENTRY_LABEL = "Learning Center";
  * (#2084, closing the TODO(#2057) that used to sit here): while a reading
  * session is active, this component renders that window in place of the
  * catalogue, and the floating step card stays hidden because the panel is
- * open. This message is only for the Reading tab's empty list.
+ * open. A reading tutorial is started from its own source's tab (#2157).
  */
-const READING_TAB_EMPTY_MESSAGE = "Reading tutorials will appear here.";
-
-const GROUP_TAB_EMPTY_MESSAGE = "This source ships no hands-on tutorials.";
+const GROUP_TAB_EMPTY_MESSAGE = "This source ships no tutorials.";
 
 export function LearningCenter() {
   const open = useAppStore((state) => state.learningCenterOpen);
@@ -128,9 +126,13 @@ export function LearningCenter() {
     );
   }, [open, session]);
 
-  /* A tab with nothing selected shows its first tutorial rather than a blank column. */
+  /*
+   * A tab with nothing selected shows its first tutorial rather than a blank
+   * column. The Reading tab has no tutorials at all — running this against it
+   * would clear the selection the reader made in the tab they came from.
+   */
   useEffect(() => {
-    if (!activeTab) return;
+    if (!activeTab || activeTab.id === READING_TAB_ID) return;
     const keys = activeTab.tutorials.map(tutorialEntryKey);
     setSelectedKey((current) => (current && keys.includes(current) ? current : (keys[0] ?? null)));
   }, [activeTab]);
@@ -145,9 +147,10 @@ export function LearningCenter() {
   }, [selectedKey, tabs]);
 
   /*
-   * The ring counts one source. In a source's own tab that is the tab; in the
-   * Reading tab, whose tutorials may come from several sources at once, it is
-   * the selected tutorial's source — never a sum across them (FR-076).
+   * The ring counts one source, and that is the tab's own (FR-076 forbids a sum
+   * across sources). The fallback to the selected tutorial's source is what the
+   * Reading tab needed while it listed tutorials from several sources; it is
+   * kept because a tab without a group still must not show another's count.
    */
   const ringGroup = useMemo<TutorialCatalogueGroup | null>(() => {
     if (activeTab?.group) return activeTab.group;
@@ -160,6 +163,9 @@ export function LearningCenter() {
       )?.group ?? null
     );
   }, [activeTab, selectedEntry, tabs]);
+
+  /** The documentation, rather than a source's tutorials (#2157). */
+  const readingTab = activeTab?.id === READING_TAB_ID;
 
   const handleStart = useCallback(
     (entry: TutorialCatalogueEntry, restart: boolean) => {
@@ -331,129 +337,136 @@ export function LearningCenter() {
           </div>
         ) : null}
 
-        <div className="flex min-h-0 flex-1">
-          <div className="w-60 shrink-0 overflow-y-auto border-r border-stone-200">
-            {loading && tabs.length === 0 ? (
-              <p className="inline-flex items-center gap-2 px-4 py-6 text-sm text-stone-500">
-                <Loader2 aria-hidden="true" className="size-4 animate-spin" />
-                Loading tutorials…
-              </p>
-            ) : (
-              <TutorialList
-                emptyMessage={
-                  activeTab?.id === READING_TAB_ID
-                    ? READING_TAB_EMPTY_MESSAGE
-                    : GROUP_TAB_EMPTY_MESSAGE
-                }
-                onSelect={(entry) => setSelectedKey(tutorialEntryKey(entry))}
-                selectedKey={selectedKey}
-                tutorials={activeTab?.tutorials ?? []}
-              />
-            )}
-          </div>
-
-          <div className="min-w-0 flex-1 overflow-y-auto">
-            <TutorialDetail entry={selectedEntry} onStart={handleStart} />
-          </div>
-
-          <div className="w-60 shrink-0 overflow-y-auto border-l border-stone-200">
-            <GroupProgress
-              group={ringGroup}
-              onLeave={() => void leaveActiveTutorial()}
-              session={session}
-            />
-          </div>
-        </div>
-
-        <footer className="border-t border-stone-200 px-6 py-3">
-          {/*
-           * Discovery problems are shown rather than swallowed: one malformed
-           * manifest never empties a group, but the user should be able to see
-           * that something in a source did not load.
-           */}
-          {catalogue && catalogue.diagnostics.length > 0 ? (
-            <ul className="mb-3 flex flex-col gap-1" data-testid="learning-center-diagnostics">
-              {catalogue.diagnostics.map((line) => (
-                <li className="text-xs leading-5 text-stone-500" key={line}>
-                  {line}
-                </li>
-              ))}
-            </ul>
-          ) : null}
-
-          {/* FR-088 */}
-          {clearPreview === null && clearedDirectories === null ? (
-            <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
-              <button
-                className="shrink-0 rounded-full border border-stone-300 px-3 py-1.5 text-xs font-medium text-stone-600 transition hover:border-red-400 hover:text-red-600"
-                onClick={() => void handleClearRequested()}
-                type="button"
-              >
-                Clear tutorial data
-              </button>
-              {/* FR-068 */}
-              <p className="min-w-0 flex-1 text-xs leading-5 text-stone-500">
-                {TEMPORARY_PROJECTS_NOTICE}
-              </p>
-            </div>
-          ) : null}
-
-          {clearPreview !== null ? (
-            <div data-testid="learning-center-clear-confirm">
-              <p className="text-sm leading-6 text-ink">
-                Clearing tutorial data resets your tutorial progress and deletes these directories:
-              </p>
-              {clearPreview.length > 0 ? (
-                <ul className="mt-2 flex flex-col gap-1">
-                  {clearPreview.map((directory) => (
-                    <li
-                      className="break-all rounded-lg bg-stone-50 px-2 py-1 font-mono text-xs text-stone-600"
-                      key={directory}
-                    >
-                      {directory}
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="mt-2 text-xs text-stone-500">
-                  There is nothing on disk to delete right now.
+        {/*
+         * The Reading tab is the documentation, not a source: its own menu, its
+         * own page, and none of the three tutorial columns (#2157).
+         */}
+        {readingTab ? (
+          <DocsBrowser />
+        ) : (
+          <div className="flex min-h-0 flex-1">
+            <div className="w-60 shrink-0 overflow-y-auto border-r border-stone-200">
+              {loading && tabs.length === 0 ? (
+                <p className="inline-flex items-center gap-2 px-4 py-6 text-sm text-stone-500">
+                  <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+                  Loading tutorials…
                 </p>
+              ) : (
+                <TutorialList
+                  emptyMessage={GROUP_TAB_EMPTY_MESSAGE}
+                  onSelect={(entry) => setSelectedKey(tutorialEntryKey(entry))}
+                  selectedKey={selectedKey}
+                  tutorials={activeTab?.tutorials ?? []}
+                />
               )}
-              <div className="mt-3 flex flex-wrap gap-2">
-                <button
-                  className="rounded-full bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-red-700"
-                  onClick={() => {
-                    void (async () => {
-                      const deleted = await clearTutorialData();
-                      setClearPreview(null);
-                      setClearedDirectories(deleted);
-                    })();
-                  }}
-                  type="button"
-                >
-                  Delete them and clear progress
-                </button>
-                <button
-                  className="rounded-full border border-stone-300 px-3 py-1.5 text-xs font-medium text-stone-600 transition hover:border-pine hover:text-pine"
-                  onClick={() => setClearPreview(null)}
-                  type="button"
-                >
-                  Cancel
-                </button>
-              </div>
             </div>
-          ) : null}
 
-          {clearedDirectories !== null ? (
-            <p className="text-sm leading-6 text-stone-600" data-testid="learning-center-cleared">
-              {clearedDirectories.length > 0
-                ? `Tutorial progress is cleared and ${clearedDirectories.length} director${
-                    clearedDirectories.length === 1 ? "y was" : "ies were"
-                  } deleted.`
-                : "Tutorial progress is cleared."}
-            </p>
-          ) : null}
-        </footer>
+            <div className="min-w-0 flex-1 overflow-y-auto">
+              <TutorialDetail entry={selectedEntry} onStart={handleStart} />
+            </div>
+
+            <div className="w-60 shrink-0 overflow-y-auto border-l border-stone-200">
+              <GroupProgress
+                group={ringGroup}
+                onLeave={() => void leaveActiveTutorial()}
+                session={session}
+              />
+            </div>
+          </div>
+        )}
+
+        {readingTab ? null : (
+          <footer className="border-t border-stone-200 px-6 py-3">
+            {/*
+             * Discovery problems are shown rather than swallowed: one malformed
+             * manifest never empties a group, but the user should be able to see
+             * that something in a source did not load.
+             */}
+            {catalogue && catalogue.diagnostics.length > 0 ? (
+              <ul className="mb-3 flex flex-col gap-1" data-testid="learning-center-diagnostics">
+                {catalogue.diagnostics.map((line) => (
+                  <li className="text-xs leading-5 text-stone-500" key={line}>
+                    {line}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+
+            {/* FR-088 */}
+            {clearPreview === null && clearedDirectories === null ? (
+              <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+                <button
+                  className="shrink-0 rounded-full border border-stone-300 px-3 py-1.5 text-xs font-medium text-stone-600 transition hover:border-red-400 hover:text-red-600"
+                  onClick={() => void handleClearRequested()}
+                  type="button"
+                >
+                  Clear tutorial data
+                </button>
+                {/* FR-068 */}
+                <p className="min-w-0 flex-1 text-xs leading-5 text-stone-500">
+                  {TEMPORARY_PROJECTS_NOTICE}
+                </p>
+              </div>
+            ) : null}
+
+            {clearPreview !== null ? (
+              <div data-testid="learning-center-clear-confirm">
+                <p className="text-sm leading-6 text-ink">
+                  Clearing tutorial data resets your tutorial progress and deletes these
+                  directories:
+                </p>
+                {clearPreview.length > 0 ? (
+                  <ul className="mt-2 flex flex-col gap-1">
+                    {clearPreview.map((directory) => (
+                      <li
+                        className="break-all rounded-lg bg-stone-50 px-2 py-1 font-mono text-xs text-stone-600"
+                        key={directory}
+                      >
+                        {directory}
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="mt-2 text-xs text-stone-500">
+                    There is nothing on disk to delete right now.
+                  </p>
+                )}
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <button
+                    className="rounded-full bg-red-600 px-3 py-1.5 text-xs font-medium text-white transition hover:bg-red-700"
+                    onClick={() => {
+                      void (async () => {
+                        const deleted = await clearTutorialData();
+                        setClearPreview(null);
+                        setClearedDirectories(deleted);
+                      })();
+                    }}
+                    type="button"
+                  >
+                    Delete them and clear progress
+                  </button>
+                  <button
+                    className="rounded-full border border-stone-300 px-3 py-1.5 text-xs font-medium text-stone-600 transition hover:border-pine hover:text-pine"
+                    onClick={() => setClearPreview(null)}
+                    type="button"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : null}
+
+            {clearedDirectories !== null ? (
+              <p className="text-sm leading-6 text-stone-600" data-testid="learning-center-cleared">
+                {clearedDirectories.length > 0
+                  ? `Tutorial progress is cleared and ${clearedDirectories.length} director${
+                      clearedDirectories.length === 1 ? "y was" : "ies were"
+                    } deleted.`
+                  : "Tutorial progress is cleared."}
+              </p>
+            ) : null}
+          </footer>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/__tests__/LearningCenter.test.tsx
+++ b/frontend/src/components/__tests__/LearningCenter.test.tsx
@@ -49,6 +49,25 @@ vi.mock("../../lib/api/learningCenter", async (importOriginal) => {
   };
 });
 
+/*
+ * #2157 — the Reading tab reads the shipped documentation. This suite is about
+ * the Learning Center's own seams, so the reader is given a one-page tree; the
+ * reader itself is covered in `DocsBrowser.test.tsx`.
+ */
+vi.mock("../../lib/api/userDocs", () => ({
+  fetchUserDocsNav: vi.fn(async () => ({
+    title: "User guide",
+    root: "README.md",
+    items: [{ kind: "page", title: "SciStudio user guide", path: "README.md", children: [] }],
+  })),
+  fetchUserDocPage: vi.fn(async () => ({
+    path: "README.md",
+    title: "SciStudio user guide",
+    kind: "markdown",
+    text: "# SciStudio user guide\n\nWelcome.\n",
+  })),
+}));
+
 function entry(overrides: Partial<TutorialCatalogueEntry> = {}): TutorialCatalogueEntry {
   return {
     source_kind: "core",
@@ -266,6 +285,13 @@ describe("Learning Center — one tab per source (FR-084, FR-076)", () => {
   });
 });
 
+/**
+ * #2157 — the Reading tab is the shipped documentation, not a source.
+ *
+ * The reader itself is covered in `DocsBrowser.test.tsx`; what matters here is
+ * the seam: the tab shows the reader instead of the three tutorial columns, and
+ * a reading tutorial is listed by its own source rather than lifted out of it.
+ */
 describe("Learning Center — the Reading tab", () => {
   function withReading(): TutorialCatalogueResponse {
     const base = catalogue();
@@ -278,43 +304,51 @@ describe("Learning Center — the Reading tab", () => {
     return base;
   }
 
-  it("is offered even with no reading tutorials, and says what belongs there", async () => {
+  it("opens the documentation reader rather than a tutorial list", async () => {
     await renderOpenPanel();
 
     fireEvent.click(await screen.findByTestId("tutorial-tab-reading"));
 
-    expect(await screen.findByTestId("tutorial-list-empty")).toHaveTextContent(
-      /Reading tutorials will appear here/,
-    );
+    expect(await screen.findByTestId("docs-browser")).toBeInTheDocument();
+    expect(screen.queryByTestId("tutorial-list-empty")).not.toBeInTheDocument();
   });
 
-  it("collects reading tutorials out of their source's tab", async () => {
+  it("leaves reading tutorials in their own source's tab", async () => {
     await renderOpenPanel(withReading());
 
-    // Not in the core tab, which is what is selected on open.
-    expect(await screen.findByTestId("tutorial-entry-core--first-workflow")).toBeInTheDocument();
-    expect(screen.queryByTestId("tutorial-entry-core--what-there-is")).not.toBeInTheDocument();
-
-    fireEvent.click(screen.getByTestId("tutorial-tab-reading"));
-
+    // The core tab is what is selected on open, and it lists all five.
     expect(await screen.findByTestId("tutorial-entry-core--what-there-is")).toBeInTheDocument();
+    expect(screen.getByTestId("tutorial-entry-core--first-workflow")).toBeInTheDocument();
   });
 
-  it("carries no count of its own, because its tutorials span sources (FR-076)", async () => {
+  it("carries no count, because it carries no tutorials (FR-076)", async () => {
     await renderOpenPanel(withReading());
 
     const reading = await screen.findByTestId("tutorial-tab-reading");
     expect(reading.textContent).toBe("Reading");
   });
 
-  it("rings the selected tutorial's own source rather than a total", async () => {
+  it("keeps the tutorial selected in the tab the reader came from", async () => {
     await renderOpenPanel(withReading());
 
-    fireEvent.click(await screen.findByTestId("tutorial-tab-reading"));
-    await select("tutorial-entry-core--what-there-is");
+    await select("tutorial-entry-core--history");
+    fireEvent.click(screen.getByTestId("tutorial-tab-reading"));
+    await screen.findByTestId("docs-browser");
+    fireEvent.click(screen.getByTestId("tutorial-tab-core:"));
 
-    // The core group's own count — 1 of 5 once the reading tutorial widens it.
-    expect(await screen.findByTestId("learning-center-progress-ring")).toHaveTextContent("1/5");
+    expect(await screen.findByTestId("tutorial-detail")).toHaveTextContent(
+      "Recover work from History",
+    );
+  });
+
+  it("hides the tutorial-data footer, which is about tutorial directories", async () => {
+    await renderOpenPanel();
+
+    expect(await screen.findByText(/Tutorial projects are temporary/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("tutorial-tab-reading"));
+    await screen.findByTestId("docs-browser");
+
+    expect(screen.queryByText(/Tutorial projects are temporary/)).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/lib/api/userDocs.ts
+++ b/frontend/src/lib/api/userDocs.ts
@@ -1,0 +1,71 @@
+/**
+ * Client for `/api/user-docs` — the shipped user documentation (#2157).
+ *
+ * The wire shapes are `scistudio/api/routes/user_docs.py`'s response models.
+ * Nothing here interprets them: the navigation tree arrives already ordered and
+ * titled the way the published site orders and titles it, because the backend
+ * reproduces MkDocs' rules rather than re-listing the documentation by hand.
+ *
+ * Types live beside the client, following `learningCenter.ts` and the
+ * work-import module, so the contract and the calls that depend on it move
+ * together.
+ */
+
+import { apiFetch } from "./core";
+
+/**
+ * One row of the navigation tree.
+ *
+ * A `page` row carries the `path` it opens. A `section` row carries none: on
+ * the published site a section is a directory MkDocs turned into a heading, and
+ * a heading has nothing to open.
+ */
+export interface DocsNavItem {
+  kind: "page" | "section";
+  title: string;
+  path: string | null;
+  children: DocsNavItem[];
+}
+
+/** The navigation tree, and the page the reader starts on. */
+export interface DocsNavResponse {
+  /** The caption the published sidebar prints above this group. */
+  title: string;
+  /** The entry page — the user guide's front page. */
+  root: string;
+  items: DocsNavItem[];
+}
+
+/** One documentation file, as text. */
+export interface DocsPageResponse {
+  path: string;
+  title: string;
+  /**
+   * `markdown` for a guide page; `source` for a file a page links to as a
+   * worked example (`block.py`, `accucor.R`) — the site serves those verbatim
+   * beside the page that links them, and so does the reader.
+   */
+  kind: "markdown" | "source";
+  text: string;
+}
+
+/** The navigation tree. */
+export async function fetchUserDocsNav(): Promise<DocsNavResponse> {
+  return apiFetch<DocsNavResponse>("/api/user-docs/nav");
+}
+
+/**
+ * One documentation file.
+ *
+ * The path is tree-relative and its segments are encoded, because a page name
+ * becomes a URL segment. `%2F` would be encoded away by encoding the whole
+ * path, so each segment is encoded and the separators are kept.
+ */
+export async function fetchUserDocPage(path: string): Promise<DocsPageResponse> {
+  const encoded = path
+    .split("/")
+    .filter((segment) => segment.length > 0)
+    .map(encodeURIComponent)
+    .join("/");
+  return apiFetch<DocsPageResponse>(`/api/user-docs/pages/${encoded}`);
+}

--- a/frontend/src/store/learningCenterSlice.ts
+++ b/frontend/src/store/learningCenterSlice.ts
@@ -80,9 +80,8 @@ export const READING_TAB_LABEL = "Reading";
  * One tab of the Learning Center: a source, or the Reading tab.
  *
  * `group` is the source group the tab's ring counts against. The Reading tab
- * has none, because its tutorials can come from several sources at once and
- * FR-076 forbids reporting a count across them — there, the ring follows the
- * selected tutorial's own source instead.
+ * has none: it lists no tutorials at all (#2157), so there is no count to
+ * report and no source to report it for.
  */
 export interface LearningCenterTab {
   id: string;
@@ -103,35 +102,27 @@ export function tutorialEntryKey(entry: {
 /**
  * The tabs, in display order: core first, then the other sources, Reading last.
  *
- * Reading tutorials are lifted out of their source tabs rather than listed
- * twice. A tutorial that only ever asks the reader to read on is a different
- * kind of thing to sit down to than one that asks them to build something, and
- * showing it in both places would make each tab's list a poor answer to "what
- * is there to do here".
+ * Every tutorial is listed in its own source's tab, reading tutorials included.
+ * They used to be lifted out into the Reading tab on the argument that sitting
+ * down to read is a different undertaking to sitting down to build; #2157 gave
+ * the Reading tab to the shipped documentation instead, so a tutorial lifted
+ * there now would be a tutorial nobody could find. A reading tutorial still
+ * runs the way it always did — it is simply listed where its siblings are.
  *
- * The Reading tab is present even when empty. It is the answer to "where did
- * the reading material go", and a tab that appears only once content exists
- * cannot answer that.
+ * The Reading tab carries no tutorials and is always present: it is not a
+ * source, it is the documentation.
  */
 export function learningCenterTabs(
   catalogue: TutorialCatalogueResponse | null,
 ): LearningCenterTab[] {
-  const reading: TutorialCatalogueEntry[] = [];
-  const tabs: LearningCenterTab[] = [];
+  const tabs: LearningCenterTab[] = orderedTutorialGroups(catalogue).map((group) => ({
+    id: `${group.source_kind}:${group.source_id}`,
+    label: group.label,
+    group,
+    tutorials: Array.isArray(group.tutorials) ? group.tutorials : [],
+  }));
 
-  for (const group of orderedTutorialGroups(catalogue)) {
-    const entries = Array.isArray(group.tutorials) ? group.tutorials : [];
-    const hands_on = entries.filter((entry) => !entry.reading);
-    reading.push(...entries.filter((entry) => entry.reading));
-    tabs.push({
-      id: `${group.source_kind}:${group.source_id}`,
-      label: group.label,
-      group,
-      tutorials: hands_on,
-    });
-  }
-
-  tabs.push({ id: READING_TAB_ID, label: READING_TAB_LABEL, group: null, tutorials: reading });
+  tabs.push({ id: READING_TAB_ID, label: READING_TAB_LABEL, group: null, tutorials: [] });
   return tabs;
 }
 

--- a/src/scistudio/api/app.py
+++ b/src/scistudio/api/app.py
@@ -27,6 +27,7 @@ from scistudio.api.routes import (
     runs,
     tutorials,
     types,
+    user_docs,
     user_library,
     work_import,
     workflows,
@@ -307,6 +308,8 @@ def create_app() -> FastAPI:
     app.include_router(diagnostics.router)
     # ADR-053 §4 — Bring In My Work session spawn (POST /api/work-import/sessions).
     app.include_router(work_import.router)
+    # #2157: the shipped user documentation, read in the Learning Center.
+    app.include_router(user_docs.router)
 
     @app.get("/api/logs/stream")
     async def logs_stream(request: Request) -> object:

--- a/src/scistudio/api/routes/user_docs.py
+++ b/src/scistudio/api/routes/user_docs.py
@@ -1,0 +1,259 @@
+"""Serve the shipped user documentation to the in-app reader (#2157).
+
+SciStudio already writes a complete user documentation set: ``scistudio/_user_guide/``
+— the guide pages plus the generated, self-contained API reference. It ships in
+the wheel, provisioning copies it into every project, and the published site is
+that same tree (site = Home + this tree + the repo-only package development
+guide). Until now the product gave a reader no way to open it without leaving
+for the browser.
+
+These two endpoints are what the Learning Center's Reading tab reads:
+
+* ``GET /api/user-docs/nav``          — the navigation tree
+* ``GET /api/user-docs/pages/{path}`` — one file's text
+
+**The packaged tree, not a project's copy.** The reader is served from
+``importlib.resources``, so the documentation opens with no project on screen and
+can never disagree with the code it was generated from. A project's provisioned
+``user-guide/`` is a copy for the in-project human and the embedded agent; it is
+not a second source of truth.
+
+**The navigation is the site's own.** The owner asked for the web version's left
+menu, so the tree here is not an editorial re-listing: it reproduces the rules
+MkDocs applies when it generates a nav from a directory (MkDocs 1.6,
+``mkdocs.structure.files.get_files`` and ``mkdocs.utils.nest_paths``), which are
+the rules that produced the published sidebar. :func:`_nav_of` documents each one
+against the behaviour it mirrors. Package Development is absent because it is a
+developer document that lives in the repository rather than in this tree — it was
+never part of what ships.
+
+The tree is read once per process and cached: it is packaged data, so it cannot
+change under a running server.
+"""
+
+from __future__ import annotations
+
+import importlib.resources
+import posixpath
+import re
+from functools import lru_cache
+from importlib.resources.abc import Traversable
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+#: The packaged documentation tree. ``_user_guide`` is not an importable package
+#: (it holds no Python), but it is a namespace portion inside one, which is
+#: enough for ``importlib.resources`` — the same access ``agent_provisioning.docs``
+#: uses to copy it into a project.
+_DOCS_PACKAGE = "scistudio._user_guide"
+
+#: Extensions rendered as prose. MkDocs builds its nav from Markdown pages only;
+#: every other file is copied verbatim beside them and reachable by link.
+_PAGE_SUFFIX = ".md"
+
+#: A directory link (``examples/``) means that directory's index page, and
+#: MkDocs accepts either spelling as one.
+_INDEX_STEMS = ("index", "README")
+
+#: MkDocs' extracted page title: the document's *first* block element, and only
+#: when that element is an ``h1``. A file that opens with anything else — the
+#: generated reference opens with a provenance comment — takes the filename
+#: title instead, which is why the site's sidebar says "Index" there.
+_H1 = re.compile(r"^#[^#\S]*\s*(.+?)\s*#*\s*$")
+
+#: A link, reduced to its text; then the emphasis and code markers, dropped.
+#: MkDocs takes a title off the *rendered* heading and keeps only its text, so
+#: the site's sidebar reads "a custom .npy loader" where the source says
+#: ``a custom `.npy` loader``. A menu that kept the backticks would not match it.
+_LINK = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+_MARKUP = re.compile(r"(\*\*|__|[*`_])")
+
+router = APIRouter(prefix="/api/user-docs", tags=["user-docs"])
+
+
+class DocsNavItem(BaseModel):
+    """One row of the navigation tree.
+
+    A row is either a page (has ``path``) or a section (has ``children``).
+    Sections carry no path because MkDocs generates them from a directory name
+    and gives them nothing to open — in the published sidebar they are headings
+    that expand, not links.
+    """
+
+    kind: str = Field(description="``page`` or ``section``.")
+    title: str
+    #: Tree-relative POSIX path of the file this row opens; sections have none.
+    path: str | None = None
+    children: list[DocsNavItem] = Field(default_factory=list)
+
+
+class DocsNavResponse(BaseModel):
+    """The navigation tree, and where the reader starts."""
+
+    #: The caption the published sidebar prints above this group.
+    title: str
+    #: The entry page: the user guide's front page.
+    root: str
+    items: list[DocsNavItem] = Field(default_factory=list)
+
+
+class DocsPageResponse(BaseModel):
+    """One documentation file, as text."""
+
+    path: str
+    title: str
+    #: ``markdown`` for a guide page; ``source`` for a file the guide links to
+    #: as a worked example (``block.py``, ``accucor.R``), which the site serves
+    #: verbatim beside the page that links it.
+    kind: str
+    text: str
+
+
+def _dirname_title(name: str) -> str:
+    """A directory's section title, by MkDocs' rule (``utils.dirname_to_title``).
+
+    Separators become spaces, and an all-lowercase name is capitalised — which
+    is where the sidebar's "Api reference" and "App fiji" come from. A name that
+    already carries capitals is left alone.
+    """
+    title = name.replace("-", " ").replace("_", " ")
+    return title.capitalize() if title.lower() == title else title
+
+
+def _filename_title(name: str) -> str:
+    """A page's fallback title, by MkDocs' rule (``Page._get_title_from_filename``).
+
+    Same transformation as a directory's, applied to the stem. This is what the
+    site shows for a page whose first element is not a heading.
+    """
+    stem = name[: -len(_PAGE_SUFFIX)] if name.endswith(_PAGE_SUFFIX) else name
+    return _dirname_title(stem)
+
+
+def _title_of(name: str, text: str) -> str:
+    """The title MkDocs would print for this page in the sidebar.
+
+    MkDocs reads the title off the rendered document's first element, using it
+    only when that element is an ``h1``; anything else in front of the heading —
+    a comment, a paragraph, a table — and the page falls back to its filename.
+    Reproducing that is the difference between the reader's menu matching the
+    published one and merely resembling it.
+    """
+    for line in text.lstrip("﻿").splitlines():
+        if not line.strip():
+            continue
+        heading = _H1.match(line)
+        if not heading:
+            return _filename_title(name)
+        return _MARKUP.sub("", _LINK.sub(r"\1", heading.group(1))).strip()
+    return _filename_title(name)
+
+
+def _sort_key(name: str, *, is_dir: bool) -> tuple[int, int, str]:
+    """Order one directory's entries the way MkDocs walks them.
+
+    Three rules, in order: a directory's own files come before its
+    subdirectories (``os.walk`` is top-down); ``index``/``README`` leads the
+    files (``files._file_sort_key``); everything else is alphabetical.
+    """
+    if is_dir:
+        return (1, 1, name)
+    stem = name[: -len(_PAGE_SUFFIX)] if name.endswith(_PAGE_SUFFIX) else name
+    return (0, 0 if stem in _INDEX_STEMS else 1, name)
+
+
+def _nav_of(directory: Traversable, prefix: str) -> list[DocsNavItem]:
+    """Build the navigation for one directory, recursively.
+
+    Only Markdown files become rows. The example directories' ``block.py`` and
+    ``accucor.R`` are absent here for the same reason they are absent from the
+    published sidebar: MkDocs navigates pages and copies everything else, so
+    those files are reached through the page that links them, not through the
+    menu.
+    """
+    entries = sorted(
+        ((child.name, child) for child in directory.iterdir() if not child.name.startswith((".", "__"))),
+        key=lambda pair: _sort_key(pair[0], is_dir=pair[1].is_dir()),
+    )
+    items: list[DocsNavItem] = []
+    for name, child in entries:
+        path = posixpath.join(prefix, name) if prefix else name
+        if child.is_dir():
+            children = _nav_of(child, path)
+            if children:
+                items.append(DocsNavItem(kind="section", title=_dirname_title(name), children=children))
+            continue
+        if not name.endswith(_PAGE_SUFFIX):
+            continue
+        text = child.read_text(encoding="utf-8")
+        items.append(DocsNavItem(kind="page", title=_title_of(name, text), path=path))
+    return items
+
+
+@lru_cache(maxsize=1)
+def _nav() -> DocsNavResponse:
+    """The whole tree's navigation, read once — packaged data does not change."""
+    root = importlib.resources.files(_DOCS_PACKAGE)
+    return DocsNavResponse(
+        # The caption the published sidebar prints above this group. It comes
+        # from the site's staging directory name, not from this tree.
+        title=_dirname_title("user-guide"),
+        root="README.md",
+        items=_nav_of(root, ""),
+    )
+
+
+def _resolve(path: str) -> Traversable:
+    """Resolve a tree-relative path, or refuse.
+
+    Containment is not checked after the fact: the path is normalised, then
+    walked one segment at a time from the package root, so a segment that is not
+    a plain name never reaches the filesystem. A directory resolves to its index
+    page, which is what a link like ``examples/`` means.
+    """
+    normalised = posixpath.normpath(path.strip("/")) if path.strip("/") else ""
+    segments = [segment for segment in normalised.split("/") if segment not in ("", ".")]
+    if not segments or any(segment == ".." for segment in segments):
+        raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}")
+    current: Traversable = importlib.resources.files(_DOCS_PACKAGE)
+    for segment in segments:
+        try:
+            current = current / segment
+            if not (current.is_file() or current.is_dir()):
+                raise FileNotFoundError(segment)
+        except (FileNotFoundError, NotADirectoryError, OSError, ValueError):
+            raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}") from None
+    if current.is_dir():
+        for stem in _INDEX_STEMS:
+            candidate = current / f"{stem}{_PAGE_SUFFIX}"
+            if candidate.is_file():
+                return candidate
+        raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}")
+    return current
+
+
+@router.get("/nav", response_model=DocsNavResponse)
+async def get_nav() -> DocsNavResponse:
+    """Return the documentation navigation tree."""
+    return _nav()
+
+
+@router.get("/pages/{path:path}", response_model=DocsPageResponse)
+async def get_page(path: str) -> DocsPageResponse:
+    """Return one documentation file's text."""
+    resolved = _resolve(path)
+    try:
+        text = resolved.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        # A file that is not text is not something the reader can show. The
+        # tree holds none today; a future binary asset should not 500.
+        raise HTTPException(status_code=415, detail=f"Not a readable document: {path!r}") from None
+    name = resolved.name
+    markdown = name.endswith(_PAGE_SUFFIX)
+    return DocsPageResponse(
+        path=path.strip("/"),
+        title=_title_of(name, text) if markdown else name,
+        kind="markdown" if markdown else "source",
+        text=text,
+    )

--- a/tests/api/test_user_docs.py
+++ b/tests/api/test_user_docs.py
@@ -1,0 +1,191 @@
+"""``/api/user-docs`` — the shipped user documentation, as the reader gets it (#2157).
+
+The owner's requirement for the in-app reader was that its menu match the
+published site's, so these tests are written against the *published sidebar*
+rather than against this module's own idea of a nice tree. The expected values
+below were read out of a real ``mkdocs build`` of ``mkdocs.site.yml`` — including
+the parts that are not pretty:
+
+* ``api-reference/index.md`` is titled **"Index"**, not "SciStudio API reference".
+  MkDocs takes a page title off the document's *first* element and only when
+  that element is an ``h1``; the generated reference opens with a provenance
+  comment, so it falls back to its filename. The reader reproduces that, because
+  matching the site means matching it where it is unflattering too.
+* Section titles are MkDocs' ``dirname_to_title``, which is why they read
+  "Api reference" and "App fiji" rather than "API Reference" and "app-fiji".
+* Files that are not Markdown — an example's ``block.py`` — are absent from the
+  menu and reachable by path, exactly as they are on the site, which navigates
+  pages and copies everything else beside them.
+
+Package Development is not part of this tree and so cannot appear here: it is a
+developer guide that lives in the repository, not in the wheel.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+#: The User Guide group of the published sidebar, in order, as
+#: ``(depth, kind, title)``. Depth 0 is a top-level row.
+PUBLISHED_SIDEBAR: tuple[tuple[int, str, str], ...] = (
+    (0, "page", "SciStudio user guide"),
+    (0, "page", "The AI assistant"),
+    (0, "page", "Built-in blocks"),
+    (0, "page", "Making your own data type"),
+    (0, "page", "Data types"),
+    (0, "page", "Getting started with SciStudio"),
+    (0, "page", "Run history and branches"),
+    (0, "page", "How SciStudio works"),
+    (0, "page", "Using the canvas: build, run, preview"),
+    (0, "page", "Writing a block"),
+    (0, "page", "Writing a plot"),
+    (0, "section", "Api reference"),
+    (1, "page", "Index"),
+    (1, "page", "Scistudio.blocks.app"),
+    (1, "page", "Scistudio.blocks.base"),
+    (1, "page", "Scistudio.blocks.code"),
+    (1, "page", "Scistudio.blocks.io"),
+    (1, "page", "Scistudio.blocks.process"),
+    (1, "page", "Scistudio.core.meta"),
+    (1, "page", "Scistudio.core.types"),
+    (1, "page", "Scistudio.previewers.data access"),
+    (1, "page", "Scistudio.previewers.models"),
+    (1, "page", "Scistudio.tutorials"),
+    (0, "section", "Examples"),
+    (1, "page", "Examples"),
+    (1, "section", "App fiji"),
+    (2, "page", "AppBlock example — run a Fiji macro"),
+    (1, "section", "Code accucor r"),
+    (2, "page", "CodeBlock example — run an R script (AccuCor)"),
+    (1, "section", "Io load npy"),
+    (2, "page", "IOBlock example — a custom .npy loader"),
+    (1, "section", "Process scale array"),
+    (2, "page", "ProcessBlock example — normalize table columns"),
+)
+
+
+def _flatten(items: list[dict], depth: int = 0) -> list[tuple[int, str, str]]:
+    rows: list[tuple[int, str, str]] = []
+    for item in items:
+        rows.append((depth, item["kind"], item["title"]))
+        rows.extend(_flatten(item.get("children", []), depth + 1))
+    return rows
+
+
+def _paths(items: list[dict]) -> list[str]:
+    found: list[str] = []
+    for item in items:
+        if item["kind"] == "page":
+            found.append(item["path"])
+        found.extend(_paths(item.get("children", [])))
+    return found
+
+
+@pytest.fixture()
+def nav(client: TestClient) -> dict:
+    response = client.get("/api/user-docs/nav")
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestNavigation:
+    def test_matches_the_published_sidebar(self, nav: dict) -> None:
+        """Row for row, in order: the site's User Guide group."""
+        assert _flatten(nav["items"]) == list(PUBLISHED_SIDEBAR)
+
+    def test_opens_on_the_user_guide_front_page(self, nav: dict) -> None:
+        assert nav["root"] == "README.md"
+        assert nav["title"] == "User guide"
+        assert nav["items"][0] == {
+            "kind": "page",
+            "title": "SciStudio user guide",
+            "path": "README.md",
+            "children": [],
+        }
+
+    def test_a_section_opens_nothing(self, nav: dict) -> None:
+        """A directory MkDocs turned into a heading has no page behind it."""
+        sections = [row for row in nav["items"] if row["kind"] == "section"]
+        assert sections, "the tree has directories, so it must have sections"
+        assert all(section["path"] is None for section in sections)
+        assert all(section["children"] for section in sections)
+
+    def test_excludes_the_package_development_guide(self, nav: dict) -> None:
+        """It is a developer document in the repository, never in the wheel."""
+        titles = {title for _, _, title in _flatten(nav["items"])}
+        assert not any("ackage development" in title for title in titles)
+
+    def test_lists_only_markdown_pages(self, nav: dict) -> None:
+        """An example's sources are linked from its page, not from the menu."""
+        assert all(path.endswith(".md") for path in _paths(nav["items"]))
+        assert "examples/app-fiji/block.py" not in _paths(nav["items"])
+
+    def test_every_listed_page_can_be_opened(self, client: TestClient, nav: dict) -> None:
+        for path in _paths(nav["items"]):
+            assert client.get(f"/api/user-docs/pages/{path}").status_code == 200, path
+
+
+class TestPages:
+    def test_serves_a_guide_page_as_markdown(self, client: TestClient) -> None:
+        body = client.get("/api/user-docs/pages/README.md").json()
+
+        assert body["kind"] == "markdown"
+        assert body["path"] == "README.md"
+        assert body["title"] == "SciStudio user guide"
+        assert body["text"].startswith("# SciStudio user guide")
+
+    def test_serves_a_linked_source_file_verbatim(self, client: TestClient) -> None:
+        """The site copies these beside the page that links them; so does this."""
+        response = client.get("/api/user-docs/pages/examples/app-fiji/block.py")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["kind"] == "source"
+        assert body["title"] == "block.py"
+        assert "AppBlock" in body["text"]
+
+    @pytest.mark.parametrize(
+        "path",
+        ["examples/", "examples/app-fiji/", "api-reference/"],
+        ids=["examples", "one example", "reference"],
+    )
+    def test_a_directory_serves_its_index_page(self, client: TestClient, path: str) -> None:
+        """The guide links to directories (`examples/`), and the site indexes them."""
+        response = client.get(f"/api/user-docs/pages/{path}")
+
+        assert response.status_code == 200
+        assert response.json()["kind"] == "markdown"
+
+    def test_reports_a_missing_page_rather_than_failing(self, client: TestClient) -> None:
+        response = client.get("/api/user-docs/pages/no-such-page.md")
+
+        assert response.status_code == 404
+        assert "no-such-page.md" in response.json()["detail"]
+
+
+class TestContainment:
+    """The path is a request parameter, so it is never allowed to leave the tree."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "../../pyproject.toml",
+            "../version.py",
+            "..%2f..%2fpyproject.toml",
+            "examples/../../version.py",
+            "....//pyproject.toml",
+        ],
+        ids=["climb", "sibling", "encoded climb", "climb from within", "doubled dots"],
+    )
+    def test_refuses_a_path_that_leaves_the_documentation(self, client: TestClient, path: str) -> None:
+        response = client.get(f"/api/user-docs/pages/{path}")
+
+        assert response.status_code == 404
+        # The refusal quotes the path back, which is the point of a 404; what
+        # must never appear is any of the file it asked for.
+        for outside in ("[build-system]", "[project]", "def get_version"):
+            assert outside not in response.text
+
+    def test_refuses_an_empty_path(self, client: TestClient) -> None:
+        assert client.get("/api/user-docs/pages/").status_code == 404


### PR DESCRIPTION
## What

SciStudio writes a complete user guide and generates a self-contained API reference from its own code. Both ship in the wheel, both are provisioned into every project, and both are exactly what the published documentation site serves.

The product gave a reader no way to open any of it without leaving for a browser.

The Learning Center's Reading tab was built to hold *reading tutorials* — tutorials whose steps only ask the reader to read pages the tutorial ships. None exist on `main`, so the tab held one sentence saying they would appear there.

It now holds the documentation.

- Opens on the user guide's front page.
- The documentation's menu sits beside it.
- A link inside a page goes to the page it names, rather than out of the product.

## The menu is the site's own

The requirement was that the left menu match the web version, so it is not an editorial re-listing that would drift the first time a page is added. `GET /api/user-docs/nav` derives the tree from the packaged `scistudio/_user_guide/` directory by the rules MkDocs applies when it generates a nav from a directory — `os.walk` order with `index`/`README` first, `dirname_to_title` for sections, and a page title taken from its first element only when that element is an `h1`.

That last rule is why the generated reference's front page is titled **"Index"** and not "SciStudio API reference": it opens with a provenance comment, so MkDocs falls back to the filename, and the published sidebar says "Index" too. Matching the site means matching it where it is unflattering.

`tests/api/test_user_docs.py` asserts the tree row for row against a table read out of a real `mkdocs build` of `mkdocs.site.yml` — 33 rows, three depths, both sections. A separate check confirmed all **101 headings** across the guide slug identically to the anchors the built site generates, which is what makes a cross-page link like `using-the-gui.md#previewing-data` land.

## Rendering

`react-markdown` + `remark-gfm` are new frontend dependencies (96 packages added to the lockfile; no existing package removed or moved). The guide contains **158 fenced code blocks and 132 rows of table**, and the tutorial reading pane's deliberately tiny renderer produces neither — a guide whose tables came out as raw pipes would be a picture of the documentation rather than the documentation.

Raw HTML in a document is not parsed: `rehype-raw` is deliberately absent. Links are dispatched rather than handed to the browser — an in-guide link navigates the reader, an `http(s)` link opens outside, and anything else (an absolute path, a foreign scheme, a target that climbs out of the guide) renders as its own text instead of as a link that goes nowhere.

## What is not included

**Package Development.** It is a developer guide that lives in the repository rather than in the shipped tree, so it was never part of what a user gets.

**Reading tutorials are not removed.** They run exactly as before. They are simply listed in their own source's tab alongside every other tutorial, because the tab they used to be lifted into is no longer theirs — a tutorial lifted there now would be a tutorial nobody could find. `ReadingSurface`, `is_reading_only` and the pages route are untouched.

## Verification

- `tests/api/test_user_docs.py` — 18 tests: the sidebar match, page and source delivery, directory indexing, and five containment refusals.
- `DocsBrowser.test.tsx` (10), `DocMarkdown.test.tsx` (11), `docsNav.test.ts` (21) — the reader, the rendering, and the link arithmetic.
- `LearningCenter.test.tsx` — its Reading-tab suite rewritten for the new behaviour; 29 tests pass.
- Tier-2 pre-PR gate reconciled: `format_check`, `frontend`, `full_audit`, `import_contracts`, `lint_format`, `python_tests`, `type_check`.

The frontend CI mirror caught one defect that no unit test of mine would have: **with no catalogue the Reading tab is the only tab**, so it is what the Learning Center opens on — and a nav body arriving without its `items` array threw inside a render, which is not a caught error but a blank application. `App.test.tsx` went down whole. It is now guarded the way `catalogueGroups` guards the catalogue, with the entry page falling back to the tree's first page, and both cases are regression-tested.

The frontend and backend were **not** launched for live testing, per the owner's instruction (a hot-update session is using them).

One thing worth the owner's eye: the four external links in the guide are opened with `window.open`. In a browser that is a tab; in the Electron shell, which installs no `setWindowOpenHandler`, it is a new window rather than the system browser. Routing those to `shell.openExternal` means touching `desktop/main.js`, which the hot-update session is currently on, so it is left alone here.

Gate record: `.workflow/records/2157-guided-reading-doc-viewer.json`

Closes #2157
