### PR TITLE
chore(#2162): bump version to 0.3.4 (alpha) and unblock the runtime build

### DIFF
--- a/.github/workflows/desktop-linux-appimage.yml
+++ b/.github/workflows/desktop-linux-appimage.yml
@@ -59,6 +59,13 @@ jobs:
         run: npm --prefix desktop ci
 
       - name: Build portable Python runtime
+        # #2162: the runtime build asks the GitHub releases API which
+        # python-build-standalone asset to fetch. Unauthenticated that call draws
+        # on a rate limit shared by every Actions runner on the same egress IP,
+        # which is how a macOS build failed 0.24s in with HTTP 403. The token is
+        # only used for that query, never for the asset download.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: npm --prefix desktop run build:python:linux
 
       # #1908: An OTA channel enables launch-time update checks against that

--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -78,6 +78,13 @@ jobs:
         run: npm --prefix desktop ci
 
       - name: Build portable Python runtime
+        # #2162: the runtime build asks the GitHub releases API which
+        # python-build-standalone asset to fetch. Unauthenticated that call draws
+        # on a rate limit shared by every Actions runner on the same egress IP,
+        # which is how a macOS build failed 0.24s in with HTTP 403. The token is
+        # only used for that query, never for the asset download.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: npm --prefix desktop run build:python:mac
 
       # #1908: An OTA channel enables launch-time update checks against that

--- a/.github/workflows/desktop-windows-installer.yml
+++ b/.github/workflows/desktop-windows-installer.yml
@@ -58,6 +58,13 @@ jobs:
         run: npm --prefix desktop ci
 
       - name: Build portable Python runtime
+        # #2162: the runtime build asks the GitHub releases API which
+        # python-build-standalone asset to fetch. Unauthenticated that call draws
+        # on a rate limit shared by every Actions runner on the same egress IP,
+        # which is how a macOS build failed 0.24s in with HTTP 403. The token is
+        # only used for that query, never for the asset download.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: npm --prefix desktop run build:python
 
       # #1908: An OTA channel enables launch-time update checks against that

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -1,0 +1,76 @@
+{
+  "base_ref": null,
+  "branch": "guided/2162-version-bump-0-3-4",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_version.py",
+      "pyproject.toml",
+      "desktop/package.json",
+      "desktop/package-lock.json",
+      "frontend/package.json",
+      "frontend/package-lock.json",
+      "tests/packaging/test_version_alignment.py",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T06:50:59.492993Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/user/reference/index.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2162,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Bump the version to 0.3.4, then build a fresh release installer for each of the three platforms, then push the update to users from the latest remote main. Owner agreed the installer is stamped build 30.",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2162-version-bump-0-3-4",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:50:59.492963Z",
+      "pattern": "docs/user/reference/**",
+      "reason": "The API reference carries the version in its header and is generated, with a 'Do not hand-edit; regenerate' banner, so the bump requires running scripts/docs/build_reference.py rather than editing the line. That regeneration also swept in pre-existing drift: src/scistudio/_user_guide/api-reference/scistudio.tutorials.md was stale on main and gained step_entered_at, rendered_plots and ui_events_with_targets, which are real API additions from the tutorials work. The docs/user/reference/ copy was already current, so the two generated trees had diverged. Six files, +23/-8 in total. Declaring it rather than hand-trimming the generator output, which the banner forbids."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:50:59.492984Z",
+      "pattern": "src/scistudio/_user_guide/api-reference/**",
+      "reason": "The API reference carries the version in its header and is generated, with a 'Do not hand-edit; regenerate' banner, so the bump requires running scripts/docs/build_reference.py rather than editing the line. That regeneration also swept in pre-existing drift: src/scistudio/_user_guide/api-reference/scistudio.tutorials.md was stale on main and gained step_entered_at, rendered_plots and ui_events_with_targets, which are real API additions from the tutorials work. The docs/user/reference/ copy was already current, so the two generated trees had diverged. Six files, +23/-8 in total. Declaring it rather than hand-trimming the generator output, which the banner forbids."
+    }
+  ],
+  "session_id": "240bf74d-8c15-4973-b645-2849df412187",
+  "strictness_tier": null,
+  "task_kind": "guided",
+  "test_events": []
+}

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -461,6 +461,12 @@
       "at": "2026-08-25T07:17:47.655301Z",
       "pattern": ".github/workflows/desktop-windows-installer.yml",
       "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:23:00.787859Z",
+      "pattern": "scripts/version.py",
+      "reason": "version.py sync writes every manifest with Path.write_text and no explicit newline, so on Windows it emits CRLF. Git normalises that on commit and CI never sees it, but the local gate's frontend check runs prettier against the working tree and fails on frontend/package.json -- reading as a formatting fault in a file nobody hand-edited. Forcing newline LF fixes it at the source. Worth recording how this was diagnosed: I reached the right answer first, then withdrew it after a measurement that used grep -c with an unescaped carriage return, which in Git Bash counts lines containing the letter r rather than CR. Two independent bad measurements later, a byte-level check settled it. The fix is verified by round-tripping a real rewrite and confirming every manifest comes out LF."
     }
   ],
   "session_id": "240bf74d-8c15-4973-b645-2849df412187",

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -1,7 +1,174 @@
 {
   "base_ref": null,
   "branch": "guided/2162-version-bump-0-3-4",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-25T06:52:25.856203Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:63771860ba97b251b5ee24f7032178da479cc6137c8768fb08a738d278d693ee",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:52:27.246882Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:93e054f508055e69156d406519e41f084120b1800aaabfd292df7bea42e6c71a",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:52:27.274779Z",
+      "command": "ruff format src/scistudio/_version.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:875b6e4fd9cf6cea12f221deb439821470f0a1e017c98a8d6aeddf4f4db08bd2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:52:53.605921Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:fee3029a2cfd48048f8524d84192d443d5822662e9e5d2c8594b8167010ed692",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:53:06.061860Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:95e3ec46221113e88f69f90379d1eb39c76cf796f0a8d0085a4f16f4f2b4f1f4",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:53:06.516769Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:04839d8df899cfbc32e15be0ddcc753a011e6caa49b6c483146aae9c4ccd5134",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:53:06.538623Z",
+      "command": "ruff check src/scistudio/_version.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e56a7aff346b55f43b524b3a739309b66867559bbf1803f765daacee35a06a0d",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:59:48.690774Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5eacc7c936e835a964dad833c1824c43aa4d22c0bd2c602ed68122435268cf49",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:59:49.388871Z",
+      "command": "mypy src/scistudio/_version.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dbe3694f2582c201b653448bd538b21be13d6c33a9307383689bfc078595c60e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-25T07:00:04.201365Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9906504e95ba752016a879b45930bff519a87f962f618e0aa55f0fb2909604e",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -17,7 +184,13 @@
       "CHANGELOG.md"
     ]
   },
-  "directive_events": [],
+  "directive_events": [
+    {
+      "at": "2026-08-25T07:17:47.655275Z",
+      "owner_directive": "The macOS build failed before signing on an unauthenticated GitHub API 403. Fix it and commit it together with this PR.",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    }
+  ],
   "docs_events": [
     {
       "at": "2026-08-25T06:50:59.492993Z",
@@ -28,8 +201,119 @@
       "verified_in_diff": null
     }
   ],
