### PR TITLE
fix(#2169): let --min-base override the derived value

### DIFF
--- a/.workflow/records/2169-ota-min-base.json
+++ b/.workflow/records/2169-ota-min-base.json
@@ -1,0 +1,51 @@
+{
+  "base_ref": null,
+  "branch": "fix/2169-ota-min-base",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "scripts/ota_publish.py",
+      "tests/scripts/test_ota_publish.py",
+      "docs/ai-developer/release-runbook.md",
+      "docs/specs/desktop-shell-ota-hot-update.md",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2169,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Add the min-base override parameter.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2169-ota-min-base",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "fd727d8b-d466-488d-8f2c-cca3573b4e7f",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": []
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2169] **The reinstall notice can now reach the clients it exists for.**
+  `--reinstall-notice` was written for one situation — the base version moved,
+  older clients cannot reach the new build over the air, and they must be told
+  to reinstall in a web page because a native dialog renders an address that is
+  neither clickable nor selectable. It could not be used for that situation.
+  `requires.min_base` derived from the version being published, so after a base
+  bump the manifest declared the *new* base and every client on the old one
+  evaluated to `incompatible` rather than `patch` — and the incompatible branch
+  never downloads, so the notice page was built, uploaded, and never fetched.
+  A new `--min-base` overrides it. Verified against the client's own decision
+  module: with the derived value a 0.3.3 client returns
+  `{kind: "incompatible"}`, with the override `{kind: "patch"}`, both mandatory.
+
 - [#2151] **Left-panel sections show what is actually there when you switch to
   them.** Blocks, Data types and Previewers each read their listing once and
   kept it, so a block or type added while another section was open stayed

--- a/docs/specs/desktop-shell-ota-hot-update.md
+++ b/docs/specs/desktop-shell-ota-hot-update.md
@@ -263,6 +263,11 @@ has to say "click Update now", which it already does through `manifest.notes`.
 For this the manifest must satisfy `min_base <= 0.3.3` so the decision is
 `patch` rather than `incompatible`, with `min_build` set to make it mandatory.
 
+`min_base` derives from the build's own base unless overridden, so after a bump
+it is the *new* base and every old client takes the incompatible branch — which
+never downloads, so the notice page is never fetched. `ota_publish.py --min-base`
+(#2169) is what makes this route usable at all.
+
 Because the address is copyable, it does not need to be short: use the real
 0.3.4 release URL rather than an abbreviation.
 

--- a/scripts/ota_publish.py
+++ b/scripts/ota_publish.py
@@ -131,14 +131,23 @@ def build_manifest(
     notes: str,
     published_at: str,
     min_build: int | None = None,
+    min_base: str | None = None,
 ) -> dict:
     """Assemble the manifest document the desktop client compares against.
 
     #1868: pass ``min_build`` to mark the patch mandatory — clients whose
     effective build is below it must take the update before they can continue
     (the desktop shell blocks startup). Omit it for an ordinary optional patch.
+
+    #2169: ``min_base`` defaults to this build's own base, which is right for an
+    ordinary patch and wrong for the one case ``--reinstall-notice`` exists for.
+    After a base bump the derived value is the *new* base, so every client on the
+    old base evaluates to ``incompatible`` rather than ``patch`` — and the
+    incompatible branch never downloads anything, so the notice page is never
+    fetched and the user gets the plain native dialog the notice was written to
+    avoid. Pass ``min_base`` at or below the target clients' base to reach them.
     """
-    requires: dict[str, object] = {"min_base": base}
+    requires: dict[str, object] = {"min_base": min_base or base}
     if min_build is not None:
         requires["min_build"] = min_build
     return {
@@ -345,6 +354,17 @@ def main(argv: list[str] | None = None) -> int:
         help="Build the snapshot and manifest locally without creating/uploading a release.",
     )
     parser.add_argument(
+        "--min-base",
+        metavar="A.B.C",
+        default=None,
+        help=(
+            "#2169: override requires.min_base, which otherwise derives from this build's "
+            "own base. Needed whenever the base moved and older clients must still be "
+            "reached: set it at or below their base so they evaluate the manifest as a "
+            "patch rather than incompatible. Pair with --reinstall-notice."
+        ),
+    )
+    parser.add_argument(
         "--reinstall-notice",
         metavar="URL",
         default=None,
@@ -396,6 +416,7 @@ def main(argv: list[str] | None = None) -> int:
         notes=args.notes,
         published_at=_utc_now_iso(),
         min_build=args.min_build,
+        min_base=args.min_base,
     )
     manifest_path = workdir / "manifest.json"
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -332,3 +332,70 @@ def test_snapshot_without_a_notice_keeps_the_real_spa(mod: ModuleType, tmp_path:
     with tarfile.open(out, "r:gz") as tar:
         payload = tar.extractfile(mod.SPA_INDEX_ARCNAME).read().decode("utf-8")
     assert payload == "<html>the real SPA</html>"
+
+
+# --------------------------------------------------------------------------- #
+# #2169: min_base override — what makes --reinstall-notice reach anyone.
+# --------------------------------------------------------------------------- #
+def _manifest(mod: ModuleType, **kw: object) -> dict:
+    args: dict[str, object] = {
+        "channel": "alpha",
+        "base": "0.3.4",
+        "build": 26,
+        "url": "https://example.test/backend-build26.tar.gz",
+        "sha256": "abc",
+        "size": 1,
+        "notes": "",
+        "published_at": "2026-08-25T00:00:00Z",
+    }
+    args.update(kw)
+    return mod.build_manifest(**args)
+
+
+def test_min_base_defaults_to_the_builds_own_base(mod: ModuleType) -> None:
+    assert _manifest(mod)["requires"]["min_base"] == "0.3.4"
+
+
+def test_min_base_can_be_overridden(mod: ModuleType) -> None:
+    assert _manifest(mod, min_base="0.3.3")["requires"]["min_base"] == "0.3.3"
+
+
+def test_the_override_is_what_turns_incompatible_into_patch(mod: ModuleType) -> None:
+    """The whole point, expressed as the client's own comparison.
+
+    compareBase(clientBase, min_base) < 0 is what desktop/ota.js uses to pick the
+    incompatible branch, and that branch never downloads -- so a notice page
+    published under a derived min_base is built, uploaded, and never fetched.
+    """
+
+    def client_is_incompatible(client_base: str, min_base: str) -> bool:
+        def parts(v: str) -> list[int]:
+            out = []
+            for seg in v.split(".")[:3]:
+                digits = ""
+                for ch in seg:
+                    if not ch.isdigit():
+                        break
+                    digits += ch
+                out.append(int(digits) if digits else 0)
+            while len(out) < 3:
+                out.append(0)
+            return out
+
+        return parts(client_base) < parts(min_base)
+
+    derived = _manifest(mod)["requires"]["min_base"]
+    overridden = _manifest(mod, min_base="0.3.3")["requires"]["min_base"]
+
+    # Without the override a 0.3.3 client takes the dialog-only path.
+    assert client_is_incompatible("0.3.3", str(derived)) is True
+    # With it, the same client takes the patch path and downloads the notice.
+    assert client_is_incompatible("0.3.3", str(overridden)) is False
+
+
+def test_the_migration_manifest_is_both_mandatory_and_a_patch(mod: ModuleType) -> None:
+    """The shape the 0.3.3 -> 0.3.4 migration actually needs."""
+    m = _manifest(mod, min_build=26, min_base="0.3.3")
+    assert m["requires"] == {"min_base": "0.3.3", "min_build": 26}
+    # mandatory needs manifest.build >= min_build, or isMandatoryUpdate returns False
+    assert m["build"] >= m["requires"]["min_build"]


### PR DESCRIPTION
Closes #2169

## The defect

`--reinstall-notice` (#2097, spec 8.1) exists for exactly one situation: the
base version moved, older clients cannot reach the new build over the air, and
they must be told to reinstall **in a web page**, because a native dialog
renders an address that is neither clickable nor selectable.

It could not be used for that situation.

`requires.min_base` derived from the version being published, with no override.
So after a base bump the manifest declared the **new** base, every client on the
old one evaluated to `incompatible` rather than `patch`, and that branch **never
downloads anything** — the notice page was built, uploaded, and never fetched.
The user got the plain dialog the notice was written to avoid.

This was found while preparing the actual 0.3.3 → 0.3.4 migration, one step
before publishing it.

## Verified against the client, not by reasoning

`desktop/ota.js` is dependency-free, so the real decision can be run directly:

```
min_base=0.3.4  -> {"kind":"incompatible","build":26,"minBase":"0.3.4","mandatory":true}
min_base=0.3.3  -> {"kind":"patch","build":26,"mandatory":true}
```

Same manifest, same client, one field apart. The first never downloads.

## What changed

`--min-base` overrides the derived value. Tests cover the default still deriving
from the version, the override reaching `requires.min_base`, the combination the
migration needs (`min_base` old, `min_build` set, both mandatory and a patch),
and — the one that matters — that the override is what flips the client's own
comparison from incompatible to patch.

Spec 8.1 now says why the flag exists. The runbook section that tells the reader
to "keep `min_base` at or below the target clients' base" without saying how is
updated in #2166, where that file still lives unmerged.

## Why a flag rather than a hand-written manifest

Hand-writing the manifest was the obvious workaround and the wrong one: `sha256`
and `size` have to be filled in by hand, and either one wrong locks out every
client on the channel with no way back. It also recurs — every base bump needs
the same override, and the knowledge that it is needed lived nowhere.
