### PR TITLE
fix(#2160): refuse a Windows separator before resolving a documentation path

### DIFF
--- a/.workflow/records/2160-fix-2160-docs-path-containment.json
+++ b/.workflow/records/2160-fix-2160-docs-path-containment.json
@@ -122,7 +122,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "3c9ed312067cf94526483de2147715d17b4e1244",
+    "shas": [
+      "3c9ed312067cf94526483de2147715d17b4e1244"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -249,6 +255,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.050443Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.065214Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.108239Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.123785Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.143518Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.159380Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.173854Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.188771Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.233684Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.248248Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:03.264637Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -271,9 +365,9 @@
       "src/scistudio/api/routes/user_docs.py",
       "tests/api/test_user_docs.py"
     ],
-    "diff_fingerprint": "sha256:1070257747aafaf601a7db53f6e97675516f438ce7e5323ea3b1daf1159fb5c0",
+    "diff_fingerprint": "sha256:c5e3879ed733f0a7ec05e672f4250a88b41b5294d16fc803836c7caa5ffefc30",
     "head": "HEAD",
-    "head_sha": "9ee3025a0",
+    "head_sha": "3c9ed3120",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -290,11 +384,26 @@
   },
   "owner_directive": "Reject Windows separators before resolving doc paths: an encoded backslash stays inside one segment, passes the '..' check, and escapes _user_guide, so /api/user-docs/pages/%2e%2e%5cversion.py served scistudio/version.py and repeated climbs reached the repository root. Reject both platform separators in every segment, or verify the resolved filesystem path remains beneath the documentation root. PR #2158 is merged; land this as a new PR.",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2160
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-25T06:43:55.109088Z",
       "diff_fingerprint": "sha256:1070257747aafaf601a7db53f6e97675516f438ce7e5323ea3b1daf1159fb5c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:44:03.264671Z",
+      "diff_fingerprint": "sha256:c5e3879ed733f0a7ec05e672f4250a88b41b5294d16fc803836c7caa5ffefc30",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2160-fix-2160-docs-path-containment.json
+++ b/.workflow/records/2160-fix-2160-docs-path-containment.json
@@ -1,7 +1,126 @@
 {
   "base_ref": null,
   "branch": "fix/2160-docs-path-containment",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-25T06:41:40.060794Z",
+      "command": "ruff format src/scistudio/api/routes/user_docs.py tests/api/test_user_docs.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c3fedbf2e4933ace2d0ea36f758bdb447963334abcee239f932bf0884cdf23ae",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:43:30.947946Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7284fa923d44a4c72254019e6d9d8caac7afc899ab81a214ad38e80acd837933",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:43:42.280049Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:75abe35ef10d3183e330ebec1d8795fb6d1f6aac2fea0e5037db10bdcd2af59c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:43:42.539154Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7bdf1b472202f9bd154a71b9333ac74cd2d4c1bc3dc87db576b1236ea6297479",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:43:42.564460Z",
+      "command": "ruff check src/scistudio/api/routes/user_docs.py tests/api/test_user_docs.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3e3b333d5712fc2c9f62174e8d2159f6d2fef4272e98a90975063c9c80eddfa0",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:43:53.243332Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/api/routes tests/api/test_user_docs.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6321562debf3e971c8b96761e8f65a639f3bb086c8947221d4d14f7223186a75",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:43:54.911450Z",
+      "command": "mypy src/scistudio/api/routes/user_docs.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a67d0addf611c509ff9524e473c5dab570e4884fe77902d03bbaa62af12f875d",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -42,7 +161,96 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-25T06:43:54.962526Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:54.979290Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:54.996926Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.011450Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.025222Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.038819Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.053592Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.067875Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.081199Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.094609Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:43:55.109049Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -52,25 +260,85 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "0a334b3c1",
+    "changed_files": [
+      ".workflow/records/2160-fix-2160-docs-path-containment.json",
+      "CHANGELOG.md",
+      "frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts",
+      "frontend/src/components/LearningCenter.parts/docsNav.ts",
+      "src/scistudio/api/routes/user_docs.py",
+      "tests/api/test_user_docs.py"
+    ],
+    "diff_fingerprint": "sha256:1070257747aafaf601a7db53f6e97675516f438ce7e5323ea3b1daf1159fb5c0",
+    "head": "HEAD",
+    "head_sha": "9ee3025a0",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 2,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 3,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Reject Windows separators before resolving doc paths: an encoded backslash stays inside one segment, passes the '..' check, and escapes _user_guide, so /api/user-docs/pages/%2e%2e%5cversion.py served scistudio/version.py and repeated climbs reached the repository root. Reject both platform separators in every segment, or verify the resolved filesystem path remains beneath the documentation root. PR #2158 is merged; land this as a new PR.",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T06:43:55.109088Z",
+      "diff_fingerprint": "sha256:1070257747aafaf601a7db53f6e97675516f438ce7e5323ea3b1daf1159fb5c0",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2160-fix-2160-docs-path-containment",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "b5d02b8b-63de-4487-bb99-4dcd9770f530",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2160-fix-2160-docs-path-containment.json
+++ b/.workflow/records/2160-fix-2160-docs-path-containment.json
@@ -123,9 +123,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "3c9ed312067cf94526483de2147715d17b4e1244",
+    "sha": "c5a0ffd08031aa932827b9891913971f533213eb",
     "shas": [
-      "3c9ed312067cf94526483de2147715d17b4e1244"
+      "c5a0ffd08031aa932827b9891913971f533213eb"
     ],
     "trailers": []
   },
