### PR TITLE
docs(#2163): a canonical desktop release runbook, pointed at from every AI runtime

### DIFF
--- a/.agents/rules/rules.md
+++ b/.agents/rules/rules.md
@@ -9,6 +9,11 @@ This file is a pointer only. It is not an independent policy source.
 - Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
   AI-facing gate record and local receipt commands.
 
+- Use `docs/ai-developer/release-runbook.md` if you are cutting a desktop
+  release or publishing an OTA update. Two of its rules brick users when
+  broken: the installer must be downloadable before any mandatory manifest,
+  and it must carry a build number at or above the highest published patch.
+
 - Use `docs/ai-developer/gate-cli-command-set.md` for the full consolidated
   gate CLI reference (arguments, `--mode` family, exit codes, strictness tiers,
   per-task-kind and per-persona profiles, and a soft-routing decision guide).

--- a/.claude/rules/rules.md
+++ b/.claude/rules/rules.md
@@ -9,6 +9,11 @@ This file is a pointer only. It is not an independent policy source.
 - Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
   AI-facing gate record and local receipt commands.
 
+- Use `docs/ai-developer/release-runbook.md` if you are cutting a desktop
+  release or publishing an OTA update. Two of its rules brick users when
+  broken: the installer must be downloadable before any mandatory manifest,
+  and it must carry a build number at or above the highest published patch.
+
 - Use `docs/ai-developer/gate-cli-command-set.md` for the full consolidated
   gate CLI reference (arguments, `--mode` family, exit codes, strictness tiers,
   per-task-kind and per-persona profiles, and a soft-routing decision guide).

--- a/.codex/rules/rules.md
+++ b/.codex/rules/rules.md
@@ -9,6 +9,11 @@ This file is a pointer only. It is not an independent policy source.
 - Use `docs/ai-developer/rules.md#5-gate-cli-command-set` for the canonical
   AI-facing gate record and local receipt commands.
 
+- Use `docs/ai-developer/release-runbook.md` if you are cutting a desktop
+  release or publishing an OTA update. Two of its rules brick users when
+  broken: the installer must be downloadable before any mandatory manifest,
+  and it must carry a build number at or above the highest published patch.
+
 - Use `docs/ai-developer/gate-cli-command-set.md` for the full consolidated
   gate CLI reference (arguments, `--mode` family, exit codes, strictness tiers,
   per-task-kind and per-persona profiles, and a soft-routing decision guide).

--- a/.workflow/records/2163-release-runbook.json
+++ b/.workflow/records/2163-release-runbook.json
@@ -1,8 +1,162 @@
 {
   "base_ref": null,
   "branch": "docs/2163-release-runbook",
-  "check_events": [],
-  "check_na": [],
+  "check_events": [
+    {
+      "at": "2026-08-25T07:34:49.485633Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0deac04405434cdca6d65dc3c51f5b5938ddb201f6adf484ce98451ad607e155",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:34:53.891592Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0ed41aa063dc0144756451add9a77624e15b086cd73d6fd32ca0ea35c69591da",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:34:55.419624Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:102f4fec721ebfc465e7a0ebf36ba896c75f73ca64a3d872407303e84c235e40",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:34:55.512791Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T07:35:07.602611Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d9feccb4ece2cf94ba59dbd1d1533a5ec8db16fec0b14821db41e4699fca6ae5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:35:08.124608Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:35:08.203707Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T07:38:01.925826Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:47eac75ed95c8abfde2e5868831e97df5202e82116cf9c4a1b1122e549884f6c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:38:17.555253Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Blocked by the tracked Windows local-mirror flake classes #2103 and #2107 -- 9 failed against 7222 passed, all in tests/api/test_system_vertical.py and tests/api/test_workflows.py, the files those issues name. This branch contains no Python at all: its diff is one new markdown file plus a single pointer line in each of three rules files and AGENTS.md. CI on Ubuntu is the authoritative gate."
+    }
+  ],
   "commit": null,
   "declared_scope": {
     "exclude": [],
@@ -15,9 +169,115 @@
     ]
   },
   "directive_events": [],
-  "docs_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T08:19:36.973387Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/release-runbook.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
   "governance_touch": true,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-25T07:38:17.616569Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.637303Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.653268Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "governed_files": [
+              ".agents/rules/rules.md",
+              ".claude/rules/rules.md",
+              ".codex/rules/rules.md",
+              "AGENTS.md",
+              "docs/ai-developer/release-runbook.md"
+            ]
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "docs_landing",
+          "git_evidence": null,
+          "id": "docs_landing.missing-landing",
+          "line": null,
+          "message": "governed change requires docs/changelog/checklist landing evidence or an explicit N/A rationale",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "docs_landing.missing-landing",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "docs_landing",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-25T07:38:17.668217Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.684050Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.699097Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.715645Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.731550Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.746803Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.761482Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:17.777182Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -27,25 +287,89 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "acfe20255",
+    "changed_files": [
+      ".agents/rules/rules.md",
+      ".claude/rules/rules.md",
+      ".codex/rules/rules.md",
+      ".workflow/records/2163-release-runbook.json",
+      "AGENTS.md",
+      "docs/ai-developer/release-runbook.md"
+    ],
+    "diff_fingerprint": "sha256:dd5b94551d15d38e93550a20bcb6a05c08d7ac9b0deffb3e7c3c037cd6957fbc",
+    "head": "HEAD",
+    "head_sha": "204ce874e",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 5,
+      "governed_docs": 1,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Write the release procedure where Codex and Kimi can find it too, so they know how to publish an update.",
   "persona": "adr_author",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T07:38:17.777219Z",
+      "diff_fingerprint": "sha256:dd5b94551d15d38e93550a20bcb6a05c08d7ac9b0deffb3e7c3c037cd6957fbc",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "docs.docs_required_or_na",
+        "guard.docs_landing"
+      ]
+    }
+  ],
   "record_id": "2163-release-runbook",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "e052edff-5767-4811-a341-ed890a12d6a5",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "docs",
   "test_events": []
 }