-  "governance_touch": false,
-  "guard_events": [],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-25T07:00:04.237756Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.250835Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.264805Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.277716Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.317659Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.331065Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "pyproject.toml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": "pyproject.toml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-25T07:00:04.343938Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.356803Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.369368Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.382362Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:00:04.395105Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -39,19 +323,93 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "0a334b3c1",
+    "changed_files": [
+      ".workflow/records/2162-version-bump-0-3-4.json",
+      "desktop/package-lock.json",
+      "desktop/package.json",
+      "docs/user/reference/index.md",
+      "docs/user/reference/scistudio.tutorials.md",
+      "frontend/package-lock.json",
+      "frontend/package.json",
+      "pyproject.toml",
+      "src/scistudio/_user_guide/api-reference/index.md",
+      "src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md",
+      "src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md",
+      "src/scistudio/_user_guide/api-reference/scistudio.tutorials.md",
+      "src/scistudio/_version.py"
+    ],
+    "diff_fingerprint": "sha256:ba37fb2d34bc487976a24638cee72590e310060bf1936a77cd7935d550be394d",
+    "head": "HEAD",
+    "head_sha": "aa9af5fd4",
+    "surfaces": {
+      "docs": 2,
+      "frontend": 2,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 8,
+      "packaging": 1,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 7,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Bump the version to 0.3.4, then build a fresh release installer for each of the three platforms, then push the update to users from the latest remote main. Owner agreed the installer is stamped build 30.",
   "persona": "live_implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T07:00:04.395126Z",
+      "diff_fingerprint": "sha256:ba37fb2d34bc487976a24638cee72590e310060bf1936a77cd7935d550be394d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.frontend",
+        "guard.mod_guard",
+        "tests.changed_test_required"
+      ]
+    }
+  ],
   "record_id": "2162-version-bump-0-3-4",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check",
+      "wheel_release_smoke"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -67,10 +425,46 @@
       "at": "2026-08-25T06:50:59.492984Z",
       "pattern": "src/scistudio/_user_guide/api-reference/**",
       "reason": "The API reference carries the version in its header and is generated, with a 'Do not hand-edit; regenerate' banner, so the bump requires running scripts/docs/build_reference.py rather than editing the line. That regeneration also swept in pre-existing drift: src/scistudio/_user_guide/api-reference/scistudio.tutorials.md was stale on main and gained step_entered_at, rendered_plots and ui_events_with_targets, which are real API additions from the tutorials work. The docs/user/reference/ copy was already current, so the two generated trees had diverged. Six files, +23/-8 in total. Declaring it rather than hand-trimming the generator output, which the banner forbids."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655290Z",
+      "pattern": "desktop/scripts/build-python-runtime-macos.sh",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655295Z",
+      "pattern": "desktop/scripts/build-python-runtime-linux.sh",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655297Z",
+      "pattern": "desktop/scripts/build-python-runtime.ps1",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655298Z",
+      "pattern": ".github/workflows/desktop-macos-dmg.yml",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655300Z",
+      "pattern": ".github/workflows/desktop-linux-appimage.yml",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:17:47.655301Z",
+      "pattern": ".github/workflows/desktop-windows-installer.yml",
+      "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
     }
   ],
   "session_id": "240bf74d-8c15-4973-b645-2849df412187",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": []
 }

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -756,6 +756,12 @@
       "at": "2026-08-25T07:31:57.694433Z",
       "pattern": "tests/packaging/test_desktop_runtime_build_auth.py",
       "reason": "Two records. (1) tests/packaging/test_desktop_runtime_build_auth.py was recorded as a test path but never added to the declared scope, so the evaluator saw it as an unexplained changed file; it is the guard for the API-authentication fix folded into this PR. (2) python_tests classification plus the owner's preflight-skip authorization."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:44:40.743549Z",
+      "pattern": "scripts/docs/build_reference.py",
+      "reason": "CI's commit_hygiene check failed on end-of-file-fixer, naming exactly the six API-reference pages the version bump had forced a regeneration of. The generator never wrote a trailing newline; nothing noticed because nobody had regenerated those pages in a while, so the bump exposed a latent defect rather than introducing one. Fixed in the generator, not the output, because every page opens with a do-not-hand-edit banner and a manual newline would vanish on the next run. The same helper pins LF for the reason version.py needed it. Note on process: running pre-commit --all-files locally also 'fixed' 28 unrelated files across .specify/, .claude/skills/ and docs/, which were reverted -- CI named only the six, so those are working-tree artefacts, not repository state."
     }
   ],
   "session_id": "240bf74d-8c15-4973-b645-2849df412187",

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -167,9 +167,180 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:24:56.957675Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a7e509f681f91d5c178f0a2e573506ff616794dd513298c49921f706b128fff0",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:24:58.313245Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7db0555edd50fccc4d2f1b3eda0d02d768401235af612ab8965d3be962c1c996",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:24:58.339295Z",
+      "command": "ruff format scripts/version.py src/scistudio/_version.py tests/packaging/test_desktop_runtime_build_auth.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d8d63eff99118fc058c8b1a45d6bf947497ea0efb9a0f68d81ff2b24b41df00c",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T07:26:50.240388Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7193bd32ac17967ccfa6efd1125ef4221205e29a9f1c713066a1de02874721ab",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:27:01.351192Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e1680708952343c7f86eb997fa696f550e8b9abea3dce782eb453c69c5ee6dae",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:27:01.619181Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b7eb34d5300b2b1d1aae7eb6d0537881c9bbe2223a31d4c6e7cced9074e5418b",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:27:01.646212Z",
+      "command": "ruff check scripts/version.py src/scistudio/_version.py tests/packaging/test_desktop_runtime_build_auth.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:422606f4a7f8cf3cbad18e2bc62f5b8678557e4560ffd6c21b0016de2ca548c6",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T07:30:14.880463Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c80ce0d4321632bf92feb4d63eb73766601aa9dbd0c54298f3b0d686d65523ad",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:30:15.138686Z",
+      "command": "mypy src/scistudio/_version.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aab278fab9593c02b61caab54a06643c5fe97befa9607e9575ffa8041fb5717e",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "mypy": "2.1.0"
+      }
+    },
+    {
+      "at": "2026-08-25T07:30:26.602370Z",
+      "command": "python -m build --wheel",
+      "covered_surface": "packaging",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a4e7ba0db7d45271bd7b995d3d722bbda39afe3fd38ea0cbc806cf95a379c36a",
+      "name": "wheel_release_smoke",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/wheel_release_smoke.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Blocked by the tracked Windows local-mirror flake classes #2103 and #2107. 10 failed against 7209 passed, all in tests/api/test_system_vertical.py, tests/api/test_workflows.py and tests/api/test_tutorial_project_visibility.py -- the exact files those issues name. This diff touches no file under src/scistudio/api or src/scistudio/tutorials at all; its Python surface is scripts/version.py and a new packaging test. CI on Ubuntu is the authoritative gate. Owner authorized opening the PR with SCISTUDIO_SKIP_PREFLIGHT=1."
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -189,6 +360,11 @@
       "at": "2026-08-25T07:17:47.655275Z",
       "owner_directive": "The macOS build failed before signing on an unauthenticated GitHub API 403. Fix it and commit it together with this PR.",
       "reason": "Owner-directed scope expansion, and a governance_touch because the three desktop build workflows are governance-critical files. I flagged that this is a pre-existing main defect better suited to its own issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4 installers -- without it no platform can build at all. All three build scripts query the GitHub releases API unauthenticated, and none of the three workflows passes a token, so they draw on the shared per-IP rate limit that every Actions runner competes for. The macOS run failed 0.24s in with curl 56 / HTTP 403. That earlier builds succeeded is timing, not configuration. The fix sends an Authorization header only when a token is present, so a developer running the script locally without one is unaffected, and the asset download itself is untouched because browser_download_url is public CDN and needs no auth."
+    },
+    {
+      "at": "2026-08-25T07:31:57.694417Z",
+      "owner_directive": "Skip preflight and get this PR up quickly; the update is urgent.",
+      "reason": "Two records. (1) tests/packaging/test_desktop_runtime_build_auth.py was recorded as a test path but never added to the declared scope, so the evaluator saw it as an unexplained changed file; it is the guard for the API-authentication fix folded into this PR. (2) python_tests classification plus the owner's preflight-skip authorization."
     }
   ],
   "docs_events": [
@@ -312,6 +488,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.648338Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.663372Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.678142Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.692624Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.707105Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.727955Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.751988Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.767205Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.781337Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.795724Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:30:26.810437Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -327,35 +591,43 @@
     "base": "origin/main",
     "base_sha": "0a334b3c1",
     "changed_files": [
+      ".github/workflows/desktop-linux-appimage.yml",
+      ".github/workflows/desktop-macos-dmg.yml",
+      ".github/workflows/desktop-windows-installer.yml",
       ".workflow/records/2162-version-bump-0-3-4.json",
       "desktop/package-lock.json",
       "desktop/package.json",
+      "desktop/scripts/build-python-runtime-linux.sh",
+      "desktop/scripts/build-python-runtime-macos.sh",
+      "desktop/scripts/build-python-runtime.ps1",
       "docs/user/reference/index.md",
       "docs/user/reference/scistudio.tutorials.md",
       "frontend/package-lock.json",
       "frontend/package.json",
       "pyproject.toml",
+      "scripts/version.py",
       "src/scistudio/_user_guide/api-reference/index.md",
       "src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md",
       "src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md",
       "src/scistudio/_user_guide/api-reference/scistudio.tutorials.md",
-      "src/scistudio/_version.py"
+      "src/scistudio/_version.py",
+      "tests/packaging/test_desktop_runtime_build_auth.py"
     ],
-    "diff_fingerprint": "sha256:ba37fb2d34bc487976a24638cee72590e310060bf1936a77cd7935d550be394d",
+    "diff_fingerprint": "sha256:76768336b67f499e3cc745c17ce1272be0cdb626bd5e59d24448e8b13543e04b",
     "head": "HEAD",
-    "head_sha": "aa9af5fd4",
+    "head_sha": "3cf518563",
     "surfaces": {
       "docs": 2,
       "frontend": 2,
-      "governance": 1,
+      "governance": 4,
       "governed_docs": 0,
-      "implementation": 8,
+      "implementation": 11,
       "packaging": 1,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 7,
-      "test": 0,
-      "workflow_ci": 0
+      "sentrux": 11,
+      "test": 1,
+      "workflow_ci": 3
     }
   },
   "owner_directive": "Bump the version to 0.3.4, then build a fresh release installer for each of the three platforms, then push the update to users from the latest remote main. Owner agreed the installer is stamped build 30.",
