### PR TITLE
docs(#2167): backfill six user-visible changes that shipped without an entry

### DIFF
--- a/.workflow/records/2167-changelog-backfill.json
+++ b/.workflow/records/2167-changelog-backfill.json
@@ -1,0 +1,47 @@
+{
+  "base_ref": null,
+  "branch": "docs/2167-changelog-backfill",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2167,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Investigate every PR since the last hot update and write the announcement fully. That comparison exposed six user-visible changes with no CHANGELOG entry, and both announcements point readers at the CHANGELOG.",
+  "persona": "adr_author",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2167-changelog-backfill",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "cb0375b2-5b86-4285-a81e-65bb4e089799",
+  "strictness_tier": null,
+  "task_kind": "docs",
+  "test_events": []
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2090] **The left sidebar is a VS Code-style icon rail, and it gained two
+  sections.** The Blocks / Data types / Project text tabs are replaced by a 48px
+  vertical rail of icons that sits outside the resizable area, so it stays put
+  when the panel is dragged and stays visible when the panel is closed. Clicking
+  the active icon collapses the panel and clicking again reopens it, which is
+  also what `Ctrl+B` has always meant — the shortcut wrote a `paletteCollapsed`
+  flag nothing read, so the panel never moved.
+  **Workflows** lists every workflow in the open project with the description
+  from its YAML, opens one on the canvas in a single click, and marks the one
+  already there. **Data** shows the project tree rooted at `data/` — `raw`,
+  `processed`, `zarr`, `parquet`, `artifacts`, `exchange` — so the files a
+  workflow reads and writes are reachable without leaving the app. A section
+  entered programmatically, by the library reveal or by a Learning Center step,
+  always expands the panel first.
+
+- [#1719] **Plot cards gained Edit and Delete.** A plot could be created and
+  looked at, and that was all: changing how it rendered meant finding the render
+  script by hand, and a plot you no longer wanted stayed. Edit opens that script
+  in a Monaco editor tab; Delete removes the project-local plot directory after
+  a confirmation and refreshes both the plot list and the project tree.
+
 - [#2157] **The Learning Center's Reading tab is now a reader for the shipped
   user documentation.** SciStudio already writes a complete user guide and
   generates a self-contained API reference from its own code; both ship in the
@@ -316,6 +337,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- [#2137] **The built-in AI assistant is named Mio.** It had no name, which made
+  it hard to write about and hard to speak to — every tutorial line had to say
+  "the assistant". Mio is also the guide in the Learning Center dialogue, so the
+  same character is what a reader meets in the tutorials and what answers them
+  in the chat panel. The provisioned agent guide is unified on `AGENTS.md` in
+  the same change, so a project carries one file describing how agents work here
+  rather than one per runtime.
+
+- [#2135] **A tutorial step is a character's dialogue rather than a paragraph.**
+  A step carried one `say` string and the card printed it beside whatever it
+  pointed at: accurate and inert, reading like the reference manual for a
+  scientific tool, which is what it was. It gave a first-time reader no reason
+  to continue. A step is now delivered as dialogue, and core levels 1 and 2 are
+  rewritten in it.
+
 - [#2097] **The Electron shell updates over the air like the rest of the app.**
   Changing `main.js`, `preload.js`, `ota.js`, `runtime-port.js` or `splash.html`
   used to require a full installer download — the CHANGELOG entry for #1805
@@ -500,6 +536,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   breaking regardless, because a route leaves the API surface.
 
 ### Fixed
+
+- [#2151] **Left-panel sections show what is actually there when you switch to
+  them.** Blocks, Data types and Previewers each read their listing once and
+  kept it, so a block or type added while another section was open stayed
+  invisible until a manual Reload. Each section now re-reads on entry.
+  Dropping a block from the palette also lands it centred on the cursor rather
+  than offset from it — React Flow positions a node by its top-left corner, and
+  the drop was passing the cursor point straight through.
+
+- [#2141] **An edge takes its colour from the port type before the driving
+  parameter is set.** Edges leaving a Load block rendered in the grey-black
+  `DataObject` fallback instead of the colour of the block's own output port,
+  because a dynamic port has no resolved type until its driving parameter is
+  filled in. The edge now matches the port it leaves from either way, so the
+  canvas does not briefly claim every new connection is untyped.
 
 - [#2160] **The documentation reader can no longer be talked out of the
   documentation.** `GET /api/user-docs/pages/{path}` split the request path on


### PR DESCRIPTION
Closes #2167

## Why

Writing the 0.3.4 announcement meant listing what users actually get. Comparing
the 36 PRs merged since the last hot update against `CHANGELOG.md` turned up
**six user-visible changes with no entry at all**.

Both announcements — the GitHub release notes and the in-app reinstall page —
say *"Full detail: CHANGELOG.md"*. A reader following that link to learn about
the rebuilt sidebar, or about Mio, would have found neither. The announcement
copy had to be reconstructed from PR titles and source, which is exactly the
work the CHANGELOG exists to make unnecessary.

Two of the six are among the most visible things in the release: the sidebar is
the first thing a returning user sees, and Mio appears by name in the tutorials.

## What

| PR | Entry added under |
|---|---|
| #2090 | Added — the icon rail, Workflows and Data sections, `Ctrl+B` collapse |
| #1719 | Added — plot card Edit and Delete |
| #2137 | Changed — the assistant is named Mio |
| #2135 | Changed — a tutorial step is a character's dialogue |
| #2151 | Fixed — sections reload on switch; dropped blocks centre on the cursor |
| #2141 | Fixed — edge colour follows an unresolved dynamic port |

Written from the PR descriptions and the source rather than from the titles, in
the existing narrative voice. `Ctrl+B`, for instance, turns out to have been
writing a `paletteCollapsed` flag that nothing read, so the shortcut existed but
the panel never moved — that is the kind of detail a title does not carry.

## Scope

Documentation only. No feature changed, and nothing older than the last hot
update was backfilled.