--- a/.workflow/records/2163-release-runbook.json
+++ b/.workflow/records/2163-release-runbook.json
@@ -1,0 +1,51 @@
+{
+  "base_ref": null,
+  "branch": "docs/2163-release-runbook",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "docs/ai-developer/release-runbook.md",
+      ".agents/rules/rules.md",
+      ".codex/rules/rules.md",
+      ".claude/rules/rules.md",
+      "AGENTS.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": true,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2163,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Write the release procedure where Codex and Kimi can find it too, so they know how to publish an update.",
+  "persona": "adr_author",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2163-release-runbook",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "e052edff-5767-4811-a341-ed890a12d6a5",
+  "strictness_tier": null,
+  "task_kind": "docs",
+  "test_events": []
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,6 +218,11 @@ If any item is missing, the task is not complete.
   strictness tiers, per-task-kind and per-persona obligation profiles, and a
   soft-routing decision guide an agent can follow to self-route a task.
 
+- Use `docs/ai-developer/release-runbook.md` if you are cutting a desktop
+  release or publishing an OTA update. Two of its rules brick users when
+  broken: the installer must be downloadable before any mandatory manifest,
+  and it must carry a build number at or above the highest published patch.
+
 - Use `docs/ai-developer/specific_rules/gated-workflow.md` if you are doing
   AI-authored work that needs gate evidence.
 

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -156,7 +156,7 @@ xcrun stapler validate "$APP"
 ## 4. Publish the release and **verify the download**
 
 Attach the installers to a GitHub Release for the tag -- three from CI plus the
-macOS x64 dmg from section 3.2.
+macOS x64 dmg from section 3.3.
 
 Then actually download one and install it. This is the gate for section 1.1, not
 a formality: everything after this point assumes the artifact is reachable.

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -101,7 +101,29 @@ and a dmg that still prompts. The workflow's `Verify signature, hardened runtime
 and notarization` step exists to turn that into a red build. If it is skipped,
 the artifact is not signed no matter what the rest of the log says.
 
-### 3.2 macOS Intel (x64) is not built by CI
+### 3.2 Notarization can stall, and says nothing while it does
+
+The macOS build has two long silent phases inside one step. Signing walks every
+Mach-O in the bundle — several hundred `.so` files in the interpreter, one
+`codesign` process each — and takes 10 to 30 minutes. Then `notarytool` uploads
+to Apple and waits, with **no upper bound**, because the queue is not ours.
+
+A 0.3.4 build sat there for 118 minutes and was cancelled. The only evidence of
+where it had been came from the runner's own cleanup line,
+`Terminate orphan process (notarytool)` — enough to rule out signing, and
+nothing more. `notarytool` itself printed nothing for two hours.
+
+So: **a static log is not evidence of a hang**, and until #2174 lands there is
+no way to tell "still queued" from "stuck" while it is happening. If a build
+passes an hour in `Build DMG`, cancel it and re-run rather than waiting it out;
+if the second run stalls the same way, the problem is not the queue and the
+credentials or the submission itself need looking at from an account that can
+run `notarytool history`.
+
+The first submission from a newly issued Developer ID is a known slow case.
+
+
+### 3.3 macOS Intel (x64) is not built by CI
 
 `dist:dmg` is hardcoded to `--arm64`, and the workflow's own comment rules out
 running it on an Intel runner: `build:python:mac` keys off `uname -m`, so an

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -1,0 +1,200 @@
+---
+title: "Desktop Release Runbook"
+status: Approved
+owners:
+  - "@jiazhenz026"
+related_specs:
+  - desktop-ota-hot-update
+  - desktop-shell-ota-hot-update
+  - desktop-macos-signing-notarization
+  - alpha-version-management
+language_source: en
+---
+
+# Desktop Release Runbook
+
+How to ship a desktop release and then update installed clients. This is the
+procedure; the *reasoning* lives in the specs listed above and is not repeated
+here.
+
+## 1. Two rules that brick users when broken
+
+Read these before anything else. Neither is visible in the code, and neither
+produces a symptom when it goes wrong.
+
+### 1.1 The installer must exist and download **before** any mandatory manifest
+
+A mandatory manifest blocks startup. If it is published before the installer it
+tells people to fetch, every older client is stopped at launch with nowhere to
+go — the incompatible dialog carries a single **Quit** button, and there is no
+"remind me later".
+
+Publish the installers, download one yourself, *then* publish the manifest.
+
+### 1.2 The installer must carry a build number ≥ the highest published patch
+
+`resolveActivePatch` discards a patch only when
+`baselineBuild >= pointer.build`. The committed version is
+`a.b.c-alpha-build0000` by design, and the build number is stamped at build time
+from the workflow's `build_number` input.
+
+Ship an installer stamped `build0000` and every user's applied patch stays
+**active**: they install the new version, keep running the old code, and nothing
+fails loudly. If that patch predates shell OTA it also carries no `shell/`, so
+the new loader silently falls back to the bundled shell.
+
+Check the current channel high-water mark first:
+
+```bash
+gh release download ota-alpha --pattern manifest.json --output - | python -c "import json,sys; print(json.load(sys.stdin)['build'])"
+```
+
+Then stamp above it, with headroom for the migration patch.
+
+## 2. Version bump
+
+`src/scistudio/_version.py` is the single source of truth.
+
+```bash
+# edit BASE_VERSION, then
+python scripts/version.py sync
+python scripts/version.py show
+```
+
+The API reference carries the version in its header and is generated — do not
+edit the line:
+
+```bash
+python scripts/docs/build_reference.py
+```
+
+Land this as its own PR before building anything.
+
+## 3. Build the installers
+
+Three `workflow_dispatch` workflows, one per platform. Give each the **same**
+`build_number` (section 1.2) and the OTA channel.
+
+| Platform | Workflow |
+|---|---|
+| macOS | `Desktop macOS DMG` |
+| Windows | `Desktop Windows Installer` |
+| Linux | `Desktop Linux AppImage` |
+
+```bash
+gh workflow run desktop-macos-dmg.yml --ref main -f build_number=30 -f ota_channel=alpha
+```
+
+Leaving `ota_channel` empty produces a build with OTA **disabled** — correct for
+a local test artifact, wrong for a release.
+
+### 3.1 macOS signing is secret-driven
+
+Signing turns on when `MACOS_CSC_LINK` is configured; without it the dmg builds
+unsigned and users still meet Gatekeeper. The five secrets are `MACOS_CSC_LINK`,
+`MACOS_CSC_KEY_PASSWORD`, `APPLE_API_KEY_P8`, `APPLE_API_KEY_ID`,
+`APPLE_API_ISSUER`.
+
+electron-builder's notarization **fails soft** — a missing or mistyped
+credential logs `skipped macOS notarization` and returns, leaving a green build
+and a dmg that still prompts. The workflow's `Verify signature, hardened runtime
+and notarization` step exists to turn that into a red build. If it is skipped,
+the artifact is not signed no matter what the rest of the log says.
+
+## 4. Publish the release and **verify the download**
+
+Attach all three installers to a GitHub Release for the tag.
+
+Then actually download one and install it. This is the gate for section 1.1, not
+a formality: everything after this point assumes the artifact is reachable.
+
+For macOS, confirm on a machine that has never had the app installed that it
+opens without any security prompt.
+
+## 5. Publish the OTA update
+
+From a **clean detached worktree at `origin/main`**, with the backend staged:
+
+```bash
+npm --prefix desktop run stage:sh     # or `stage` on Windows
+python scripts/ota_publish.py --channel alpha --notes "<what changed>"
+```
+
+The snapshot carries `src/` **and** `shell/`, sharing one build number.
+`bootstrap.js` and `package.json` are never published — the loader must not be
+replaceable by the thing it decides whether to trust.
+
+`--dry-run` always reports build 1; its `build` and `url` are meaningless, while
+`sha256`, `size`, `notes` and `requires` are real.
+
+### 5.1 Clients that must reinstall
+
+When the base version moved, older clients cannot reach the new build by OTA.
+Do **not** migrate them with a mandatory *incompatible* manifest: that renders in
+a native dialog, whose text is neither clickable nor selectable, so the address
+has to be retyped — and it cannot be improved, because that dialog is drawn by
+the one part a patch cannot replace.
+
+Publish a mandatory **patch** instead:
+
+```bash
+python scripts/ota_publish.py --channel alpha --min-build N \
+  --reinstall-notice "https://github.com/jiazhenz026/SciStudio/releases/tag/vX.Y.Z"
+```
+
+It swaps the snapshot's SPA for an ordinary web page with selectable text and a
+clipboard button. Keep `min_base` **at or below** the target clients' base so the
+decision is `patch`, not `incompatible`. Because the address is copyable it does
+not need to be short — use the real release URL.
+
+### 5.2 Making an update mandatory
+
+`--min-build N` writes `requires.min_build` and makes startup blocking. Say the
+consequences out loud before publishing, because each one is "the user cannot
+open the app": declining quits, a failed download or sha mismatch quits, and a
+client below `requires.min_base` gets the reinstall path. Offline is
+**fail-open** — an unreachable manifest lets the app start.
+
+## 6. Verify the published patch
+
+A sha mismatch locks out every client, so check the live artifacts rather than
+the publish script's own output:
+
+```bash
+gh release download ota-alpha -p manifest.json -p backend-buildNN.tar.gz -D <dir> --clobber
+sha256sum <dir>/backend-buildNN.tar.gz          # must equal manifest.sha256
+tar -tzf <dir>/backend-buildNN.tar.gz | head    # src/scistudio/... and shell/...
+```
+
+Then feed the live manifest through the real decision module rather than
+reasoning about it. `desktop/ota.js` is dependency-free:
+
+```bash
+cd desktop && node -e "
+const ota = require('./ota.js'); const m = require('C:/.../manifest.json');
+const cfg = {enabled:true, channel:'alpha'}, base = {base:'0.3.4', channel:'alpha', build:30};
+for (const eff of [25,29,30]) console.log(eff, JSON.stringify(ota.evaluateUpdate(cfg, m, base, eff)));
+"
+```
+
+## 7. Testing a release without touching real users
+
+Channel isolation protects other people; it does not protect this machine.
+`evaluateUpdate` filters on `manifest.channel`, but `getActivePatch` and the
+bootstrap loader read `userData/patches/active.json` with **no channel check at
+all**.
+
+- Isolate with Electron's `--user-data-dir`. Changing `build.productName` does
+  **not** work: `app.getName()` reads the packaged `package.json`'s top-level
+  `name`, so a renamed build still shares the real client's userData.
+- Serve the manifest from `127.0.0.1` via `SCISTUDIO_OTA_MANIFEST_URL`;
+  `otaHttpGet` selects the `http` module for `http:` URLs, so no public release
+  is involved.
+- Nothing else may be running. The single-instance lock (#1867) makes a second
+  launch `app.quit()` immediately with **exit code 0** — indistinguishable from a
+  clean run.
+- `ELECTRON_RUN_AS_NODE` inherited from the launching shell starts the binary as
+  Node, rejects `--user-data-dir`, and exits 0 having done nothing.
+
+The full scenario, with expected log lines, is
+`docs/ai-developer/e2e/2026-08-23-shell-ota-hot-update-lifecycle.md`.

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -170,13 +170,34 @@ Publish a mandatory **patch** instead:
 
 ```bash
 python scripts/ota_publish.py --channel alpha --min-build N \
+  --min-base <the OLD base, e.g. 0.3.3> \
   --reinstall-notice "https://github.com/jiazhenz026/SciStudio/releases/tag/vX.Y.Z"
 ```
 
 It swaps the snapshot's SPA for an ordinary web page with selectable text and a
-clipboard button. Keep `min_base` **at or below** the target clients' base so the
-decision is `patch`, not `incompatible`. Because the address is copyable it does
-not need to be short — use the real release URL.
+clipboard button. Because the address is copyable it does not need to be
+short — use the real release URL.
+
+**`--min-base` is not optional here (#2169).** Without it the value derives
+from the build's own base, which after a bump is the *new* one — so every
+client on the old base evaluates to `incompatible` instead of `patch`, and
+that branch never downloads anything. The notice page would be built,
+uploaded, and never fetched, leaving the user at the plain native dialog the
+notice exists to avoid.
+
+Check the decision before publishing rather than reasoning about it:
+
+```bash
+cd desktop && node -e "
+const ota = require('./ota.js');
+console.log(JSON.stringify(ota.evaluateUpdate(
+  {enabled:true, channel:'alpha'},
+  require('/path/to/manifest.json'),
+  {base:'0.3.3', channel:'alpha', build:0},   // a client you are migrating
+  25                                          // its effective build
+)));   // must read kind:'patch', mandatory:true
+"
+```
 
 ### 5.2 Making an update mandatory
 

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -101,9 +101,40 @@ and a dmg that still prompts. The workflow's `Verify signature, hardened runtime
 and notarization` step exists to turn that into a red build. If it is skipped,
 the artifact is not signed no matter what the rest of the log says.
 
+### 3.2 macOS Intel (x64) is not built by CI
+
+`dist:dmg` is hardcoded to `--arm64`, and the workflow's own comment rules out
+running it on an Intel runner: `build:python:mac` keys off `uname -m`, so an
+Intel runner would bundle x64 Python inside an arm64 shell. Yet
+`v0.3.3-alpha` shipped an `-x64.dmg`.
+
+That artefact is produced **locally**, and the procedure is not written down
+anywhere — the only trace is a line in the body of a closed issue.
+
+<!-- TODO(#2165): document the macOS Intel (x64) build.
+     The procedure exists only as tacit knowledge; this section cannot be
+     completed without it. Followup:
+     https://github.com/jiazhenz026/SciStudio/issues/2165 -->
+
+Two things to carry over from section 3.1 when building it by hand:
+
+* the same `APPLE_API_KEY` / `APPLE_API_KEY_ID` / `APPLE_API_ISSUER` must be
+  exported, or the dmg is unsigned;
+* `dist:dmg` does **not** run the workflow's verification step, and
+  electron-builder's notarization fails soft, so run the four checks manually:
+
+```sh
+APP=$(find dist -maxdepth 2 -name '*.app' -print -quit)
+codesign --verify --deep --strict --verbose=2 "$APP"
+codesign --display --verbose=2 "$APP"   # must report flags=...runtime
+spctl -a -vvv -t exec "$APP"
+xcrun stapler validate "$APP"
+```
+
 ## 4. Publish the release and **verify the download**
 
-Attach all three installers to a GitHub Release for the tag.
+Attach the installers to a GitHub Release for the tag -- three from CI plus the
+macOS x64 dmg from section 3.2.
 
 Then actually download one and install it. This is the gate for section 1.1, not
 a formality: everything after this point assumes the artifact is reachable.


### PR DESCRIPTION
Closes #2163

## Why

The desktop release procedure existed only as design-record prose spread across
`docs/specs/desktop-ota-hot-update.md`,
`docs/specs/desktop-shell-ota-hot-update.md` §8/§8.1 and chat history. Anyone
cutting a release had to reassemble it, and **two of its rules brick users when
broken** — neither visible in the code, neither producing a symptom when it goes
wrong:

1. **The installer must be downloadable before any mandatory manifest.**
   Reversed, every older client is stopped at launch with nowhere to go: the
   incompatible dialog carries a single "Quit" button and there is no "remind me
   later".
2. **The installer must carry a build number ≥ the highest published patch.**
   `resolveActivePatch` discards a patch only when
   `baselineBuild >= pointer.build`, so a `build0000` installer leaves the user's
   applied patch active — they install the new version, keep running the old
   code, and nothing fails loudly.

## What

`docs/ai-developer/release-runbook.md` — the whole sequence in order: version
bump, per-platform builds with the `build_number` input, the Release, the
download verification gate, and only then the OTA publish, including
`--reinstall-notice` for clients that must reinstall.

It also carries the four things that make a release test *look* like it worked
when it did nothing: `--user-data-dir` is the only isolation that works
(`build.productName` does not, because `app.getName()` reads the packaged
`package.json`'s top-level `name`), the single-instance lock exits 0 silently,
`ELECTRON_RUN_AS_NODE` exits 0 silently, and electron-builder's notarization
fails soft.

## Why pointers, not copies

The three runtime rule files and the `AGENTS.md` index gain **one pointer line
each**. They deliberately do not carry the procedure:

> `.codex/rules/rules.md`: This file is a pointer only. It is not an independent
> policy source.

> `AGENTS.md`: Runtime files, skills, memory, and tool-specific configs must
> point here and to canonical docs instead of creating separate policy.

That rule earns its keep here specifically: a release procedure duplicated three
ways drifts, and three inconsistent sets of publishing instructions are worse
than none when the failure mode is "every user is locked out of the app".

The runbook itself states steps and cites the specs for the reasoning rather than
restating it, for the same reason — one place to change when the procedure
changes.

## One gap the runbook carries openly

`v0.3.3-alpha` shipped four installers, one of them `-x64.dmg`. CI cannot
produce it: `dist:dmg` is hardcoded to `--arm64`, and the workflow's own comment
rules out an Intel runner because `build:python:mac` keys off `uname -m`. The
only trace of how that artefact was made is a line in the body of a closed
issue.

Section 3.2 says exactly that and carries a `TODO(#2165)` rather than inventing
steps. It does state the two things that carry over regardless: the same
notarization credentials must be exported for a local build, and `dist:dmg`
does **not** run the workflow's verification step — so with electron-builder's
fail-soft notarization, a local build can produce a green-looking unsigned dmg.

## Note

`docs/ai-developer/**` is a governance surface; `governance_touch` is declared
and this needs owner review.

Kimi is covered by `.agents/rules/rules.md` — there is no `.kimi/` directory, and
`AGENTS.md` routes generic agent tooling there.