@@ -372,6 +644,17 @@
         "checks.frontend",
         "guard.mod_guard",
         "tests.changed_test_required"
+      ]
+    },
+    {
+      "at": "2026-08-25T07:30:26.810469Z",
+      "diff_fingerprint": "sha256:76768336b67f499e3cc745c17ce1272be0cdb626bd5e59d24448e8b13543e04b",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "scope.out-of-scope"
       ]
     }
   ],
@@ -467,6 +750,12 @@
       "at": "2026-08-25T07:23:00.787859Z",
       "pattern": "scripts/version.py",
       "reason": "version.py sync writes every manifest with Path.write_text and no explicit newline, so on Windows it emits CRLF. Git normalises that on commit and CI never sees it, but the local gate's frontend check runs prettier against the working tree and fails on frontend/package.json -- reading as a formatting fault in a file nobody hand-edited. Forcing newline LF fixes it at the source. Worth recording how this was diagnosed: I reached the right answer first, then withdrew it after a measurement that used grep -c with an unescaped carriage return, which in Git Bash counts lines containing the letter r rather than CR. Two independent bad measurements later, a byte-level check settled it. The fix is verified by round-tripping a real rewrite and confirming every manifest comes out LF."
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T07:31:57.694433Z",
+      "pattern": "tests/packaging/test_desktop_runtime_build_auth.py",
+      "reason": "Two records. (1) tests/packaging/test_desktop_runtime_build_auth.py was recorded as a test path but never added to the declared scope, so the evaluator saw it as an unexplained changed file; it is the guard for the API-authentication fix folded into this PR. (2) python_tests classification plus the owner's preflight-skip authorization."
     }
   ],
   "session_id": "240bf74d-8c15-4973-b645-2849df412187",

--- a/.workflow/records/2162-version-bump-0-3-4.json
+++ b/.workflow/records/2162-version-bump-0-3-4.json
@@ -472,5 +472,22 @@
   "session_id": "240bf74d-8c15-4973-b645-2849df412187",
   "strictness_tier": 1,
   "task_kind": "guided",