@@ -343,6 +343,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.382825Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.411017Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.442108Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.484346Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.528963Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.565781Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.594277Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.654626Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.698667Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.712472Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:13.728457Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.253679Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.269663Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.285196Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.301086Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.317382Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.333824Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.349694Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.365081Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.380560Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.395802Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:44:25.412797Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -355,7 +531,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "0a334b3c15b8549733f7e1744adf4cd45dd61b5b",
     "base_sha": "0a334b3c1",
     "changed_files": [
       ".workflow/records/2160-fix-2160-docs-path-containment.json",
@@ -365,9 +541,9 @@
       "src/scistudio/api/routes/user_docs.py",
       "tests/api/test_user_docs.py"
     ],
-    "diff_fingerprint": "sha256:c5e3879ed733f0a7ec05e672f4250a88b41b5294d16fc803836c7caa5ffefc30",
+    "diff_fingerprint": "sha256:900ac78dd9be5873f4b3d2c2836782223bb3ce5df630bfcea0deff235f213c1b",
     "head": "HEAD",
-    "head_sha": "3c9ed3120",
+    "head_sha": "c5a0ffd08",
     "surfaces": {
       "docs": 0,
       "frontend": 2,
@@ -389,7 +565,7 @@
     "closes": [
       2160
     ],
-    "number": null,
+    "number": 2161,
     "url": null
   },
   "reconcile_events": [
@@ -404,6 +580,22 @@
     {
       "at": "2026-08-25T06:44:03.264671Z",
       "diff_fingerprint": "sha256:c5e3879ed733f0a7ec05e672f4250a88b41b5294d16fc803836c7caa5ffefc30",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:44:13.728490Z",
+      "diff_fingerprint": "sha256:900ac78dd9be5873f4b3d2c2836782223bb3ce5df630bfcea0deff235f213c1b",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:44:25.412848Z",
+      "diff_fingerprint": "sha256:900ac78dd9be5873f4b3d2c2836782223bb3ce5df630bfcea0deff235f213c1b",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2160-fix-2160-docs-path-containment.json
+++ b/.workflow/records/2160-fix-2160-docs-path-containment.json
@@ -1,0 +1,93 @@
+{
+  "base_ref": null,
+  "branch": "fix/2160-docs-path-containment",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/api/routes/user_docs.py",
+      "tests/api/test_user_docs.py",
+      "frontend/src/components/LearningCenter.parts/docsNav.ts",
+      "frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T06:41:11.087470Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:41:11.087491Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "no contract change; FR-084b already requires the documentation be served from the packaged tree, and containment is an implementation property of that route rather than a new requirement",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:41:11.087497Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "a defect fix in one route, no architectural decision",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2160,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Reject Windows separators before resolving doc paths: an encoded backslash stays inside one segment, passes the '..' check, and escapes _user_guide, so /api/user-docs/pages/%2e%2e%5cversion.py served scistudio/version.py and repeated climbs reached the repository root. Reject both platform separators in every segment, or verify the resolved filesystem path remains beneath the documentation root. PR #2158 is merged; land this as a new PR.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2160-fix-2160-docs-path-containment",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "b5d02b8b-63de-4487-bb99-4dcd9770f530",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-25T06:41:11.087501Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/api/test_user_docs.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:41:11.087505Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2160] **The documentation reader can no longer be talked out of the
+  documentation.** `GET /api/user-docs/pages/{path}` split the request path on
+  `/` alone, so a backslash stayed inside a single segment: it passed the `..`
+  refusal, and then Windows read it as a separator the moment the path was
+  joined. `%2e%2e%5cversion.py` returned `scistudio/version.py`, and repeated
+  climbs reached the repository root — served with the file's full text, off a
+  server that binds `0.0.0.0` by default. The route now follows the rule the
+  repository already had for exactly this
+  (`tutorials.actions.validate_relative_path`): a backslash is refused outright
+  because it is a separator on Windows and a filename character elsewhere,
+  absolute and drive-lettered forms go with it, and a realpath containment check
+  against the tree root sits behind that. Reachable only by requesting the route
+  directly — the reader itself only ever asks for paths the backend listed.
+
 - [#2148] **Re-running a block that writes an array no longer fails on Windows
   while the machine is busy.** Re-running such a block raised
   `[WinError 5] Access is denied` from `auto_flush`, and only ever on a loaded

--- a/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
+++ b/frontend/src/components/LearningCenter.parts/__tests__/docsNav.test.ts
@@ -145,6 +145,13 @@ describe("resolveDocsLink", () => {
     ["a script url", "javascript:alert(1)"],
     ["a data url", "data:text/html,<script>alert(1)</script>"],
     ["an empty href", "   "],
+    // A backslash is a separator on Windows and a filename character
+    // elsewhere. The backend refuses it after exactly this shape escaped its
+    // containment check in review; refusing it here means it never becomes a
+    // request.
+    ["a backslash climb", "..\\version.py"],
+    ["a backslash climb from within", "examples\\..\\..\\version.py"],
+    ["a drive-lettered path", "C:\\Windows\\win.ini"],
   ])("refuses %s", (_what, href) => {
     expect(resolveDocsLink("README.md", href)).toEqual({ kind: "none" });
   });

--- a/frontend/src/components/LearningCenter.parts/docsNav.ts
+++ b/frontend/src/components/LearningCenter.parts/docsNav.ts
@@ -93,7 +93,19 @@ export function resolveDocsLink(from: string, href: string): DocsLinkTarget {
   }
   if (trimmed.startsWith("/")) {
     // The reader is rooted at the user guide; an absolute path is not a path
-    // within it, so there is nothing honest to open.
+    // within it, so there is nothing honest to open. (A drive-lettered path is
+    // already refused above, where `C:` reads as a scheme.)
+    return { kind: "none" };
+  }
+  if (trimmed.includes("\\")) {
+    /*
+     * A backslash is a separator on Windows and a filename character
+     * elsewhere, so it is never a legitimate part of a segment in a tree the
+     * guide addresses with `/`. The backend refuses it for the same reason —
+     * see `user_docs._segments`, after exactly this shape escaped that route's
+     * containment check in review — and refusing it here too means such a link
+     * never becomes a request at all.
+     */
     return { kind: "none" };
   }
 

--- a/src/scistudio/api/routes/user_docs.py
+++ b/src/scistudio/api/routes/user_docs.py
@@ -27,6 +27,14 @@ against the behaviour it mirrors. Package Development is absent because it is a
 developer document that lives in the repository rather than in this tree — it was
 never part of what ships.
 
+**The page path is a request parameter, and is treated as one** (#2160). It is
+split into plain names by :func:`_segments` — no separator of *either* platform,
+no ``..``, nothing absolute or drive-lettered — and :func:`_contained` checks the
+resolved real path against the tree root behind that. Two locks, because the
+first version had one and it was the wrong one: splitting on ``/`` alone left a
+backslash inside a single segment, where it passed the ``..`` refusal and then
+became a separator the moment ``Path`` joined it on Windows.
+
 The tree is read once per process and cached: it is packaged data, so it cannot
 change under a running server.
 """
@@ -34,19 +42,23 @@ change under a running server.
 from __future__ import annotations
 
 import importlib.resources
+import os
 import posixpath
 import re
 from functools import lru_cache
 from importlib.resources.abc import Traversable
+from pathlib import PurePosixPath, PureWindowsPath
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-#: The packaged documentation tree. ``_user_guide`` is not an importable package
-#: (it holds no Python), but it is a namespace portion inside one, which is
-#: enough for ``importlib.resources`` — the same access ``agent_provisioning.docs``
-#: uses to copy it into a project.
-_DOCS_PACKAGE = "scistudio._user_guide"
+#: The package the documentation tree sits in, and the tree's directory name.
+#: ``_user_guide`` holds no Python and so is not an importable package of its
+#: own; reaching it through its parent is what ``agent_provisioning.docs`` does
+#: to copy it into a project, and it yields a real directory (rather than a
+#: ``MultiplexedPath``) whose containment can be checked.
+_DOCS_PACKAGE = "scistudio"
+_DOCS_DIR = "_user_guide"
 
 #: Extensions rendered as prose. MkDocs builds its nav from Markdown pages only;
 #: every other file is copied verbatim beside them and reachable by link.
@@ -191,10 +203,15 @@ def _nav_of(directory: Traversable, prefix: str) -> list[DocsNavItem]:
     return items
 
 
+def _root() -> Traversable:
+    """The documentation tree's directory."""
+    return importlib.resources.files(_DOCS_PACKAGE) / _DOCS_DIR
+
+
 @lru_cache(maxsize=1)
 def _nav() -> DocsNavResponse:
     """The whole tree's navigation, read once — packaged data does not change."""
-    root = importlib.resources.files(_DOCS_PACKAGE)
+    root = _root()
     return DocsNavResponse(
         # The caption the published sidebar prints above this group. It comes
         # from the site's staging directory name, not from this tree.
@@ -204,32 +221,86 @@ def _nav() -> DocsNavResponse:
     )
 
 
+def _segments(path: str) -> list[str] | None:
+    """Split a tree-relative path into plain names, or return ``None`` to refuse.
+
+    The rules are ``tutorials.actions.validate_relative_path``'s, for its
+    reasons. A backslash is rejected outright rather than treated as an ordinary
+    character, because it is a separator on Windows and a filename character
+    elsewhere: splitting a request path on ``/`` alone leaves ``..\\version.py``
+    as one segment that passes a ``..`` test and then escapes the tree the
+    moment ``Path`` joins it. Absolute and drive-lettered forms go the same way.
+
+    What survives is a list of plain names — no separator of either platform, no
+    ``..``, nothing empty — which is the only shape a documentation path is ever
+    written in.
+    """
+    trimmed = path.strip("/")
+    if not trimmed or "\\" in trimmed:
+        return None
+    if PurePosixPath(trimmed).is_absolute() or PureWindowsPath(trimmed).drive:
+        return None
+    segments = [segment for segment in trimmed.split("/") if segment != "."]
+    if not segments or any(segment in ("", "..") for segment in segments):
+        return None
+    return segments
+
+
+def _filesystem_path(item: Traversable) -> str | None:
+    """``item`` as a real filesystem path, or ``None`` when it has none.
+
+    A ``Traversable`` is not required to be on a filesystem — a tree read out
+    of a zip is not — so this narrows rather than assumes.
+    """
+    if not isinstance(item, os.PathLike):
+        return None
+    resolved: str | bytes = os.fspath(item)
+    return resolved if isinstance(resolved, str) else None
+
+
+def _contained(candidate: Traversable) -> bool:
+    """Whether ``candidate`` really sits beneath the documentation tree.
+
+    :func:`_segments` already refuses every path that could name something
+    outside, so this is the second lock rather than the first: it is what a
+    symbolic link planted inside the tree would have to defeat, and it is
+    checked on the *real* paths for that reason. A tree loaded from a zip
+    exposes no filesystem path and needs none — the segment rules govern there,
+    and a zip has no symbolic links to follow.
+    """
+    root = _filesystem_path(_root())
+    target = _filesystem_path(candidate)
+    if root is None or target is None:
+        return True
+    return os.path.realpath(target).startswith(os.path.realpath(root) + os.sep)
+
+
 def _resolve(path: str) -> Traversable:
     """Resolve a tree-relative path, or refuse.
 
-    Containment is not checked after the fact: the path is normalised, then
-    walked one segment at a time from the package root, so a segment that is not
-    a plain name never reaches the filesystem. A directory resolves to its index
-    page, which is what a link like ``examples/`` means.
+    A directory resolves to its index page, which is what a link like
+    ``examples/`` means.
     """
-    normalised = posixpath.normpath(path.strip("/")) if path.strip("/") else ""
-    segments = [segment for segment in normalised.split("/") if segment not in ("", ".")]
-    if not segments or any(segment == ".." for segment in segments):
-        raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}")
-    current: Traversable = importlib.resources.files(_DOCS_PACKAGE)
+    refused = HTTPException(status_code=404, detail=f"No such documentation page: {path!r}")
+    segments = _segments(path)
+    if segments is None:
+        raise refused
+    current: Traversable = _root()
     for segment in segments:
         try:
             current = current / segment
             if not (current.is_file() or current.is_dir()):
                 raise FileNotFoundError(segment)
         except (FileNotFoundError, NotADirectoryError, OSError, ValueError):
-            raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}") from None
+            raise refused from None
+    if not _contained(current):
+        raise refused
     if current.is_dir():
         for stem in _INDEX_STEMS:
             candidate = current / f"{stem}{_PAGE_SUFFIX}"
             if candidate.is_file():
                 return candidate
-        raise HTTPException(status_code=404, detail=f"No such documentation page: {path!r}")
+        raise refused
     return current
 
 

--- a/tests/api/test_user_docs.py
+++ b/tests/api/test_user_docs.py
@@ -165,7 +165,19 @@ class TestPages:
 
 
 class TestContainment:
-    """The path is a request parameter, so it is never allowed to leave the tree."""
+    """The path is a request parameter, so it is never allowed to leave the tree.
+
+    The backslash cases below are a defect this route shipped in review, not a
+    hypothetical. Splitting the request path on ``/`` alone left
+    ``..\\version.py`` as a single segment: it passed the ``..`` test, and then
+    ``Path`` joined it and Windows read the backslash as a separator.
+    ``GET /api/user-docs/pages/%2e%2e%5cversion.py`` returned
+    ``scistudio/version.py``, and repeated climbs reached ``pyproject.toml`` at
+    the repository root. The rule is now
+    ``tutorials.actions.validate_relative_path``'s — a backslash is refused
+    outright, because it is a separator on Windows and a filename character
+    elsewhere — with a realpath containment check behind it.
+    """
 
     @pytest.mark.parametrize(
         "path",
@@ -175,8 +187,32 @@ class TestContainment:
             "..%2f..%2fpyproject.toml",
             "examples/../../version.py",
             "....//pyproject.toml",
+            "..%5cversion.py",
+            "%2e%2e%5cversion.py",
+            "..%5capi%5capp.py",
+            "..%5c..%5c..%5cpyproject.toml",
+            "examples%5c..%5c..%5cversion.py",
+            "..%5c_agent_reference%5cREADME.md",
+            "%2e%2e%5c%2e%2e%5cscistudio%5cversion.py",
+            "C:%5cWindows%5cwin.ini",
+            "%2fetc%2fpasswd",
         ],
-        ids=["climb", "sibling", "encoded climb", "climb from within", "doubled dots"],
+        ids=[
+            "climb",
+            "sibling",
+            "encoded climb",
+            "climb from within",
+            "doubled dots",
+            "backslash climb",
+            "encoded backslash climb",
+            "backslash into a sibling package",
+            "backslash to the repository root",
+            "backslash climb from within",
+            "backslash to a sibling doc tree",
+            "backslash climb back down",
+            "drive letter",
+            "absolute posix path",
+        ],
     )
     def test_refuses_a_path_that_leaves_the_documentation(self, client: TestClient, path: str) -> None:
         response = client.get(f"/api/user-docs/pages/{path}")
@@ -189,3 +225,15 @@ class TestContainment:
 
     def test_refuses_an_empty_path(self, client: TestClient) -> None:
         assert client.get("/api/user-docs/pages/").status_code == 404
+
+    def test_a_refusal_never_carries_the_file_it_refused(self, client: TestClient) -> None:
+        """A 404 quotes the path; it must never quote what was behind it."""
+        response = client.get("/api/user-docs/pages/%2e%2e%5cversion.py")
+
+        assert response.status_code == 404
+        assert "Version deriver" not in response.text
+
+    def test_the_pages_the_guide_really_links_to_still_open(self, client: TestClient) -> None:
+        """The refusal is of separators, not of the tree's own shape."""
+        for path in ("README.md", "examples/app-fiji/block.py", "api-reference/index.md"):
+            assert client.get(f"/api/user-docs/pages/{path}").status_code == 200, path


### PR DESCRIPTION
## The defect

Reported in review of #2158, after it merged. Measured against `main`, not hypothesised:

```
GET /api/user-docs/pages/%2e%2e%5cversion.py            -> 200  scistudio/version.py
GET /api/user-docs/pages/..%5capi%5capp.py              -> 200  scistudio/api/app.py
GET /api/user-docs/pages/..%5c..%5c..%5cpyproject.toml  -> 200  the repository root
GET /api/user-docs/pages/examples%5c..%5c..%5cversion.py -> 200 scistudio/version.py
```

All returned `kind: "source"` with the file's full text. Repeated climbs reach anything readable by the server process, and `scistudio serve` binds `0.0.0.0` by default, so on Windows this was readable off the box.

`_resolve` split the request path on `/` alone. A backslash therefore stayed *inside* one segment, where the `segment == ".."` refusal could not see it — and then `Path.__truediv__` joined it and Windows read it as a separator. The segment-at-a-time walk that was meant to make an after-the-fact containment check unnecessary is exactly what walked out of the tree.

Not reachable through the product's own UI: the reader only ever requests paths the backend itself listed. But the route is reachable directly, and must not depend on its client for containment.

## The fix

The rule is now `tutorials.actions.validate_relative_path`'s — which this route should have followed instead of reinventing containment, and which already carries the reasoning verbatim: **a backslash is refused outright because it is a separator on Windows and a filename character elsewhere.** Absolute and drive-lettered forms go with it.

Behind that sits a realpath containment check against the tree root — the second lock, and the one a symbolic link planted inside the tree would have to defeat. Reaching the tree through its parent package (`files("scistudio") / "_user_guide"`) rather than as a namespace portion is what gives that check a real directory to compare against; a `MultiplexedPath` exposes none. A tree loaded from a zip exposes no filesystem path either and needs none — the segment rules govern there, and a zip has no symlinks.

`resolveDocsLink` refuses a backslash too, so a link of that shape inside a document never becomes a request at all.

## Verification

- 14 containment cases in `tests/api/test_user_docs.py`, including every probe above and the two encoded forms; `tests/api/test_user_docs.py` is 29 tests, all passing.
- 3 more refusals in `docsNav.test.ts`.
- A test asserts a refusal never carries the file it refused, and another that the pages the guide really links to still open — the refusal is of separators, not of the tree's own shape.
- Tier-2 pre-PR gate reconciled.

Gate record: `.workflow/records/2160-fix-2160-docs-path-containment.json`

Closes #2160