-  "test_events": []
+  "test_events": [
+    {
+      "at": "2026-08-25T07:24:39.608986Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_runtime_build_auth.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T07:24:39.609007Z",
+      "class": "version-bump",
+      "kind": "na",
+      "path": null,
+      "rationale": "The bump itself is covered by tests/packaging/test_version_alignment.py, which reads the SSOT and is therefore version-agnostic by construction; it passes unmodified and editing it for each bump would be churn without signal. The API-authentication fix folded into this PR does get a new test.",
+      "verified_in_diff": null
+    }
+  ]
 }

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.3-alpha-build0000",
+  "version": "0.3.4-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-desktop",
-      "version": "0.3.3-alpha-build0000",
+      "version": "0.3.4-alpha-build0000",
       "devDependencies": {
         "electron": "42.2.0",
         "electron-builder": "26.15.3"

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-desktop",
-  "version": "0.3.3-alpha-build0000",
+  "version": "0.3.4-alpha-build0000",
   "private": true,
   "description": "SciStudio ADR-037 desktop MVP shell",
   "author": "SciStudio",

--- a/desktop/scripts/build-python-runtime-linux.sh
+++ b/desktop/scripts/build-python-runtime-linux.sh
@@ -35,9 +35,25 @@ esac
 
 mkdir -p "$CACHE_ROOT" "$RESOURCES_ROOT"
 
+# #2162: this API query is rate limited per egress IP when unauthenticated, and
+# every GitHub Actions runner shares that pool -- a macOS build died 0.24s in
+# with `curl: (56) ... 403` while earlier ones had succeeded, so the difference
+# was timing rather than configuration. A token raises the budget from 60
+# requests an hour per IP to 1000 per repository.
+#
+# Only the QUERY is authenticated. The download below uses browser_download_url,
+# which is public CDN and must not carry an Authorization header. The header is
+# omitted entirely when no token is set, so running this script locally works.
+GH_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 if [ ! -f "$ASSET_JSON" ]; then
-  curl -fsSL "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
-    -o "$ASSET_JSON"
+  if [ -n "$GH_API_TOKEN" ]; then
+    curl -fsSL -H "Authorization: Bearer $GH_API_TOKEN" \
+      "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+      -o "$ASSET_JSON"
+  else
+    curl -fsSL "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+      -o "$ASSET_JSON"
+  fi
 fi
 
 ASSET_URL="$(

--- a/desktop/scripts/build-python-runtime-macos.sh
+++ b/desktop/scripts/build-python-runtime-macos.sh
@@ -27,9 +27,25 @@ esac
 
 mkdir -p "$CACHE_ROOT" "$RESOURCES_ROOT"
 
+# #2162: this API query is rate limited per egress IP when unauthenticated, and
+# every GitHub Actions runner shares that pool -- a macOS build died 0.24s in
+# with `curl: (56) ... 403` while earlier ones had succeeded, so the difference
+# was timing rather than configuration. A token raises the budget from 60
+# requests an hour per IP to 1000 per repository.
+#
+# Only the QUERY is authenticated. The download below uses browser_download_url,
+# which is public CDN and must not carry an Authorization header. The header is
+# omitted entirely when no token is set, so running this script locally works.
+GH_API_TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
 if [ ! -f "$ASSET_JSON" ]; then
-  curl -fsSL "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
-    -o "$ASSET_JSON"
+  if [ -n "$GH_API_TOKEN" ]; then
+    curl -fsSL -H "Authorization: Bearer $GH_API_TOKEN" \
+      "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+      -o "$ASSET_JSON"
+  else
+    curl -fsSL "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" \
+      -o "$ASSET_JSON"
+  fi
 fi
 
 ASSET_URL="$(

--- a/desktop/scripts/build-python-runtime.ps1
+++ b/desktop/scripts/build-python-runtime.ps1
@@ -45,8 +45,22 @@ New-Item -ItemType Directory -Force -Path $ResourcesRoot | Out-Null
 if (-not (Test-Path $AssetJson)) {
     Write-Host "Querying python-build-standalone latest release"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    # #2162: this query is rate limited per egress IP when unauthenticated, and
+    # every GitHub Actions runner shares that pool -- a macOS build died 0.24s
+    # in with an HTTP 403 while earlier ones had succeeded, so the difference
+    # was timing rather than configuration. A token raises the budget from 60
+    # requests an hour per IP to 1000 per repository.
+    #
+    # Only the QUERY is authenticated; the download below uses the public
+    # browser_download_url and must not carry an Authorization header. With no
+    # token set the header is omitted, so a local run is unaffected.
+    $GhHeaders = @{ "User-Agent" = "scistudio-desktop-build" }
+    $GhToken = if ($env:GITHUB_TOKEN) { $env:GITHUB_TOKEN } else { $env:GH_TOKEN }
+    if ($GhToken) {
+        $GhHeaders["Authorization"] = "Bearer $GhToken"
+    }
     Invoke-WebRequest -Uri "https://api.github.com/repos/astral-sh/python-build-standalone/releases/latest" `
-        -Headers @{ "User-Agent" = "scistudio-desktop-build" } -OutFile $AssetJson
+        -Headers $GhHeaders -OutFile $AssetJson
 }
 
 $Release = Get-Content $AssetJson -Raw | ConvertFrom-Json

--- a/docs/user/reference/index.md
+++ b/docs/user/reference/index.md
@@ -26,4 +26,3 @@ A handful of public constants and type-aliases (a bare `str`, a `list[...]` or `
 - [`scistudio.previewers.models`](scistudio.previewers.models.md) — 21 public symbols (17 stability-marked)
 - [`scistudio.previewers.data_access`](scistudio.previewers.data_access.md) — 11 public symbols (11 stability-marked)
 - [`scistudio.tutorials`](scistudio.tutorials.md) — 16 public symbols (14 stability-marked)
-

--- a/docs/user/reference/index.md
+++ b/docs/user/reference/index.md
@@ -2,7 +2,7 @@
 
 # SciStudio API Reference
 
-**Version:** `0.3.3a0` — single-version reference for this release (ADR-052 §7; multi-version hosting via `mike` is a tracked follow-up, #1817).
+**Version:** `0.3.4a0` — single-version reference for this release (ADR-052 §7; multi-version hosting via `mike` is a tracked follow-up, #1817).
 
 This reference is **generated** from the public API's docstrings and the `scistudio.stability` decorators (ADR-052 §7). It contains only the public surface — the symbols declared in each canonical root's `__all__`; `internal` symbols are excluded. Do not hand-edit; regenerate with `scripts/docs/build_reference.py`.
 
@@ -26,3 +26,4 @@ A handful of public constants and type-aliases (a bare `str`, a `list[...]` or `
 - [`scistudio.previewers.models`](scistudio.previewers.models.md) — 21 public symbols (17 stability-marked)
 - [`scistudio.previewers.data_access`](scistudio.previewers.data_access.md) — 11 public symbols (11 stability-marked)
 - [`scistudio.tutorials`](scistudio.tutorials.md) — 16 public symbols (14 stability-marked)
+

--- a/docs/user/reference/scistudio.blocks.app.md
+++ b/docs/user/reference/scistudio.blocks.app.md
@@ -97,4 +97,3 @@ Public surface — every symbol below is declared in this module's `__all__` (7 
       members_order: source
       filters: ["!^_"]
       show_labels: false
-

--- a/docs/user/reference/scistudio.blocks.base.md
+++ b/docs/user/reference/scistudio.blocks.base.md
@@ -177,4 +177,3 @@ Public surface — every symbol below is declared in this module's `__all__` (13
       members_order: source
       filters: ["!^_"]
       show_labels: false
-

--- a/docs/user/reference/scistudio.blocks.code.md
+++ b/docs/user/reference/scistudio.blocks.code.md
@@ -812,4 +812,3 @@ Public surface — every symbol below is declared in this module's `__all__` (60
       members_order: source
       filters: ["!^_"]
       show_labels: false
-

--- a/docs/user/reference/scistudio.blocks.io.md
+++ b/docs/user/reference/scistudio.blocks.io.md
@@ -163,4 +163,3 @@ Public surface — every symbol below is declared in this module's `__all__` (12
       heading_level: 4
       members_order: source
       filters: ["!^_"]
-

--- a/docs/user/reference/scistudio.blocks.process.md
+++ b/docs/user/reference/scistudio.blocks.process.md
@@ -18,4 +18,3 @@ Public surface — every symbol below is declared in this module's `__all__` (1 
       heading_level: 4
       members_order: source
       filters: ["!^_"]
-

--- a/docs/user/reference/scistudio.core.meta.md
+++ b/docs/user/reference/scistudio.core.meta.md
@@ -45,4 +45,3 @@ Public surface — every symbol below is declared in this module's `__all__` (3 
       members_order: source
       filters: ["!^_"]
       show_labels: false
-

--- a/docs/user/reference/scistudio.core.types.md
+++ b/docs/user/reference/scistudio.core.types.md
@@ -135,4 +135,3 @@ Public surface — every symbol below is declared in this module's `__all__` (10
       heading_level: 4
       members_order: source
       filters: ["!^_"]
-

--- a/docs/user/reference/scistudio.previewers.data_access.md
+++ b/docs/user/reference/scistudio.previewers.data_access.md
@@ -148,4 +148,3 @@ Public surface — every symbol below is declared in this module's `__all__` (11
       heading_level: 4
       members_order: source
       filters: ["!^_"]
-

--- a/docs/user/reference/scistudio.previewers.models.md
+++ b/docs/user/reference/scistudio.previewers.models.md
@@ -282,4 +282,3 @@ Public surface — every symbol below is declared in this module's `__all__` (21
       heading_level: 4
       members_order: source
       filters: ["!^_"]
-

--- a/docs/user/reference/scistudio.tutorials.md
+++ b/docs/user/reference/scistudio.tutorials.md
@@ -217,3 +217,4 @@ Public surface — every symbol below is declared in this module's `__all__` (16
       members_order: source
       filters: ["!^_"]
       show_labels: false
+

--- a/docs/user/reference/scistudio.tutorials.md
+++ b/docs/user/reference/scistudio.tutorials.md
@@ -217,4 +217,3 @@ Public surface — every symbol below is declared in this module's `__all__` (16
       members_order: source
       filters: ["!^_"]
       show_labels: false
-

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.3-alpha-build0000",
+  "version": "0.3.4-alpha-build0000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scistudio-frontend",
-      "version": "0.3.3-alpha-build0000",
+      "version": "0.3.4-alpha-build0000",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scistudio-frontend",
-  "version": "0.3.3-alpha-build0000",
+  "version": "0.3.4-alpha-build0000",
   "private": true,
   "type": "module",
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "scistudio"
-version = "0.3.3a0"
+version = "0.3.4a0"
 description = "AI-native, inclusive workflow runtime for multimodal scientific data"
 readme = "README.md"
 license = {text = "Apache-2.0"}
@@ -492,7 +492,7 @@ ancestors = ["scistudio.ai.agent.mcp.tools_inspection"]
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.3.3a0"
+version = "0.3.4a0"
 tag_format = "v$version"
 
 # Issue #1340 / ADR-042 code-quality stack: vulture runs as an informational

--- a/scripts/docs/build_reference.py
+++ b/scripts/docs/build_reference.py
@@ -389,10 +389,10 @@ def generate_selfcontained() -> list[tuple[str, int]]:
     stats: list[tuple[str, int]] = []
     for root in CANONICAL_ROOTS:
         page, count = _sc_render_root_page(root)
-        (PACKAGE_REFERENCE_DIR / f"{root}.md").write_text(page, encoding="utf-8")
+        _write_page(PACKAGE_REFERENCE_DIR / f"{root}.md", page)
         stats.append((root, count))
         print(f"  [self-contained] wrote {root}.md  ({count} symbols)")
-    (PACKAGE_REFERENCE_DIR / "index.md").write_text(_sc_render_index(stats), encoding="utf-8")
+    _write_page(PACKAGE_REFERENCE_DIR / "index.md", _sc_render_index(stats))
     print(f"  [self-contained] wrote index.md  (version {_core_version()})")
     return stats
 
@@ -403,10 +403,10 @@ def generate() -> list[tuple[str, int, int]]:
     stats: list[tuple[str, int, int]] = []
     for root in CANONICAL_ROOTS:
         page, public_count, marked = _render_root_page(root)
-        (REFERENCE_DIR / f"{root}.md").write_text(page, encoding="utf-8")
+        _write_page(REFERENCE_DIR / f"{root}.md", page)
         stats.append((root, public_count, marked))
         print(f"  wrote {root}.md  ({public_count} public, {marked} marked)")
-    (REFERENCE_DIR / "index.md").write_text(_render_index(stats), encoding="utf-8")
+    _write_page(REFERENCE_DIR / "index.md", _render_index(stats))
     print(f"  wrote index.md  (version {_core_version()})")
     return stats
 
@@ -426,6 +426,27 @@ def build_strict() -> int:
     ]
     print(f"  $ {' '.join(cmd)}")
     return subprocess.call(cmd, cwd=str(REPO_ROOT))
+
+
+def _write_page(path: Path, text: str) -> None:
+    """Write a generated page the way the repository stores every other file.
+
+    Two properties the generator did not previously guarantee, both of which
+    surfaced only when a version bump forced a regeneration (#2162):
+
+    * a trailing newline, which pre-commit's end-of-file-fixer requires and
+      which the templates do not reliably produce;
+    * LF endings, because Path.write_text without an explicit newline uses the
+      platform default and a regeneration on Windows would otherwise rewrite
+      every page to CRLF.
+
+    Hand-fixing the output instead would not survive the next regeneration --
+    each page opens with "Do not hand-edit; regenerate".
+    """
+
+    if not text.endswith("\n"):
+        text += "\n"
+    path.write_text(text, encoding="utf-8", newline="\n")
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -34,6 +34,11 @@ if str(_SRC) not in sys.path:
 from scistudio import version as _v  # noqa: E402
 
 
+# #2162: every manifest this rewrites is stored LF. Path.write_text without an
+# explicit newline uses the platform default, so a sync on Windows writes CRLF.
+# Git normalises that away on commit -- CI never sees it -- but not before the
+# frontend's own `prettier --check` has failed against the working tree, which
+# reads as a formatting fault in a file nobody hand-edited.
 def _sync_pyproject(pep440: str) -> list[str]:
     """Rewrite the ``[project]`` and ``[tool.commitizen]`` versions (PEP 440)."""
     path = _REPO_ROOT / "pyproject.toml"
@@ -42,7 +47,7 @@ def _sync_pyproject(pep440: str) -> list[str]:
     # form; commitizen accepts PEP 440. These are the only `version = ` lines.
     new = re.sub(r'(?m)^version = ".*"$', f'version = "{pep440}"', text)
     if new != text:
-        path.write_text(new, encoding="utf-8")
+        path.write_text(new, encoding="utf-8", newline="\n")
         return ["pyproject.toml"]
     return []
 
@@ -55,7 +60,7 @@ def _sync_package_json(rel: str, semver: str) -> list[str]:
     text = path.read_text(encoding="utf-8")
     new = re.sub(r'("version"\s*:\s*)"[^"]*"', rf'\1"{semver}"', text, count=1)
     if new != text:
-        path.write_text(new, encoding="utf-8")
+        path.write_text(new, encoding="utf-8", newline="\n")
         return [rel]
     return []
 
@@ -73,7 +78,7 @@ def _sync_package_lock(rel: str, semver: str) -> list[str]:
     text = path.read_text(encoding="utf-8")
     new = re.sub(r'("version"\s*:\s*)"[^"]*"', rf'\1"{semver}"', text, count=2)
     if new != text:
-        path.write_text(new, encoding="utf-8")
+        path.write_text(new, encoding="utf-8", newline="\n")
         return [rel]
     return []
 
@@ -100,7 +105,7 @@ def cmd_set_channel(args: argparse.Namespace) -> int:
     if new == text and f'CHANNEL = "{channel}"' not in text:
         print(f"error: could not find CHANNEL assignment in {vpath}", file=sys.stderr)
         return 1
-    vpath.write_text(new, encoding="utf-8")
+    vpath.write_text(new, encoding="utf-8", newline="\n")
     # Reset the new channel's build counter to 0 (owner: build resets on channel
     # change). Absent counters already default to 0, but write it explicitly so
     # switching back to a previously-used channel also restarts at 0.

--- a/src/scistudio/_user_guide/api-reference/index.md
+++ b/src/scistudio/_user_guide/api-reference/index.md
@@ -2,7 +2,7 @@
 
 # SciStudio API reference
 
-**Version:** `0.3.3a0` (single-version for this release, ADR-052 §7).
+**Version:** `0.3.4a0` (single-version for this release, ADR-052 §7).
 
 The public API you may rely on, generated from the code's docstrings and `scistudio.stability` decorators. Only the public surface (each canonical root's `__all__`) appears; `internal` symbols are excluded. Import from the canonical root shown on each page, never a deeper module path.
 
@@ -24,3 +24,4 @@ The public API you may rely on, generated from the code's docstrings and `scistu
 - [`scistudio.previewers.models`](scistudio.previewers.models.md) — 21 symbols
 - [`scistudio.previewers.data_access`](scistudio.previewers.data_access.md) — 11 symbols
 - [`scistudio.tutorials`](scistudio.tutorials.md) — 16 symbols
+

--- a/src/scistudio/_user_guide/api-reference/index.md
+++ b/src/scistudio/_user_guide/api-reference/index.md
@@ -24,4 +24,3 @@ The public API you may rely on, generated from the code's docstrings and `scistu
 - [`scistudio.previewers.models`](scistudio.previewers.models.md) — 21 symbols
 - [`scistudio.previewers.data_access`](scistudio.previewers.data_access.md) — 11 symbols
 - [`scistudio.tutorials`](scistudio.tutorials.md) — 16 symbols
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.app.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.app.md
@@ -214,4 +214,3 @@ Raises:
 Example:
     >>> validate_app_command("python --version")
     ['python', '--version']
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.base.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.base.md
@@ -330,4 +330,3 @@ Args:
 Returns:
     The stored storage references as a tuple, empty when the block produced
     no intermediate.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md
@@ -1300,4 +1300,3 @@ Args:
 
 Returns:
     A list of diagnostics; empty when the configuration is valid.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.code.md
@@ -1300,3 +1300,4 @@ Args:
 
 Returns:
     A list of diagnostics; empty when the configuration is valid.
+

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.io.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.io.md
@@ -259,4 +259,3 @@ Example:
 - `load(self, config: 'BlockConfig', output_dir: 'str' = '') -> 'DataObject | Collection'` — _unmarked — see the module source / ADR-052_ — Always raises — a SimpleSaver cannot load.
 - `save(self, obj: 'DataObject | Collection', config: 'BlockConfig') -> 'None'` — _unmarked — see the module source / ADR-052_ — Validate the incoming object and write it to the configured path.
 - `save_file(self, obj: 'DataObject', path: 'Path', config: 'dict[str, Any]') -> 'None'` — `stable` · Since `0.3.1` — Write one object to *path*. Implement this in your saver.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.blocks.process.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.blocks.process.md
@@ -51,4 +51,3 @@ Example:
 - `teardown(self, state: 'Any') -> 'None'` — `stable` · Since `0.3.1` — Run once at the end of `run`, even if an item raised.
 - `process_item(self, item: 'Any', config: 'BlockConfig', state: 'Any' = None) -> 'Any'` — `stable` · Since `0.3.1` — Transform a single item; override this for the common case.
 - `run(self, inputs: 'dict[str, Collection]', config: 'BlockConfig') -> 'dict[str, Collection]'` — `stable` · Since `0.3.1` — Stream the primary input Collection through `process_item`.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.core.meta.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.core.meta.md
@@ -94,4 +94,3 @@ Example:
     (10, 2)
     >>> a.x, a.y  # original unchanged
     (1, 2)
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.core.types.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.core.types.md
@@ -343,4 +343,3 @@ Example:
 
 - `matches(self, other: 'TypeSignature') -> 'bool'` — `stable` · Since `0.3.1` — Return whether this type can stand in for *other*.
 - `from_type(cls, data_type: 'type') -> 'TypeSignature'` — `stable` · Since `0.3.1` — Build a `TypeSignature` from a `DataObject` subclass.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.previewers.data_access.md
@@ -176,4 +176,3 @@ TextChunk(content: 'str', truncated: 'bool', total_bytes: 'int', language: 'str'
 ```
 
 A bounded chunk of text plus a truncation marker.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md
@@ -422,4 +422,3 @@ class TargetKind(StrEnum)
 ```
 
 The kind of thing a `PreviewTarget` points at.
-

--- a/src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.previewers.models.md
@@ -422,3 +422,4 @@ class TargetKind(StrEnum)
 ```
 
 The kind of thing a `PreviewTarget` points at.
+

--- a/src/scistudio/_user_guide/api-reference/scistudio.tutorials.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.tutorials.md
@@ -98,7 +98,7 @@ differs, and evaluation is side-effect free (FR-055).
 
 ```python
 class DriverContext
-DriverContext(key: 'TutorialKey', tutorial_dir: 'Path', project_dir: 'Path | None', step_id: 'str | None', satisfied_step_ids: 'tuple[str, ...]' = ()) -> None
+DriverContext(key: 'TutorialKey', tutorial_dir: 'Path', project_dir: 'Path | None', step_id: 'str | None', satisfied_step_ids: 'tuple[str, ...]' = (), step_entered_at: 'str | None' = None) -> None
 ```
 
 Everything a driver is told about the session asking the question.
@@ -134,6 +134,7 @@ Every member is a pure read (FR-055).
 - `data_type_names(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
 - `previewer_type_ids(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
 - `plot_bindings(self) -> 'tuple[tuple[str, str, str], ...]'` — _unmarked — see the module source / ADR-052_ — ``(plot_id, node_id, output_port)`` for every plot that exists.
+- `rendered_plots(self) -> 'tuple[tuple[str, str, str, str], ...]'` — _unmarked — see the module source / ADR-052_ — ``(workflow_id, node_id, output_port, plot_id)`` for every plot with a rendered figure.
 - `run_records(self) -> 'tuple[RunSummary, ...]'` — _unmarked — see the module source / ADR-052_ — The recent runs, **most recent first**.
 - `port_has_output(self, node_id: 'str', port: 'str') -> 'bool'` — _unmarked — see the module source / ADR-052_
 - `git_branches(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
@@ -142,6 +143,7 @@ Every member is a pure read (FR-055).
 - `interactions_completed(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
 - `pages_reached(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
 - `ui_events(self) -> 'frozenset[str]'` — _unmarked — see the module source / ADR-052_
+- `ui_events_with_targets(self) -> 'frozenset[tuple[str, str]]'` — _unmarked — see the module source / ADR-052_ — ``(name, target)`` for every reported event that carried a target.
 
 ## `ReplayAction` — _class_
 
@@ -149,7 +151,7 @@ Every member is a pure read (FR-055).
 
 ```python
 class ReplayAction
-ReplayAction(surface: 'str', segments: 'tuple[ReplaySegment, ...]') -> None
+ReplayAction(surface: 'str', segments: 'tuple[ReplaySegment, ...]', continue_tab: 'bool' = False) -> None
 ```
 
 Replay scripted material into one named surface (FR-061, FR-061a, FR-061b).
@@ -165,7 +167,7 @@ text claiming a file was written cannot be read before the file exists.
 
 ```python
 class RunSummary
-RunSummary(run_id: 'str', workflow_id: 'str', succeeded: 'bool', succeeded_node_ids: 'frozenset[str]' = frozenset()) -> None
+RunSummary(run_id: 'str', workflow_id: 'str', succeeded: 'bool', succeeded_node_ids: 'frozenset[str]' = frozenset(), started_at: 'str | None' = None) -> None
 ```
 
 The read-only view of one recorded run that ``run_succeeded`` needs.
@@ -182,7 +184,7 @@ which nodes within it succeeded. The layer that satisfies
 
 ```python
 class StepView
-StepView(id: 'str', index: 'int', total: 'int', title: 'str | None' = None, say: 'str | None' = None, highlight: 'Mapping[str, Any] | None' = None, route_to: 'str | None' = None, prefill: 'tuple[Mapping[str, Any], ...]' = (), awaiting_continue: 'bool' = False, satisfied: 'bool' = False) -> None
+StepView(id: 'str', index: 'int', total: 'int', title: 'str | None' = None, say: 'tuple[str, ...]' = (), say_moods: 'tuple[str, ...]' = (), highlights: 'tuple[Mapping[str, Any] | None, ...]' = (), route_to: 'str | None' = None, prefill: 'tuple[Mapping[str, Any], ...]' = (), pages: 'tuple[str, ...]' = (), trigger: 'Mapping[str, Any] | None' = None, compacts: 'tuple[bool, ...]' = (), auto_advance: 'bool' = False, awaiting_continue: 'bool' = False, satisfied: 'bool' = False) -> None
 ```
 
 What one step looks like, for every driver alike (FR-040, FR-041).
@@ -243,7 +245,7 @@ leaves every other tutorial listed and startable (FR-044).
 Three properties are worth knowing before writing one, because each removes
 work rather than adding it:
 
-* **Core owns rendering.** Whatever `step_view` returns is normalised
+* **Core owns rendering.** Whatever `step_view` returns is normalized
   through `StepView.of` at the boundary, so extra attributes and extra
   mapping keys are dropped rather than reaching a response (FR-041). A
   driver cannot introduce a display primitive or ship a frontend asset, and
@@ -349,7 +351,7 @@ destination is overwritten (spec §2 Edge Cases).
 **Stability:** `provisional` · Since `0.3.4`
 
 ```python
-evaluate(condition: 'Condition', state: 'ProductState') -> 'bool'
+evaluate(condition: 'Condition', state: 'ProductState', *, entered_at: 'str | None' = None) -> 'bool'
 ```
 
 Judge ``condition`` against ``state``.
@@ -357,6 +359,13 @@ Judge ``condition`` against ``state``.
 Side-effect free (FR-055): no file is created, no registry is mutated, no
 run is triggered. Called on step entry (FR-054), on a mapped event
 (FR-050), and on an explicit request (FR-053) — never on a timer (FR-051).
+
+``entered_at`` is FR-046's session-supplied evaluation context (#2066): the
+ISO-8601 time the current step was entered, which the two run terms read
+when a condition declares ``since_step_entry: true``. It is context rather
+than product state because product state describes the world and this
+describes the reader's position in the tutorial — only the session knows
+it, and the session hands it in per evaluation.
 
 ## `parse_condition` — _function_
 
@@ -371,3 +380,4 @@ Parse a ``done_when`` mapping, rejecting anything outside the vocabulary.
 The accepted shape is a single-key mapping: ``{term: {args}}`` for a term,
 ``{all: [condition, ...]}`` or ``{any: [...]}`` for a combinator. Called at
 manifest validation (FR-049), never at evaluation.
+

--- a/src/scistudio/_user_guide/api-reference/scistudio.tutorials.md
+++ b/src/scistudio/_user_guide/api-reference/scistudio.tutorials.md
@@ -380,4 +380,3 @@ Parse a ``done_when`` mapping, rejecting anything outside the vocabulary.
 The accepted shape is a single-key mapping: ``{term: {args}}`` for a term,
 ``{all: [condition, ...]}`` or ``{any: [...]}`` for a combinator. Called at
 manifest validation (FR-049), never at evaluation.
-

--- a/src/scistudio/_version.py
+++ b/src/scistudio/_version.py
@@ -15,7 +15,7 @@ Keep this module import-cheap and dependency-free: it is imported very early
 from __future__ import annotations
 
 #: Base semantic version ``a.b.c`` (no channel/build suffix).
-BASE_VERSION = "0.3.3"
+BASE_VERSION = "0.3.4"
 
 #: Release channel. One of ``"alpha"``, ``"beta"``, ``"stable"``.
 CHANNEL = "alpha"

--- a/tests/packaging/test_desktop_runtime_build_auth.py
+++ b/tests/packaging/test_desktop_runtime_build_auth.py
@@ -1,0 +1,95 @@
+"""The desktop runtime builds must authenticate their GitHub API query (#2162).
+
+All three build scripts ask the GitHub releases API which python-build-standalone
+asset to fetch. Unauthenticated, that call draws on a rate limit shared by every
+Actions runner on the same egress IP — 60 requests an hour for the whole pool —
+which is how a 0.3.4 macOS build died 0.24 seconds in with
+``curl: (56) ... 403``, before signing was even attempted. Earlier builds had
+succeeded, so the difference was timing rather than configuration: nothing about
+the repository changed, and nothing warned.
+
+These are source-level assertions because the alternative is a release build that
+fails on someone else's traffic. They cover both halves of the fix — the scripts
+sending the header, and the workflows actually passing a token, which none of
+them did.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPTS = REPO_ROOT / "desktop" / "scripts"
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+RELEASES_API = "api.github.com/repos/astral-sh/python-build-standalone/releases"
+
+SHELL_SCRIPTS = ("build-python-runtime-macos.sh", "build-python-runtime-linux.sh")
+BUILD_WORKFLOWS = (
+    "desktop-macos-dmg.yml",
+    "desktop-linux-appimage.yml",
+    "desktop-windows-installer.yml",
+)
+
+
+@pytest.mark.parametrize("name", SHELL_SCRIPTS)
+def test_shell_scripts_send_an_authorization_header(name: str) -> None:
+    body = (SCRIPTS / name).read_text(encoding="utf-8")
+    assert RELEASES_API in body, f"{name} no longer queries the releases API"
+    assert "Authorization: Bearer" in body, f"{name} queries the API unauthenticated"
+
+
+def test_powershell_script_sends_an_authorization_header() -> None:
+    body = (SCRIPTS / "build-python-runtime.ps1").read_text(encoding="utf-8")
+    assert RELEASES_API in body, "the Windows script no longer queries the releases API"
+    assert 'Authorization" ] = "Bearer' in body or 'Authorization"] = "Bearer' in body, (
+        "the Windows script queries the API unauthenticated"
+    )
+
+
+@pytest.mark.parametrize("name", (*SHELL_SCRIPTS, "build-python-runtime.ps1"))
+def test_scripts_still_run_without_a_token(name: str) -> None:
+    """A developer running these locally has no token; the header must be optional.
+
+    Making the header unconditional would trade a CI failure for a local one.
+    """
+    body = (SCRIPTS / name).read_text(encoding="utf-8")
+    assert "GITHUB_TOKEN" in body and "GH_TOKEN" in body, (
+        f"{name} should read both token variables"
+    )
+    # Some form of "only when set" guard has to be present.
+    assert re.search(r'if \[ -n "\$GH_API_TOKEN" \]|if \(\$GhToken\)', body), (
+        f"{name} must omit the header when no token is set"
+    )
+
+
+@pytest.mark.parametrize("name", BUILD_WORKFLOWS)
+def test_workflows_pass_a_token_to_the_runtime_build(name: str) -> None:
+    """The scripts can read a token, but Actions does not supply one by default."""
+    body = (WORKFLOWS / name).read_text(encoding="utf-8")
+    assert "build:python" in body, f"{name} no longer builds the runtime"
+    assert "GITHUB_TOKEN: ${{ github.token }}" in body, (
+        f"{name} does not pass a token to the runtime build step"
+    )
+
+
+@pytest.mark.parametrize("name", (*SHELL_SCRIPTS, "build-python-runtime.ps1"))
+def test_the_asset_download_stays_unauthenticated(name: str) -> None:
+    """Only the API query is authenticated.
+
+    The download uses ``browser_download_url``, which is public CDN; sending an
+    Authorization header there is at best pointless and at worst a redirect that
+    leaks the token to a third-party host.
+    """
+    body = (SCRIPTS / name).read_text(encoding="utf-8")
+    download_lines = [
+        line
+        for line in body.splitlines()
+        if ("ASSET_URL" in line or "AssetUrl" in line)
+        and ("curl" in line or "Invoke-WebRequest" in line or "WebClient" in line)
+    ]
+    for line in download_lines:
+        assert "Authorization" not in line, f"{name}: the asset download must not be authenticated"

--- a/tests/packaging/test_desktop_runtime_build_auth.py
+++ b/tests/packaging/test_desktop_runtime_build_auth.py
@@ -57,9 +57,7 @@ def test_scripts_still_run_without_a_token(name: str) -> None:
     Making the header unconditional would trade a CI failure for a local one.
     """
     body = (SCRIPTS / name).read_text(encoding="utf-8")
-    assert "GITHUB_TOKEN" in body and "GH_TOKEN" in body, (
-        f"{name} should read both token variables"
-    )
+    assert "GITHUB_TOKEN" in body and "GH_TOKEN" in body, f"{name} should read both token variables"
     # Some form of "only when set" guard has to be present.
     assert re.search(r'if \[ -n "\$GH_API_TOKEN" \]|if \(\$GhToken\)', body), (
         f"{name} must omit the header when no token is set"
@@ -71,9 +69,7 @@ def test_workflows_pass_a_token_to_the_runtime_build(name: str) -> None:
     """The scripts can read a token, but Actions does not supply one by default."""
     body = (WORKFLOWS / name).read_text(encoding="utf-8")
     assert "build:python" in body, f"{name} no longer builds the runtime"
-    assert "GITHUB_TOKEN: ${{ github.token }}" in body, (
-        f"{name} does not pass a token to the runtime build step"
-    )
+    assert "GITHUB_TOKEN: ${{ github.token }}" in body, f"{name} does not pass a token to the runtime build step"
 
 
 @pytest.mark.parametrize("name", (*SHELL_SCRIPTS, "build-python-runtime.ps1"))


### PR DESCRIPTION
Closes #2162

## What this does

Bumps the SSOT base version 0.3.3 → 0.3.4 (channel `alpha`) and re-syncs every
manifest from it with `python scripts/version.py sync`:

| | |
|---|---|
| `src/scistudio/_version.py` | `BASE_VERSION = "0.3.4"` |
| `pyproject.toml` | `0.3.4a0` |
| `desktop/package.json` + lock | `0.3.4-alpha-build0000` |
| `frontend/package.json` + lock | `0.3.4-alpha-build0000` |

The version-alignment test is version-agnostic — it reads the SSOT — so it
covers this bump without modification and passes.

## The API reference is regenerated, not edited

It carries the version in its header and opens with *"GENERATED by
`scripts/docs/build_reference.py`. Do not hand-edit; regenerate"*, so the bump
means running the generator.

That also swept in **pre-existing drift**:
`src/scistudio/_user_guide/api-reference/scistudio.tutorials.md` was stale on
`main` and gained `step_entered_at`, `rendered_plots` and
`ui_events_with_targets` — real API additions from the tutorials work — while
the `docs/user/reference/` copy was already current. The two generated trees had
diverged. Six files, +23/−8 in total. Declared in the ledger rather than
hand-trimmed, which the banner forbids.

## ⚠️ The installer must be stamped `build_number: 30`

Not the committed `build0000`. This is the part of the release that is easy to
get wrong and impossible to see afterwards.

`VERSION_RE` parses `0.3.4-alpha-build0000` to baseline build **0**, and
`resolveActivePatch` only discards a patch when
`baselineBuild >= pointer.build`. The live alpha channel is at build **25**, so
a `build0000` installer would leave every existing user's applied patch
**active** after installing 0.3.4 — shadowing the new backend with old code, and
carrying no `shell/` directory at all. The user would install the new version
and keep running the old one, silently.

`30` clears 25 with headroom: the migration notice patch takes 26, and ordinary
patches resume from 31.

Recorded in `docs/specs/desktop-shell-ota-hot-update.md` section 8.

## What follows this PR

1. Configure the five macOS signing secrets (owner; `MACOS_CSC_LINK`,
   `MACOS_CSC_KEY_PASSWORD`, `APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`,
   `APPLE_API_ISSUER`). Without them the dmg builds **unsigned** and mac users
   still meet Gatekeeper — which is one of the reasons this release asks them to
   reinstall.
2. Build all three installers from `main` with `build_number: 30`.
3. Publish them to a GitHub Release and **confirm they download**.
4. Only then publish the migration manifest — a mandatory *patch* carrying the
   reinstall notice (`ota_publish.py --reinstall-notice <url>`), per spec 8.1.

Steps 3 and 4 are not reversible in the other order: once a mandatory manifest
is live, every 0.3.3 client is blocked at startup, so the installers have to
exist first.


## Also in here: the runtime build could not download Python

Folded in at the owner's direction after the first 0.3.4 macOS build failed
**0.24 seconds in**, before signing was even attempted:

```
curl: (56) The requested URL returned error: 403
```

All three runtime build scripts ask the GitHub releases API which
python-build-standalone asset to fetch, and all three asked **unauthenticated** —
a rate limit shared by every Actions runner on the same egress IP, 60 requests an
hour for the whole pool. None of the three workflows passed a token either. That
earlier builds succeeded was timing, not configuration, so this could have struck
any release.

Each script now sends an `Authorization` header when `GITHUB_TOKEN` or
`GH_TOKEN` is set, and the workflows pass `github.token` to the runtime build
step. Verified locally: the limit moves from 60 to 5000, and the authenticated
query returns the `aarch64-apple-darwin`, `x86_64-pc-windows-msvc` and
`x86_64-unknown-linux-gnu` assets the three platforms need.

Only the **query** is authenticated. The download uses `browser_download_url`,
public CDN, and must not carry the header. With no token the header is omitted,
so local runs are unaffected.

I flagged that this is a pre-existing `main` defect better suited to its own
issue; the owner chose to fold it in, and it is a hard prerequisite for the 0.3.4
installers — without it no platform can build at all. `governance_touch` is
declared for the three workflow files.

## Verification

- `tests/packaging/test_version_alignment.py` — 5 passed
- `tests/tutorials/test_core_tutorials.py` — 37 passed (the version-shaped
  assertions there use synthetic data and are unaffected)
- `ruff format --check .` and `ruff check .` run against the **committed bytes**
  (`git archive HEAD`), not the working tree
