### PR TITLE
feat(#2159): desktop application menu with File / Packages / Help entries

### DIFF
--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -1858,6 +1858,12 @@
       "at": "2026-08-25T09:09:29.836250Z",
       "pattern": "scripts/ota_publish.py",
       "reason": "CI Test (Python 3.11) caught shell-file drift: menu.js added to asar files but not to the OTA publisher SHELL_FILES"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T09:12:28.520597Z",
+      "pattern": "tests/scripts/test_ota_publish.py",
+      "reason": "fake-desktop test fixture must carry menu.js after SHELL_FILES gained it"
     }
   ],
   "session_id": "0fd47990-aab8-4b63-8dbc-bec76357366b",
@@ -1885,6 +1891,14 @@
       "class": null,
       "kind": "path",
       "path": "frontend/src/components/__tests__/BringInMyWorkToolbarEntry.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T09:12:28.520623Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/scripts/test_ota_publish.py",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -1852,6 +1852,12 @@
       "at": "2026-08-25T06:31:14.150522Z",
       "pattern": "CHANGELOG.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T09:09:29.836250Z",
+      "pattern": "scripts/ota_publish.py",
+      "reason": "CI Test (Python 3.11) caught shell-file drift: menu.js added to asar files but not to the OTA publisher SHELL_FILES"
     }
   ],
   "session_id": "0fd47990-aab8-4b63-8dbc-bec76357366b",

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -138,6 +138,11 @@
       "at": "2026-08-25T06:31:14.150487Z",
       "owner_directive": "desktop application menu: File (projects home, new, save/save-as, bring in my work), Packages (package manager), Help (learning center, check updates)",
       "reason": "plan"
+    },
+    {
+      "at": "2026-08-25T08:26:36.832693Z",
+      "owner_directive": "\u6388\u6743 push \u5e76\u7528 SCISTUDIO_SKIP_PREFLIGHT=1 \u5f00 PR",
+      "reason": "owner authorized preflight bypass for PR creation per #2150/#2120 precedent (semantic_dup local evidence unobtainable, #2154)"
     }
   ],
   "docs_events": [

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -345,6 +345,11 @@
       "at": "2026-08-25T20:35:06.824758Z",
       "owner_directive": "owner: \u6211\u7761\u89c9\u4e86\uff0c\u4f60\u81ea\u5df1\u505a\u5230\u5e95 (finish autonomously)",
       "reason": "documenting local-only python_tests failures before pushing the CI fix"
+    },
+    {
+      "at": "2026-08-25T23:53:12.863273Z",
+      "owner_directive": "\u4fee PR 2171 codex review \u7ed3\u8bba\uff08OTA \u76f8\u5173\u9664\u5916\uff0c\u90a3\u8fb9\u53e6\u884c\u5904\u7406\uff09",
+      "reason": "codex review follow-up: P1 sandboxed preload relative require, P2 native Save As bypasses file-tab restriction; OTA finding already fixed in 168fd9fe1"
     }
   ],
   "docs_events": [

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -117,6 +117,102 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:40:16.284056Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b6fc918fdcab67198d599754306fcf94f73bd7f065a48cb01a0f132fd1585513",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:40:39.627718Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:089e3bccd2d9192938dce6f434bd6f786d171f8c271343fb914a11bdbfc32944",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:40:52.253851Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e01fc51b7e1af0ec3d031e7f95b9bc96d66f0bb39e564d23eb2d2e829760e1f0",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:41:32.641290Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:089e3bccd2d9192938dce6f434bd6f786d171f8c271343fb914a11bdbfc32944",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:55:13.674419Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:93f43352fe9b51430e648a1e5e5de0a4df2b088b7a77abec3e0b84acd583787b",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T08:57:10.838191Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fd6949df771262b2bb950f6f553841812347d7f8eaec7f088a4ada73e0447cbe",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -126,9 +222,9 @@
     }
   ],
   "commit": {
-    "sha": "949390ea561510f880568ef87094fd07a33bdd85",
+    "sha": "871a15d1626953bb7bfbb0e5f28050027483de0e",
     "shas": [
-      "949390ea561510f880568ef87094fd07a33bdd85"
+      "871a15d1626953bb7bfbb0e5f28050027483de0e"
     ],
     "trailers": []
   },
@@ -853,6 +949,622 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.326755Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.341265Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.356124Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.371288Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.386582Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.402742Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.418605Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.461278Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.475616Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.491361Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:40:52.511287Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.715864Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.730838Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.746139Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.760424Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.774445Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.788357Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.804340Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.818124Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.832319Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.846459Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:32.864668Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.132303Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.147199Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.162435Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.176806Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.190904Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.204861Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.219940Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.234968Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.249534Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.264337Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:41:57.283478Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.911244Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.927141Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.944926Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.962585Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.978786Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:10.993459Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:11.009043Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:11.024494Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:11.040554Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:11.056455Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:11.077120Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.716520Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.732287Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.746602Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.761479Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.776677Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.790977Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.804957Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.818574Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.832890Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.848146Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:57:40.869035Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.513031Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.527167Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.540816Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.556100Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.571082Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.586043Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.600786Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.645187Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.660494Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.675949Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:00.696052Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.365408Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.380244Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.395848Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.411335Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.429257Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.444943Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.459906Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.475015Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.490333Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.504815Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:58:47.526919Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -865,8 +1577,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
-    "base_sha": "acfe20255",
+    "base": "7876ccedce0f72b43c112d6d8e31d12e0d12390b",
+    "base_sha": "7876ccedc",
     "changed_files": [
       ".workflow/records/2159-desktop-menu-bar.json",
       "CHANGELOG.md",
@@ -874,8 +1586,10 @@
       "desktop/menu.js",
       "desktop/package.json",
       "desktop/preload.js",
+      "desktop/test/bootstrap.test.js",
       "desktop/test/menu.test.js",
       "frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx",
+      "frontend/src/App.parts/closeProject.ts",
       "frontend/src/App.parts/useDesktopMenuActions.ts",
       "frontend/src/App.tsx",
       "frontend/src/components/Toolbar.tsx",
@@ -885,20 +1599,20 @@
       "frontend/src/testUtils.ts",
       "frontend/src/types/desktop.d.ts"
     ],
-    "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
+    "diff_fingerprint": "sha256:25274c11d7edfa57ae77af53ebb892c91ea0a1a324fc72e5257ac4a4d32a68ed",
     "head": "HEAD",
-    "head_sha": "949390ea5",
+    "head_sha": "871a15d16",
     "surfaces": {
       "docs": 0,
-      "frontend": 9,
+      "frontend": 10,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 9,
+      "implementation": 10,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 9,
-      "test": 3,
+      "sentrux": 10,
+      "test": 4,
       "workflow_ci": 0
     }
   },
@@ -909,7 +1623,7 @@
     "closes": [
       2159
     ],
-    "number": null,
+    "number": 2171,
     "url": null
   },
   "reconcile_events": [
@@ -986,6 +1700,69 @@
       "unsatisfied": [
         "checks.semantic_dup"
       ]
+    },
+    {
+      "at": "2026-08-25T08:40:52.511330Z",
+      "diff_fingerprint": "sha256:0b8a327ec9800aacf24c52576ab487ffd28e1db79c0749cb6ff4d8e39c003703",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "commit_message.final"
+      ]
+    },
+    {
+      "at": "2026-08-25T08:41:32.864702Z",
+      "diff_fingerprint": "sha256:0b8a327ec9800aacf24c52576ab487ffd28e1db79c0749cb6ff4d8e39c003703",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-08-25T08:41:57.283527Z",
+      "diff_fingerprint": "sha256:0b8a327ec9800aacf24c52576ab487ffd28e1db79c0749cb6ff4d8e39c003703",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend"
+      ]
+    },
+    {
+      "at": "2026-08-25T08:57:11.077175Z",
+      "diff_fingerprint": "sha256:d2d3b9b1389a201f52733bb970dd404654806057bcfd4f81933a21039a0a6c45",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T08:57:40.869088Z",
+      "diff_fingerprint": "sha256:14669978d2a9101ac9877e6c18fec7991cf23cc3d02029044322b09af591f38a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T08:58:00.696104Z",
+      "diff_fingerprint": "sha256:25274c11d7edfa57ae77af53ebb892c91ea0a1a324fc72e5257ac4a4d32a68ed",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T08:58:47.526974Z",
+      "diff_fingerprint": "sha256:25274c11d7edfa57ae77af53ebb892c91ea0a1a324fc72e5257ac4a4d32a68ed",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
     }
   ],
   "record_id": "2159-desktop-menu-bar",
@@ -993,11 +1770,11 @@
   "required_obligations": {
     "admin_labels": [],
     "checks": [
+      "commit_hygiene",
       "format_check",
       "frontend",
       "full_audit",
-      "lint_format",
-      "semantic_dup"
+      "lint_format"
     ],
     "docs": [
       "docs_required_or_na"

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -1,4 +1,5 @@
 {
+  "base_ref": null,
   "branch": "guided/desktop-menu-bar",
   "check_events": [
     {
@@ -12,6 +13,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {
@@ -29,6 +31,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
@@ -44,6 +47,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {
@@ -61,6 +65,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
@@ -76,6 +81,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
@@ -91,6 +97,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": null,
+      "scope": "repo",
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
@@ -106,6 +113,7 @@
       "parity_gap": false,
       "pr_only": false,
       "raw_log_ref": null,
+      "scope": "repo",
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
@@ -143,6 +151,11 @@
       "at": "2026-08-25T08:26:36.832693Z",
       "owner_directive": "\u6388\u6743 push \u5e76\u7528 SCISTUDIO_SKIP_PREFLIGHT=1 \u5f00 PR",
       "reason": "owner authorized preflight bypass for PR creation per #2150/#2120 precedent (semantic_dup local evidence unobtainable, #2154)"
+    },
+    {
+      "at": "2026-08-25T08:35:48.770034Z",
+      "owner_directive": "sem dup \u4e0d\u662f\u4ece CI \u5f7b\u5e95\u53d6\u6d88\u4e86\u561b\uff1f\u4e3a\u5565\u672c\u5730\u8fd8\u5728\u8dd1\uff1f\u628a\u672c\u5730\u7ed9\u5173\u6389",
+      "reason": "owner asked why local still runs semantic_dup; root cause: branch was based on stale local main. Rebased onto origin/main which contains the #2120 removal; check-na and preflight-bypass events above are superseded"
     }
   ],
   "docs_events": [

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -1,0 +1,681 @@
+{
+  "branch": "guided/desktop-menu-bar",
+  "check_events": [
+    {
+      "at": "2026-08-25T06:31:25.822352Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T06:31:37.270857Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T06:31:37.310675Z",
+      "command": "ruff check .",
+      "covered_surface": "python",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T07:28:40.160765Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:caf1bfad79e38f0361d9eeaca7d1ffb4ef4b4f39365b57c4888aaf25daf58c8b",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:28:54.833650Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1c47b21183ce2983b8159c2db8a9ae676e40aad12ebb2a7a4dcdc8f7a8417b3d",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:38:54.871093Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:b13d930beb6463e42699b177a2bcbd05d9b1207813b233e8dc556fe1dd9ba560",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "964879a16ec495cc3cef6766d4bf0c12e8552ee5",
+    "shas": [
+      "964879a16ec495cc3cef6766d4bf0c12e8552ee5"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-25T06:31:13.884126Z",
+      "owner_directive": "Help \u83dc\u5355\u5305\u542b learning center \u5165\u53e3\u548c check updates\uff1b\u65b0\u589e Packages \u83dc\u5355\uff08\u53ea\u6709 package manager\uff09\uff1bFile \u91cc\u518d\u52a0 bring in my work",
+      "reason": "owner expanded live scope: add Help menu and Packages menu"
+    },
+    {
+      "at": "2026-08-25T06:31:14.150487Z",
+      "owner_directive": "desktop application menu: File (projects home, new, save/save-as, bring in my work), Packages (package manager), Help (learning center, check updates)",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-25T06:31:14.150530Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:31:14.150541Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "no contract/schema/runtime-API change; desktop menu is a shell UI addition",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:31:14.150547Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "not architectural; no cross-module or hard-to-reverse decision",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:31:14.150549Z",
+      "class": "user-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "no user doc documents the desktop menu today; CHANGELOG covers the behavior change",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-25T06:31:37.350180Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.392825Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.408109Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.423002Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.442068Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.457687Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.473921Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.496043Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.511480Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.526900Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:31:37.542934Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.754735Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.769349Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.782977Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.796395Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.809530Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.823463Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.836929Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.850054Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.864518Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.882268Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T06:32:21.930361Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.395041Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.409592Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.425390Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.446678Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.464411Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.479698Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.494809Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.510021Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.527090Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.542526Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:25:54.561066Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:54.933690Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:54.949722Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:54.965109Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:54.980738Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:54.995238Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.009610Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.024875Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.042594Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.057017Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.071159Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:38:55.088329Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2159,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "acfe20255",
+    "changed_files": [
+      ".workflow/records/2159-desktop-menu-bar.json",
+      "CHANGELOG.md",
+      "desktop/main.js",
+      "desktop/menu.js",
+      "desktop/package.json",
+      "desktop/preload.js",
+      "desktop/test/menu.test.js",
+      "frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx",
+      "frontend/src/App.parts/useDesktopMenuActions.ts",
+      "frontend/src/App.tsx",
+      "frontend/src/components/Toolbar.tsx",
+      "frontend/src/components/__tests__/BringInMyWorkToolbarEntry.test.tsx",
+      "frontend/src/store/types.ts",
+      "frontend/src/store/uiSlice.ts",
+      "frontend/src/testUtils.ts",
+      "frontend/src/types/desktop.d.ts"
+    ],
+    "diff_fingerprint": "sha256:e2e4c1856d1b80342c390b6bbb84a2bfffe0af764056c09af87e90335bad73c3",
+    "head": "HEAD",
+    "head_sha": "964879a16",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 9,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 9,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 9,
+      "test": 3,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "\u684c\u9762\u7248\u9876\u90e8\u83dc\u5355\u680f\uff1aFile \u52a0 projects/new/save/bring-in-my-work\uff1b\u65b0\u589e Packages \u548c Help \u83dc\u5355",
+  "persona": "live_implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2159
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T06:31:37.542975Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T06:32:21.930410Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T07:25:54.561127Z",
+      "diff_fingerprint": "sha256:e2e4c1856d1b80342c390b6bbb84a2bfffe0af764056c09af87e90335bad73c3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.frontend",
+        "checks.full_audit",
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-25T07:38:55.088368Z",
+      "diff_fingerprint": "sha256:e2e4c1856d1b80342c390b6bbb84a2bfffe0af764056c09af87e90335bad73c3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2159-desktop-menu-bar",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format",
+      "semantic_dup"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "agents:kimi-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:13.884143Z",
+      "pattern": "desktop/main.js",
+      "reason": "owner expanded live scope: add Help menu and Packages menu"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:13.884151Z",
+      "pattern": "frontend/src/types",
+      "reason": "owner expanded live scope: add Help menu and Packages menu"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150505Z",
+      "pattern": "desktop/main.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150511Z",
+      "pattern": "desktop/menu.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150513Z",
+      "pattern": "desktop/preload.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150515Z",
+      "pattern": "desktop/package.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150518Z",
+      "pattern": "desktop/test",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150520Z",
+      "pattern": "frontend/src",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T06:31:14.150522Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "0fd47990-aab8-4b63-8dbc-bec76357366b",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-25T06:31:14.150554Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/menu.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:31:14.150558Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-25T06:31:14.150560Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/__tests__/BringInMyWorkToolbarEntry.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -213,12 +213,100 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T09:13:18.641601Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3170c68151bc8b66ae53bcde2c0baab75736f32d9541ffd7552dd9c4c063eb5c",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T09:13:18.719527Z",
+      "command": "ruff format scripts/ota_publish.py tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f69bfa1994856b2d4c000e527fcea6c8b35203063f5df72ba6d168f47283a698",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T09:13:29.997423Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7592baffb0a1d48580091dd7d21c2fc1c1ab042b17a2e05c0f1f11619186e4e8",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T09:13:30.021647Z",
+      "command": "ruff check scripts/ota_publish.py tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0dbc36e2e6224dd493b406ab33603c717bd753dd9f22b126a7820722ac7f6647",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T09:16:16.847262Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8f7eb2cdc6d905911129dfe6ac352a727fc7b88fa9ec903984fb47c9ba2df9cf",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
     }
   ],
   "check_na": [
     {
       "name": "semantic_dup",
       "rationale": "passes standalone with ambient interpreter (2372 functions, 11.28% dup, all ratchets OK); parity venv exceeds the gate 600s timeout (#2154); ci.yml semantic-dup-scan job remains authoritative"
+    },
+    {
+      "name": "python_tests",
+      "rationale": "local-only Windows env failure, reproduces on untouched main checkout; CI Test jobs (3.11/3.13) run the same suite on Linux and are authoritative"
     }
   ],
   "commit": {
@@ -252,6 +340,11 @@
       "at": "2026-08-25T08:35:48.770034Z",
       "owner_directive": "sem dup \u4e0d\u662f\u4ece CI \u5f7b\u5e95\u53d6\u6d88\u4e86\u561b\uff1f\u4e3a\u5565\u672c\u5730\u8fd8\u5728\u8dd1\uff1f\u628a\u672c\u5730\u7ed9\u5173\u6389",
       "reason": "owner asked why local still runs semantic_dup; root cause: branch was based on stale local main. Rebased onto origin/main which contains the #2120 removal; check-na and preflight-bypass events above are superseded"
+    },
+    {
+      "at": "2026-08-25T20:35:06.824758Z",
+      "owner_directive": "owner: \u6211\u7761\u89c9\u4e86\uff0c\u4f60\u81ea\u5df1\u505a\u5230\u5e95 (finish autonomously)",
+      "reason": "documenting local-only python_tests failures before pushing the CI fix"
     }
   ],
   "docs_events": [
@@ -1565,6 +1658,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.918300Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.932702Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.948815Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.964431Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.980449Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:16.997378Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:17.012700Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:17.028521Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:17.045054Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:17.060650Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T09:16:17.082143Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1577,8 +1758,8 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "7876ccedce0f72b43c112d6d8e31d12e0d12390b",
-    "base_sha": "7876ccedc",
+    "base": "origin/main",
+    "base_sha": "3690f61c6",
     "changed_files": [
       ".workflow/records/2159-desktop-menu-bar.json",
       "CHANGELOG.md",
@@ -1597,11 +1778,13 @@
       "frontend/src/store/types.ts",
       "frontend/src/store/uiSlice.ts",
       "frontend/src/testUtils.ts",
-      "frontend/src/types/desktop.d.ts"
+      "frontend/src/types/desktop.d.ts",
+      "scripts/ota_publish.py",
+      "tests/scripts/test_ota_publish.py"
     ],
-    "diff_fingerprint": "sha256:25274c11d7edfa57ae77af53ebb892c91ea0a1a324fc72e5257ac4a4d32a68ed",
+    "diff_fingerprint": "sha256:7a3c078004e28d84151de0ea9dc592d75f5fdd2fe5bc2b0fadf2f42481238486",
     "head": "HEAD",
-    "head_sha": "871a15d16",
+    "head_sha": "17360ac04",
     "surfaces": {
       "docs": 0,
       "frontend": 10,
@@ -1611,8 +1794,8 @@
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 10,
-      "test": 4,
+      "sentrux": 11,
+      "test": 5,
       "workflow_ci": 0
     }
   },
@@ -1763,6 +1946,16 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T09:16:17.082184Z",
+      "diff_fingerprint": "sha256:7a3c078004e28d84151de0ea9dc592d75f5fdd2fe5bc2b0fadf2f42481238486",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
     }
   ],
   "record_id": "2159-desktop-menu-bar",
@@ -1774,7 +1967,8 @@
       "format_check",
       "frontend",
       "full_audit",
-      "lint_format"
+      "lint_format",
+      "python_tests"
     ],
     "docs": [
       "docs_required_or_na"

--- a/.workflow/records/2159-desktop-menu-bar.json
+++ b/.workflow/records/2159-desktop-menu-bar.json
@@ -94,13 +94,33 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T07:50:10.689890Z",
+      "command": "python scripts/semantic_dup_scan.py --check docs/audit/baselines/semantic-dup-baseline.json",
+      "covered_surface": "python",
+      "exit_code": null,
+      "input_fingerprint": "sha256:b13d930beb6463e42699b177a2bcbd05d9b1207813b233e8dc556fe1dd9ba560",
+      "name": "semantic_dup",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
+  "check_na": [
+    {
+      "name": "semantic_dup",
+      "rationale": "passes standalone with ambient interpreter (2372 functions, 11.28% dup, all ratchets OK); parity venv exceeds the gate 600s timeout (#2154); ci.yml semantic-dup-scan job remains authoritative"
+    }
+  ],
   "commit": {
-    "sha": "964879a16ec495cc3cef6766d4bf0c12e8552ee5",
+    "sha": "949390ea561510f880568ef87094fd07a33bdd85",
     "shas": [
-      "964879a16ec495cc3cef6766d4bf0c12e8552ee5"
+      "949390ea561510f880568ef87094fd07a33bdd85"
     ],
     "trailers": []
   },
@@ -463,6 +483,358 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.477216Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.493126Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.507751Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.524157Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.539425Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.554487Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.570469Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.586423Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.601748Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.618374Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:39:40.638510Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.747830Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.762182Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.776067Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.791012Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.804263Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.817360Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.830543Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.843255Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.856082Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.899888Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:10.916898Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.593628Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.608625Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.622967Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.637271Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.651507Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.664859Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.679048Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.692999Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.706842Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.722701Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T07:50:11.740854Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.752874Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.768008Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.782218Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.796229Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.810299Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.824417Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.838187Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.851935Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.865976Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.880085Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T08:04:37.896981Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -495,9 +867,9 @@
       "frontend/src/testUtils.ts",
       "frontend/src/types/desktop.d.ts"
     ],
-    "diff_fingerprint": "sha256:e2e4c1856d1b80342c390b6bbb84a2bfffe0af764056c09af87e90335bad73c3",
+    "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
     "head": "HEAD",
-    "head_sha": "964879a16",
+    "head_sha": "949390ea5",
     "surfaces": {
       "docs": 0,
       "frontend": 9,
@@ -558,6 +930,44 @@
       "result": "pass",
       "tier": 2,
       "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T07:39:40.638552Z",
+      "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-25T07:50:10.916947Z",
+      "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T07:50:11.740894Z",
+      "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
+    },
+    {
+      "at": "2026-08-25T08:04:37.897020Z",
+      "diff_fingerprint": "sha256:3d42c87d9bf8f8feea63b90ce62ade3813a32710671f85ea025b09e2c657e8a3",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "checks.semantic_dup"
+      ]
     }
   ],
   "record_id": "2159-desktop-menu-bar",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   recorded-but-unavailable choices are shown rather than silent, because a
   drop-in refused at scan time or a choice outliving its package used to be
   indistinguishable from "never existed".
+- [#2159] **The desktop app has a real application menu.** The File menu grew
+  from a lone Exit into the actions the toolbar already had: Projects Home,
+  New Project…, Save / Save As… (with the same Ctrl/Cmd+S shortcuts), and Bring
+  In My Work…. A new Packages menu opens the in-app Package Manager, and a new
+  Help menu reaches the Learning Center and runs the update check on demand.
+  Menu clicks are forwarded to the renderer and dispatched onto the same
+  handlers the toolbar uses, so the menu and the buttons cannot drift apart.
 
 - [#2057 #2058] **SciStudio has a Learning Center**: a catalogue of tutorials
   that are real, runnable projects, reached from a permanent toolbar entry and

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -10,6 +10,7 @@ const path = require("path");
 const readline = require("readline");
 
 const ota = require("./ota");
+const { MENU_ACTION_CHANNEL, buildMenuTemplate } = require("./menu");
 const runtimePortModule = require("./runtime-port");
 
 // #1784: the in-app Package Manager stages a package update on disk (into the
@@ -186,6 +187,27 @@ function appIconPath() {
   // #2097: assets/ stays in the asar and does not travel with a shell patch, so
   // this resolves against the bundle root rather than this file's directory.
   return path.join(host().appRoot, "assets", "icon.png");
+}
+
+// Forward a menu action to the renderer; the frontend dispatches it via
+// window.scistudioDesktop.onMenuAction (App.parts/useDesktopMenuActions.ts).
+// Before the main window exists (splash still up) the action is dropped — the
+// user has no project state to act on yet anyway.
+function sendMenuAction(action) {
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send(MENU_ACTION_CHANNEL, action);
+  }
+}
+
+function installApplicationMenu() {
+  const template = buildMenuTemplate({
+    platform: process.platform,
+    appName: app.name,
+    sendMenuAction,
+    checkForUpdates: maybeCheckForUpdate,
+    showAbout,
+  });
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 // --------------------------------------------------------------------------- //
@@ -1372,38 +1394,6 @@ async function showAbout() {
   });
 }
 
-function buildAppMenu() {
-  const isMac = process.platform === "darwin";
-  const about = { label: "About SciStudio", click: () => void showAbout() };
-  // Replacing the default menu wholesale means the standard roles have to be
-  // restored explicitly; without them copy/paste and the developer tools lose
-  // their accelerators.
-  const macAppMenu = {
-    label: app.name,
-    submenu: [
-      about,
-      { type: "separator" },
-      { role: "services" },
-      { type: "separator" },
-      { role: "hide" },
-      { role: "hideOthers" },
-      { role: "unhide" },
-      { type: "separator" },
-      { role: "quit" }
-    ]
-  };
-  return Menu.buildFromTemplate([
-    ...(isMac ? [macAppMenu] : []),
-    {
-      label: "File",
-      submenu: isMac ? [{ role: "close" }] : [about, { type: "separator" }, { role: "quit" }]
-    },
-    { role: "editMenu" },
-    { role: "viewMenu" },
-    { role: "windowMenu" }
-  ]);
-}
-
 function createWindow(url) {
   mainWindow = new BrowserWindow({
     width: 1440,
@@ -1479,6 +1469,7 @@ function start(injectedHost) {
     }
     try {
       safeLog("[scistudio] electron ready");
+      installApplicationMenu();
       splashWindow = createSplashWindow();
       // #1868: enforce a mandatory OTA update before starting the runtime/window.
       // Fail-open: returns true (continue) unless a fetched manifest marks the
@@ -1501,7 +1492,6 @@ function start(injectedHost) {
       // cleanly; remember it as the rollback target for future launches.
       recordKnownGood(effectiveBuild());
       await clearCacheOnBuildChange();
-      Menu.setApplicationMenu(buildAppMenu());
       const url = launchUrl(ready.url);
       safeLog(`[scistudio] creating window for ${url}`);
       splashStatus("Loading the interface…");

--- a/desktop/menu.js
+++ b/desktop/menu.js
@@ -1,0 +1,99 @@
+"use strict";
+
+// Application menu for the desktop shell.
+//
+// The default Electron menu only offered File > Exit; this template replaces
+// it with the app-level entries the owner asked for: project navigation and
+// save actions under File, the in-app Package Manager under Packages, and the
+// Learning Center plus update check under Help.
+//
+// Most entries are frontend actions: the main process cannot reach the React
+// store, so menu clicks are forwarded to the renderer over
+// MENU_ACTION_CHANNEL. The preload bridge exposes them as
+// window.scistudioDesktop.onMenuAction (desktop/preload.js) and the frontend
+// dispatches them in App.parts/useDesktopMenuActions.ts. Keep the action ids
+// below in sync with ScistudioDesktopMenuAction in frontend/src/types/desktop.d.ts.
+
+const MENU_ACTION_CHANNEL = "scistudio:menu-action";
+
+const MENU_ACTIONS = Object.freeze([
+  "projects-home",
+  "new-project",
+  "save",
+  "save-as",
+  "bring-in-my-work",
+  "package-manager",
+  "learning-center",
+]);
+
+function menuActionClick(sendMenuAction, action) {
+  return () => sendMenuAction(action);
+}
+
+// `platform` (process.platform) and `appName` (app.name) are injected so the
+// template stays unit-testable without Electron. `sendMenuAction` forwards an
+// action id to the renderer; `checkForUpdates` runs the OTA update check and
+// `showAbout` opens the #2097 About dialog (desktop/main.js owns all three).
+function buildMenuTemplate({ platform, appName, sendMenuAction, checkForUpdates, showAbout }) {
+  const isMac = platform === "darwin";
+  const send = (action) => menuActionClick(sendMenuAction, action);
+  // #2097: About reports the effective (post-OTA-patch) build, not the
+  // installer baseline the default menu would show.
+  const about = { label: "About SciStudio", click: () => showAbout() };
+
+  const fileSubmenu = [
+    { label: "Projects Home", click: send("projects-home") },
+    { label: "New Project…", accelerator: "CmdOrCtrl+N", click: send("new-project") },
+    { type: "separator" },
+    // Save accelerators mirror the renderer's own keybindings
+    // (App.parts/useAppKeyboardShortcuts.ts). The menu accelerator wins over
+    // the in-page listener in the desktop shell, so the action arrives here.
+    { label: "Save", accelerator: "CmdOrCtrl+S", click: send("save") },
+    { label: "Save As…", accelerator: "CmdOrCtrl+Shift+S", click: send("save-as") },
+    { type: "separator" },
+    { label: "Bring In My Work…", click: send("bring-in-my-work") },
+    { type: "separator" },
+    ...(isMac ? [] : [about, { type: "separator" }]),
+    isMac ? { role: "close" } : { role: "quit", label: "Exit" },
+  ];
+
+  const helpSubmenu = [
+    { label: "Learning Center", click: send("learning-center") },
+    { type: "separator" },
+    { label: "Check for Updates…", click: () => checkForUpdates() },
+  ];
+
+  const template = [
+    { label: "File", submenu: fileSubmenu },
+    // The role menus keep text editing (copy/paste), zoom, reload, and window
+    // management working; replacing the default menu wholesale means the
+    // standard roles have to be restored explicitly.
+    { role: "editMenu" },
+    { role: "viewMenu" },
+    { role: "windowMenu" },
+    {
+      label: "Packages",
+      submenu: [{ label: "Package Manager…", click: send("package-manager") }],
+    },
+    { label: "Help", submenu: helpSubmenu },
+  ];
+  if (isMac) {
+    template.unshift({
+      label: appName,
+      submenu: [
+        about,
+        { type: "separator" },
+        { role: "services" },
+        { type: "separator" },
+        { role: "hide" },
+        { role: "hideOthers" },
+        { role: "unhide" },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    });
+  }
+  return template;
+}
+
+module.exports = { MENU_ACTION_CHANNEL, MENU_ACTIONS, buildMenuTemplate };

--- a/desktop/menu.js
+++ b/desktop/menu.js
@@ -14,6 +14,8 @@
 // dispatches them in App.parts/useDesktopMenuActions.ts. Keep the action ids
 // below in sync with ScistudioDesktopMenuAction in frontend/src/types/desktop.d.ts.
 
+// Also declared as a literal in desktop/preload.js — the sandboxed preload
+// cannot require this file, so keep the two in sync.
 const MENU_ACTION_CHANNEL = "scistudio:menu-action";
 
 const MENU_ACTIONS = Object.freeze([

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -36,6 +36,7 @@
     "files": [
       "bootstrap.js",
       "main.js",
+      "menu.js",
       "ota.js",
       "runtime-port.js",
       "preload.js",

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,6 +1,10 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
-const { MENU_ACTION_CHANNEL } = require("./menu");
+// Sandboxed preloads (desktop/main.js sets `sandbox: true`) may only require
+// Electron's restricted built-in set, so this channel cannot be imported from
+// ./menu — a relative require would abort the preload before the bridge is
+// exposed. Keep the literal in sync with MENU_ACTION_CHANNEL in desktop/menu.js.
+const MENU_ACTION_CHANNEL = "scistudio:menu-action";
 
 contextBridge.exposeInMainWorld("scistudioDesktop", {
   platform: process.platform,

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,5 +1,7 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
+const { MENU_ACTION_CHANNEL } = require("./menu");
+
 contextBridge.exposeInMainWorld("scistudioDesktop", {
   platform: process.platform,
   versions: {
@@ -9,5 +11,13 @@ contextBridge.exposeInMainWorld("scistudioDesktop", {
   // #1784: the in-app Package Manager applies a staged package update by asking
   // the main process to relaunch, so a fresh Python interpreter imports the new
   // package code (already-imported modules are not re-imported in-process).
-  relaunch: () => ipcRenderer.invoke("scistudio:relaunch")
+  relaunch: () => ipcRenderer.invoke("scistudio:relaunch"),
+  // Application-menu actions (desktop/menu.js). Subscribe with a callback that
+  // receives the action id; returns an unsubscribe function. The frontend
+  // dispatches these in App.parts/useDesktopMenuActions.ts.
+  onMenuAction: (callback) => {
+    const listener = (_event, action) => callback(action);
+    ipcRenderer.on(MENU_ACTION_CHANNEL, listener);
+    return () => ipcRenderer.removeListener(MENU_ACTION_CHANNEL, listener);
+  }
 });

--- a/desktop/test/bootstrap.test.js
+++ b/desktop/test/bootstrap.test.js
@@ -154,9 +154,11 @@ test("the loader persists its diagnostics instead of only writing stdout", () =>
 
 test("the app installs its own menu instead of inheriting Electron's default", () => {
   // The default menu is why macOS showed a stale version and Windows had no
-  // About item at all.
+  // About item at all. #2159 moved the template into the pure, unit-testable
+  // desktop/menu.js; main.js only has to install it.
   const main = read("main.js");
-  assert.match(main, /Menu\.setApplicationMenu\(buildAppMenu\(\)\)/);
+  assert.match(main, /require\("\.\/menu"\)/);
+  assert.match(main, /Menu\.setApplicationMenu\(Menu\.buildFromTemplate\(template\)\)/);
 });
 
 test("About reports the effective build, never app.getVersion()", () => {
@@ -199,19 +201,37 @@ test("About carries the licence and copyright, pinned to the repository", () => 
 
 test("every platform can reach About", () => {
   // macOS gets it in the application menu, Windows and Linux in File -- which
-  // previously held nothing but Quit.
-  const main = read("main.js");
-  const build = main.slice(main.indexOf("function buildAppMenu()"), main.indexOf("function createWindow(url)"));
-  assert.match(build, /label:\s*"About SciStudio"/);
-  assert.match(build, /isMac \? \[\{ role: "close" \}\] : \[about,/);
-  assert.match(build, /macAppMenu/);
+  // previously held nothing but Quit. The template lives in menu.js (#2159);
+  // unlike main.js it is pure, so assert on the built template directly.
+  const { buildMenuTemplate } = require("../menu");
+  const deps = {
+    appName: "SciStudio",
+    sendMenuAction: () => {},
+    checkForUpdates: () => {},
+    showAbout: () => {},
+  };
+  const hasAbout = (submenu) => submenu.some((item) => item.label === "About SciStudio");
+
+  const mac = buildMenuTemplate({ ...deps, platform: "darwin" });
+  assert.ok(hasAbout(mac[0].submenu), "macOS app menu must carry About");
+
+  const win = buildMenuTemplate({ ...deps, platform: "win32" });
+  const file = win.find((item) => item.label === "File");
+  assert.ok(hasAbout(file.submenu), "File menu must carry About on Windows/Linux");
 });
 
 test("replacing the default menu keeps the standard roles", () => {
   // Without these, copy/paste and the developer tools lose their accelerators.
-  const main = read("main.js");
-  const build = main.slice(main.indexOf("function buildAppMenu()"), main.indexOf("function createWindow(url)"));
+  const { buildMenuTemplate } = require("../menu");
+  const template = buildMenuTemplate({
+    platform: "win32",
+    appName: "SciStudio",
+    sendMenuAction: () => {},
+    checkForUpdates: () => {},
+    showAbout: () => {},
+  });
+  const roles = template.map((item) => item.role);
   for (const role of ["editMenu", "viewMenu", "windowMenu"]) {
-    assert.ok(build.includes(`{ role: "${role}" }`), `missing role ${role}`);
+    assert.ok(roles.includes(role), `missing role ${role}`);
   }
 });

--- a/desktop/test/menu.test.js
+++ b/desktop/test/menu.test.js
@@ -1,0 +1,146 @@
+"use strict";
+
+// Unit tests for the application-menu template (desktop/menu.js).
+// Run with: npm --prefix desktop test   (Node built-in runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const { MENU_ACTIONS, buildMenuTemplate } = require("../menu");
+
+function makeDeps(platform) {
+  const sent = [];
+  let updateChecks = 0;
+  let aboutShown = 0;
+  const template = buildMenuTemplate({
+    platform,
+    appName: "SciStudio",
+    sendMenuAction: (action) => sent.push(action),
+    checkForUpdates: () => {
+      updateChecks += 1;
+    },
+    showAbout: () => {
+      aboutShown += 1;
+    },
+  });
+  return { sent, updateChecks: () => updateChecks, aboutShown: () => aboutShown, template };
+}
+
+function topLevel(template, label) {
+  const entry = template.find((item) => item.label === label);
+  assert.ok(entry, `expected a top-level "${label}" menu`);
+  return entry;
+}
+
+function clickItem(submenu, label) {
+  const item = submenu.find((entry) => entry.label === label);
+  assert.ok(item, `expected a "${label}" menu item`);
+  assert.equal(typeof item.click, "function", `"${label}" must be clickable`);
+  item.click();
+}
+
+test("File menu offers projects home, new project, save actions, and bring in my work", () => {
+  const { sent, template } = makeDeps("win32");
+  const file = topLevel(template, "File");
+  const labels = file.submenu.map((item) => item.label || item.type);
+
+  assert.deepEqual(labels, [
+    "Projects Home",
+    "New Project…",
+    "separator",
+    "Save",
+    "Save As…",
+    "separator",
+    "Bring In My Work…",
+    "separator",
+    "About SciStudio",
+    "separator",
+    "Exit",
+  ]);
+
+  clickItem(file.submenu, "Projects Home");
+  clickItem(file.submenu, "New Project…");
+  clickItem(file.submenu, "Save");
+  clickItem(file.submenu, "Save As…");
+  clickItem(file.submenu, "Bring In My Work…");
+  assert.deepEqual(sent, [
+    "projects-home",
+    "new-project",
+    "save",
+    "save-as",
+    "bring-in-my-work",
+  ]);
+});
+
+test("Packages menu opens the in-app Package Manager", () => {
+  const { sent, template } = makeDeps("win32");
+  const packages = topLevel(template, "Packages");
+  clickItem(packages.submenu, "Package Manager…");
+  assert.deepEqual(sent, ["package-manager"]);
+});
+
+test("Help menu opens the Learning Center and runs the update check", () => {
+  const { sent, updateChecks, template } = makeDeps("linux");
+  const help = topLevel(template, "Help");
+  clickItem(help.submenu, "Learning Center");
+  clickItem(help.submenu, "Check for Updates…");
+  assert.deepEqual(sent, ["learning-center"]);
+  assert.equal(updateChecks(), 1);
+});
+
+test("standard role menus stay available (edit/view/window)", () => {
+  const { template } = makeDeps("win32");
+  const roles = template.map((item) => item.role).filter(Boolean);
+  assert.ok(roles.includes("editMenu"));
+  assert.ok(roles.includes("viewMenu"));
+  assert.ok(roles.includes("windowMenu"));
+});
+
+test("macOS gets the app menu with About, and Close instead of Exit", () => {
+  const { aboutShown, template } = makeDeps("darwin");
+  const appMenu = template[0];
+  assert.equal(appMenu.label, "SciStudio");
+  clickItem(appMenu.submenu, "About SciStudio");
+  assert.equal(aboutShown(), 1);
+  const file = topLevel(template, "File");
+  const last = file.submenu[file.submenu.length - 1];
+  assert.equal(last.role, "close");
+  // About lives in the app menu on macOS, not in File.
+  assert.ok(!file.submenu.some((item) => item.label === "About SciStudio"));
+});
+
+test("About opens the #2097 dialog from the File menu on Windows/Linux", () => {
+  const { aboutShown, template } = makeDeps("win32");
+  clickItem(topLevel(template, "File").submenu, "About SciStudio");
+  assert.equal(aboutShown(), 1);
+});
+
+test("Save accelerators mirror the renderer keybindings", () => {
+  const { template } = makeDeps("win32");
+  const file = topLevel(template, "File");
+  assert.equal(
+    file.submenu.find((item) => item.label === "Save").accelerator,
+    "CmdOrCtrl+S",
+  );
+  assert.equal(
+    file.submenu.find((item) => item.label === "Save As…").accelerator,
+    "CmdOrCtrl+Shift+S",
+  );
+});
+
+test("every forwarded action id is a known MENU_ACTIONS entry", () => {
+  // Guards the contract with frontend/src/types/desktop.d.ts
+  // (ScistudioDesktopMenuAction): clicking every clickable item must only
+  // ever produce ids the frontend knows how to dispatch.
+  const { sent, template } = makeDeps("win32");
+  const walk = (items) => {
+    for (const item of items || []) {
+      if (item.submenu) walk(item.submenu);
+      if (item.click) item.click();
+    }
+  };
+  walk(template);
+  assert.ok(sent.length > 0);
+  for (const action of sent) {
+    assert.ok(MENU_ACTIONS.includes(action), `unknown menu action "${action}"`);
+  }
+});

--- a/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
+++ b/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
@@ -73,6 +73,38 @@ describe("useDesktopMenuActions", () => {
     expect(handlers.saveAs).toHaveBeenCalledTimes(1);
   });
 
+  it("suppresses save-as while a file tab is active (ADR-036 §3.7)", () => {
+    const bridge = installBridge();
+    const handlers = renderMenuActions();
+
+    act(() => {
+      useAppStore.setState({
+        tabs: [
+          {
+            kind: "file",
+            id: "file-1",
+            filePath: "C:\\Project\\notes.md",
+            displayName: "notes.md",
+            language: "markdown",
+            content: "",
+            contentLoadedAt: 0,
+            dirty: false,
+            readOnly: false,
+          },
+        ],
+        activeTabId: "file-1",
+      });
+    });
+    bridge.fire("save-as");
+    expect(handlers.saveAs).not.toHaveBeenCalled();
+
+    act(() => {
+      useAppStore.setState({ tabs: [], activeTabId: null });
+    });
+    bridge.fire("save-as");
+    expect(handlers.saveAs).toHaveBeenCalledTimes(1);
+  });
+
   it("projects-home closes the active project; new-project opens the dialog", () => {
     const bridge = installBridge();
     renderMenuActions();

--- a/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
+++ b/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
@@ -31,14 +31,22 @@ function installBridge() {
 
 function renderMenuActions() {
   const handlers = {
-    goHome: vi.fn(),
-    newProject: vi.fn(),
     save: vi.fn(),
     saveAs: vi.fn(),
   };
   renderHook(() => useDesktopMenuActions(handlers));
   return handlers;
 }
+
+const DEMO_PROJECT = {
+  id: "p1",
+  name: "Project",
+  description: "",
+  path: "C:\\Project",
+  workflow_count: 1,
+  workflows: ["main"],
+  current_workflow_id: "main",
+};
 
 describe("useDesktopMenuActions", () => {
   beforeEach(() => {
@@ -54,19 +62,31 @@ describe("useDesktopMenuActions", () => {
     expect(() => renderMenuActions()).not.toThrow();
   });
 
-  it("routes project navigation and save actions to the App handlers", () => {
+  it("routes save actions to the App handlers", () => {
     const bridge = installBridge();
     const handlers = renderMenuActions();
 
-    bridge.fire("projects-home");
-    bridge.fire("new-project");
     bridge.fire("save");
     bridge.fire("save-as");
 
-    expect(handlers.goHome).toHaveBeenCalledTimes(1);
-    expect(handlers.newProject).toHaveBeenCalledTimes(1);
     expect(handlers.save).toHaveBeenCalledTimes(1);
     expect(handlers.saveAs).toHaveBeenCalledTimes(1);
+  });
+
+  it("projects-home closes the active project; new-project opens the dialog", () => {
+    const bridge = installBridge();
+    renderMenuActions();
+
+    act(() => {
+      useAppStore.setState({ currentProject: DEMO_PROJECT });
+    });
+    bridge.fire("projects-home");
+    expect(useAppStore.getState().currentProject).toBeNull();
+
+    bridge.fire("new-project");
+    const { projectDialogOpen, projectDialog } = useAppStore.getState();
+    expect(projectDialogOpen).toBe(true);
+    expect(projectDialog.mode).toBe("new");
   });
 
   it("opens the Package Manager and Learning Center through the store", () => {
@@ -88,17 +108,7 @@ describe("useDesktopMenuActions", () => {
     expect(useAppStore.getState().bringInMyWorkOpen).toBe(false);
 
     act(() => {
-      useAppStore.setState({
-        currentProject: {
-          id: "p1",
-          name: "Project",
-          description: "",
-          path: "C:\\Project",
-          workflow_count: 1,
-          workflows: ["main"],
-          current_workflow_id: "main",
-        },
-      });
+      useAppStore.setState({ currentProject: DEMO_PROJECT });
     });
     bridge.fire("bring-in-my-work");
     expect(useAppStore.getState().bringInMyWorkOpen).toBe(true);
@@ -106,13 +116,7 @@ describe("useDesktopMenuActions", () => {
 
   it("unsubscribes from the bridge on unmount", () => {
     const bridge = installBridge();
-    const handlers = {
-      goHome: vi.fn(),
-      newProject: vi.fn(),
-      save: vi.fn(),
-      saveAs: vi.fn(),
-    };
-    const hook = renderHook(() => useDesktopMenuActions(handlers));
+    const hook = renderHook(() => useDesktopMenuActions({ save: vi.fn(), saveAs: vi.fn() }));
     hook.unmount();
     expect(bridge.unsubscribe).toHaveBeenCalledTimes(1);
   });

--- a/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
+++ b/frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx
@@ -1,0 +1,119 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../../store";
+import { resetAppStore } from "../../testUtils";
+import type { ScistudioDesktopMenuAction } from "../../types/desktop";
+import { useDesktopMenuActions } from "../useDesktopMenuActions";
+
+type MenuListener = (action: ScistudioDesktopMenuAction) => void;
+
+function installBridge() {
+  let listener: MenuListener | null = null;
+  const unsubscribe = vi.fn();
+  window.scistudioDesktop = {
+    platform: "win32",
+    versions: { electron: "42.0.0", chrome: "130.0.0" },
+    relaunch: vi.fn(),
+    onMenuAction: (callback: MenuListener) => {
+      listener = callback;
+      return unsubscribe;
+    },
+  };
+  return {
+    fire: (action: ScistudioDesktopMenuAction) => {
+      expect(listener).not.toBeNull();
+      act(() => listener!(action));
+    },
+    unsubscribe,
+  };
+}
+
+function renderMenuActions() {
+  const handlers = {
+    goHome: vi.fn(),
+    newProject: vi.fn(),
+    save: vi.fn(),
+    saveAs: vi.fn(),
+  };
+  renderHook(() => useDesktopMenuActions(handlers));
+  return handlers;
+}
+
+describe("useDesktopMenuActions", () => {
+  beforeEach(() => {
+    resetAppStore();
+  });
+
+  afterEach(() => {
+    delete window.scistudioDesktop;
+  });
+
+  it("is a no-op when the desktop bridge is absent (browser build)", () => {
+    delete window.scistudioDesktop;
+    expect(() => renderMenuActions()).not.toThrow();
+  });
+
+  it("routes project navigation and save actions to the App handlers", () => {
+    const bridge = installBridge();
+    const handlers = renderMenuActions();
+
+    bridge.fire("projects-home");
+    bridge.fire("new-project");
+    bridge.fire("save");
+    bridge.fire("save-as");
+
+    expect(handlers.goHome).toHaveBeenCalledTimes(1);
+    expect(handlers.newProject).toHaveBeenCalledTimes(1);
+    expect(handlers.save).toHaveBeenCalledTimes(1);
+    expect(handlers.saveAs).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens the Package Manager and Learning Center through the store", () => {
+    const bridge = installBridge();
+    renderMenuActions();
+
+    bridge.fire("package-manager");
+    expect(useAppStore.getState().packageManagerOpen).toBe(true);
+
+    bridge.fire("learning-center");
+    expect(useAppStore.getState().learningCenterOpen).toBe(true);
+  });
+
+  it("opens Bring In My Work only when a project is open", () => {
+    const bridge = installBridge();
+    renderMenuActions();
+
+    bridge.fire("bring-in-my-work");
+    expect(useAppStore.getState().bringInMyWorkOpen).toBe(false);
+
+    act(() => {
+      useAppStore.setState({
+        currentProject: {
+          id: "p1",
+          name: "Project",
+          description: "",
+          path: "C:\\Project",
+          workflow_count: 1,
+          workflows: ["main"],
+          current_workflow_id: "main",
+        },
+      });
+    });
+    bridge.fire("bring-in-my-work");
+    expect(useAppStore.getState().bringInMyWorkOpen).toBe(true);
+  });
+
+  it("unsubscribes from the bridge on unmount", () => {
+    const bridge = installBridge();
+    const handlers = {
+      goHome: vi.fn(),
+      newProject: vi.fn(),
+      save: vi.fn(),
+      saveAs: vi.fn(),
+    };
+    const hook = renderHook(() => useDesktopMenuActions(handlers));
+    hook.unmount();
+    expect(bridge.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/App.parts/closeProject.ts
+++ b/frontend/src/App.parts/closeProject.ts
@@ -1,0 +1,34 @@
+// Extracted from App.tsx to keep App() under its max-lines-per-function
+// budget. The desktop application menu (useDesktopMenuActions) needs the same
+// close-the-project logic without importing the App component module.
+
+import { useAppStore } from "../store";
+import type { ProjectResponse, WorkflowResponse } from "../types/api";
+
+export function emptyWorkflow(id = "main"): WorkflowResponse {
+  return {
+    id,
+    version: "1.0.0",
+    description: "",
+    nodes: [],
+    edges: [],
+    metadata: {},
+  };
+}
+
+/**
+ * Close the active project: clear the project, reset the canvas/execution, and
+ * drop the previous project's open workflow tabs (bug #5). Defaults to the
+ * store's own actions so call sites don't have to thread them through.
+ */
+export function closeCurrentProject(actions?: {
+  setCurrentProject: (project: ProjectResponse | null) => void;
+  setWorkflow: (workflow: WorkflowResponse | null) => void;
+  resetExecution: () => void;
+}): void {
+  const { setCurrentProject, setWorkflow, resetExecution } = actions ?? useAppStore.getState();
+  setCurrentProject(null);
+  setWorkflow(emptyWorkflow());
+  resetExecution();
+  useAppStore.setState({ tabs: [], activeTabId: null });
+}

--- a/frontend/src/App.parts/useDesktopMenuActions.ts
+++ b/frontend/src/App.parts/useDesktopMenuActions.ts
@@ -1,0 +1,63 @@
+// Desktop application menu dispatch.
+//
+// desktop/menu.js forwards menu clicks to the renderer over IPC; the preload
+// bridge exposes them as window.scistudioDesktop.onMenuAction. This hook maps
+// each action id onto the same handlers the toolbar uses, so the native menu
+// and the in-app buttons can never drift apart. In the browser build the
+// bridge is absent and the hook is a no-op.
+
+import { useEffect, useRef } from "react";
+
+import { useAppStore } from "../store";
+
+export interface DesktopMenuHandlers {
+  /** File > Projects Home — close the active project (back to WelcomePane). */
+  goHome: () => void;
+  /** File > New Project… */
+  newProject: () => void;
+  /** File > Save — tab-aware save, same as the toolbar Save button. */
+  save: () => void;
+  /** File > Save As… */
+  saveAs: () => void;
+}
+
+export function useDesktopMenuActions(handlers: DesktopMenuHandlers): void {
+  // The IPC subscription is registered once; the ref keeps the latest handler
+  // identities without re-subscribing on every render.
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  useEffect(() => {
+    const bridge = window.scistudioDesktop;
+    if (!bridge?.onMenuAction) return undefined;
+    return bridge.onMenuAction((action) => {
+      const store = useAppStore.getState();
+      switch (action) {
+        case "projects-home":
+          handlersRef.current.goHome();
+          break;
+        case "new-project":
+          handlersRef.current.newProject();
+          break;
+        case "save":
+          handlersRef.current.save();
+          break;
+        case "save-as":
+          handlersRef.current.saveAs();
+          break;
+        case "bring-in-my-work":
+          // Mirrors the toolbar button's disabled state (ADR-053 spec 2
+          // FR-002): the import dialog writes into the open project, so it
+          // cannot open without one.
+          if (store.currentProject) store.setBringInMyWorkOpen(true);
+          break;
+        case "package-manager":
+          store.setPackageManagerOpen(true);
+          break;
+        case "learning-center":
+          store.openLearningCenter();
+          break;
+      }
+    });
+  }, []);
+}

--- a/frontend/src/App.parts/useDesktopMenuActions.ts
+++ b/frontend/src/App.parts/useDesktopMenuActions.ts
@@ -9,12 +9,9 @@
 import { useEffect, useRef } from "react";
 
 import { useAppStore } from "../store";
+import { closeCurrentProject } from "./closeProject";
 
 export interface DesktopMenuHandlers {
-  /** File > Projects Home — close the active project (back to WelcomePane). */
-  goHome: () => void;
-  /** File > New Project… */
-  newProject: () => void;
   /** File > Save — tab-aware save, same as the toolbar Save button. */
   save: () => void;
   /** File > Save As… */
@@ -34,10 +31,11 @@ export function useDesktopMenuActions(handlers: DesktopMenuHandlers): void {
       const store = useAppStore.getState();
       switch (action) {
         case "projects-home":
-          handlersRef.current.goHome();
+          closeCurrentProject();
           break;
         case "new-project":
-          handlersRef.current.newProject();
+          // Same as the toolbar's New Project entry: keep the last-used path.
+          store.openProjectDialog("new", { path: store.projectDialog.path });
           break;
         case "save":
           handlersRef.current.save();

--- a/frontend/src/App.parts/useDesktopMenuActions.ts
+++ b/frontend/src/App.parts/useDesktopMenuActions.ts
@@ -14,7 +14,7 @@ import { closeCurrentProject } from "./closeProject";
 export interface DesktopMenuHandlers {
   /** File > Save — tab-aware save, same as the toolbar Save button. */
   save: () => void;
-  /** File > Save As… */
+  /** File > Save As… — workflow-only; suppressed while a file tab is active. */
   saveAs: () => void;
 }
 
@@ -40,9 +40,16 @@ export function useDesktopMenuActions(handlers: DesktopMenuHandlers): void {
         case "save":
           handlersRef.current.save();
           break;
-        case "save-as":
-          handlersRef.current.saveAs();
+        case "save-as": {
+          // Mirror the Ctrl/Cmd+Shift+S guard in useAppKeyboardShortcuts and
+          // the toolbar's hidden button: file tabs save only to their fixed
+          // path (ADR-036 §3.7), so Save As is a workflow-only action. The
+          // native accelerator bypasses the in-page listener, so the guard
+          // has to live here at dispatch time.
+          const activeTab = store.tabs.find((tab) => tab.id === store.activeTabId);
+          if (activeTab?.kind !== "file") handlersRef.current.saveAs();
           break;
+        }
         case "bring-in-my-work":
           // Mirrors the toolbar button's disabled state (ADR-053 spec 2
           // FR-002): the import dialog writes into the open project, so it

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,10 +28,11 @@ import { useLogStream } from "./hooks/useSSE";
 import { useWorkflowWebSocket } from "./hooks/useWebSocket";
 import { useAppStore } from "./store";
 import type { AnyTab } from "./store/types";
-import type { ProjectResponse, WorkflowResponse } from "./types/api";
+import type { WorkflowResponse } from "./types/api";
 
 import { AppLevelMergeFlow } from "./App.parts/AppLevelMergeFlow";
 import { AppDialogs } from "./App.parts/AppDialogs";
+import { closeCurrentProject } from "./App.parts/closeProject";
 import { InteractiveModals } from "./App.parts/InteractiveModals";
 import { ProjectWorkspace, type LeftTab } from "./App.parts/ProjectWorkspace";
 import { WelcomePane } from "./App.parts/WelcomePane";
@@ -56,33 +57,6 @@ import { ActiveStep } from "./components/LearningCenter.parts/ActiveStep";
 import { WorkImportOffer } from "./components/LearningCenter.parts/WorkImportOffer";
 import { Toolbar } from "./components/Toolbar";
 import { TooltipProvider } from "./components/ui/tooltip";
-
-function emptyWorkflow(id = "main"): WorkflowResponse {
-  return {
-    id,
-    version: "1.0.0",
-    description: "",
-    nodes: [],
-    edges: [],
-    metadata: {},
-  };
-}
-
-/**
- * Close the active project: clear the project, reset the canvas/execution, and
- * drop the previous project's open workflow tabs (bug #5). Module-level so it
- * does not count against App()'s line budget.
- */
-function closeCurrentProject(actions: {
-  setCurrentProject: (project: ProjectResponse | null) => void;
-  setWorkflow: (workflow: WorkflowResponse | null) => void;
-  resetExecution: () => void;
-}): void {
-  actions.setCurrentProject(null);
-  actions.setWorkflow(emptyWorkflow());
-  actions.resetExecution();
-  useAppStore.setState({ tabs: [], activeTabId: null });
-}
 
 /** Dismissable top-of-canvas error banner. Extracted to keep App() under the
  * max-lines-per-function lint limit. */
@@ -417,7 +391,7 @@ export default function App() {
     wsConnected,
     setLeftTab: selectLeftTab,
     openProject,
-    closeProject: () => closeCurrentProject({ setCurrentProject, setWorkflow, resetExecution }),
+    closeProject: () => closeCurrentProject(),
   });
   /*
    * ADR-053 FR-061a (#2083) — fold the tutorial's scripted replay tab into
@@ -442,16 +416,9 @@ export default function App() {
     togglePreview,
     undoWorkflow,
   });
-  // Desktop application menu (desktop/menu.js). No-op in the browser build.
-  useDesktopMenuActions({
-    goHome: () => closeCurrentProject({ setCurrentProject, setWorkflow, resetExecution }),
-    newProject: () => openProjectDialog("new", { path: projectDialog.path }),
-    save: handleSave,
-    saveAs: () => void saveWorkflowAs(),
-  });
-  // The New-menu entries are project-scoped: `undefined` is what makes the
-  // toolbar hide/disable them. ADR-053 FR-032 adds a third one, so the shape is
-  // written once rather than three times.
+  useDesktopMenuActions({ save: handleSave, saveAs: () => void saveWorkflowAs() });
+  // The New-menu entries are project-scoped: `undefined` hides/disables them in
+  // the toolbar. ADR-053 FR-032 adds a third one, so the shape is written once.
   const whenProjectOpen = (run: () => Promise<void>) =>
     currentProject ? () => void run() : undefined;
 
@@ -474,9 +441,7 @@ export default function App() {
             onNewProject={() => openProjectDialog("new", { path: projectDialog.path })}
             onOpenProject={() => openProjectDialog("open")}
             onOpenRecent={(project) => void openProject(project.id)}
-            onCloseProject={() =>
-              closeCurrentProject({ setCurrentProject, setWorkflow, resetExecution })
-            }
+            onCloseProject={() => closeCurrentProject()}
             onNewWorkflow={newWorkflow}
             onNewCustomBlock={whenProjectOpen(createNewCustomBlock)}
             onNewDataType={whenProjectOpen(createNewDataType)}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,6 +41,7 @@ import { useAppLifecycleEffects } from "./App.parts/useAppLifecycleEffects";
 import { useBottomPanelControls } from "./App.parts/useBottomPanelControls";
 import { useCanvasHandlers } from "./App.parts/useCanvasHandlers";
 import { useCanvasReadability } from "./App.parts/useCanvasReadability";
+import { useDesktopMenuActions } from "./App.parts/useDesktopMenuActions";
 import { useFileTabsAutosave } from "./App.parts/useFileTabsAutosave";
 import { useLearningCenter } from "./App.parts/useLearningCenter";
 import { useTutorialReplayTab } from "./App.parts/useTutorialReplayTab";
@@ -440,6 +441,13 @@ export default function App() {
     togglePalette,
     togglePreview,
     undoWorkflow,
+  });
+  // Desktop application menu (desktop/menu.js). No-op in the browser build.
+  useDesktopMenuActions({
+    goHome: () => closeCurrentProject({ setCurrentProject, setWorkflow, resetExecution }),
+    newProject: () => openProjectDialog("new", { path: projectDialog.path }),
+    save: handleSave,
+    saveAs: () => void saveWorkflowAs(),
   });
   // The New-menu entries are project-scoped: `undefined` is what makes the
   // toolbar hide/disable them. ADR-053 FR-032 adds a third one, so the shape is

--- a/frontend/src/components/Toolbar.tsx
+++ b/frontend/src/components/Toolbar.tsx
@@ -1,7 +1,6 @@
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { FolderInput, GraduationCap, Package } from "lucide-react";
-import { useState } from "react";
 
 import type { ConnectionStatus } from "../hooks/connectionState";
 import { usePackageUpdates } from "../hooks/usePackageUpdates";
@@ -123,11 +122,15 @@ export function Toolbar(props: ToolbarProps) {
   void wsStatus;
   void sseStatus;
   const isFileTab = activeTabKind === "file";
-  const [packageManagerOpen, setPackageManagerOpen] = useState(false);
+  // #1784 — dialog open state lives in the store so the desktop application
+  // menu (desktop/menu.js → useDesktopMenuActions) can open it too.
+  const packageManagerOpen = useAppStore((state) => state.packageManagerOpen);
+  const setPackageManagerOpen = useAppStore((state) => state.setPackageManagerOpen);
   // ADR-053 spec 2 (#2001) — the dialog is mounted only while open so its
   // availability probe fires when the user asks for the feature, not on every
-  // app start.
-  const [bringInMyWorkOpen, setBringInMyWorkOpen] = useState(false);
+  // app start. Store-backed for the same desktop-menu reason as above.
+  const bringInMyWorkOpen = useAppStore((state) => state.bringInMyWorkOpen);
+  const setBringInMyWorkOpen = useAppStore((state) => state.setBringInMyWorkOpen);
   const { updateCount } = usePackageUpdates();
   /*
    * ADR-053 Learning Center (#2057) FR-082 — a PERMANENT entry, on the same

--- a/frontend/src/components/__tests__/BringInMyWorkToolbarEntry.test.tsx
+++ b/frontend/src/components/__tests__/BringInMyWorkToolbarEntry.test.tsx
@@ -10,10 +10,17 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { useAppStore } from "../../store";
 import { Toolbar } from "../Toolbar";
 import { ENTRY_LABEL } from "../BringInMyWorkDialog.parts/copy";
 
-afterEach(cleanup);
+// The dialog open state is store-backed (the desktop application menu opens it
+// too), so it must be reset between tests — a store value survives unmount,
+// unlike the Toolbar-local useState it replaced.
+afterEach(() => {
+  cleanup();
+  useAppStore.setState({ bringInMyWorkOpen: false, packageManagerOpen: false });
+});
 
 function makeProps(overrides: Partial<React.ComponentProps<typeof Toolbar>> = {}) {
   return {

--- a/frontend/src/store/types.ts
+++ b/frontend/src/store/types.ts
@@ -424,6 +424,17 @@ export interface UISlice {
   toggleMinimap: () => void;
   setPanelSize: (panel: "palette" | "preview" | "bottom", size: number) => void;
   setLastError: (message: string | null) => void;
+  /**
+   * Desktop application menu (desktop/menu.js) opens these dialogs from
+   * outside the toolbar, so the open state lives in the store instead of
+   * Toolbar-local useState. Not persisted: a reopened app never starts with a
+   * dialog already up.
+   */
+  packageManagerOpen: boolean;
+  /** See `packageManagerOpen`; the dialog mounts only while open. */
+  bringInMyWorkOpen: boolean;
+  setPackageManagerOpen: (open: boolean) => void;
+  setBringInMyWorkOpen: (open: boolean) => void;
 }
 
 export interface PreviewSlice {

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -114,4 +114,10 @@ export const createUISlice: StateCreator<AppStore, [], [], UISlice> = (set, get)
       },
     })),
   setLastError: (message) => set({ lastError: message }),
+  // Desktop menu (desktop/menu.js) opens these dialogs without going through
+  // the toolbar, so the open state is shared store state.
+  packageManagerOpen: false,
+  bringInMyWorkOpen: false,
+  setPackageManagerOpen: (open) => set({ packageManagerOpen: open }),
+  setBringInMyWorkOpen: (open) => set({ bringInMyWorkOpen: open }),
 });

--- a/frontend/src/testUtils.ts
+++ b/frontend/src/testUtils.ts
@@ -38,6 +38,9 @@ export function resetAppStore() {
     panelSizes: { palette: 15, preview: 22, bottom: 30 },
     minimapVisible: true,
     lastError: null,
+    // Desktop-menu-reachable dialog state (desktop/menu.js).
+    packageManagerOpen: false,
+    bringInMyWorkOpen: false,
     blocks: [],
     blockSchemas: {},
     paletteSearch: "",

--- a/frontend/src/types/desktop.d.ts
+++ b/frontend/src/types/desktop.d.ts
@@ -1,11 +1,29 @@
 // Ambient typing for the Electron preload bridge (desktop/preload.js).
 // Present only in the bundled desktop app; guard usage with optional chaining.
 
+/**
+ * Action ids sent by the desktop application menu (desktop/menu.js) over the
+ * "scistudio:menu-action" IPC channel. Keep in sync with MENU_ACTIONS there.
+ */
+export type ScistudioDesktopMenuAction =
+  | "projects-home"
+  | "new-project"
+  | "save"
+  | "save-as"
+  | "bring-in-my-work"
+  | "package-manager"
+  | "learning-center";
+
 export interface ScistudioDesktopBridge {
   platform: string;
   versions: { electron: string; chrome: string };
   /** #1784: relaunch the app so a fresh interpreter loads updated packages. */
   relaunch: () => Promise<void>;
+  /**
+   * Subscribe to application-menu actions. Returns an unsubscribe function.
+   * Only present in the desktop shell; absent in the browser build.
+   */
+  onMenuAction: (callback: (action: ScistudioDesktopMenuAction) => void) => () => void;
 }
 
 declare global {

--- a/scripts/ota_publish.py
+++ b/scripts/ota_publish.py
@@ -61,6 +61,7 @@ REINSTALL_NOTICE_TEMPLATE = REPO_ROOT / "scripts" / "templates" / "reinstall-not
 # and a manifest inside the patch would be the patch describing itself.
 SHELL_FILES = (
     "main.js",
+    "menu.js",
     "ota.js",
     "runtime-port.js",
     "preload.js",

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -182,7 +182,7 @@ def _fake_desktop(tmp_path: Path) -> Path:
     """A desktop/ directory holding just the files a snapshot deals with."""
     desktop = tmp_path / "desktop"
     desktop.mkdir(exist_ok=True)
-    for name in ("main.js", "ota.js", "runtime-port.js", "preload.js", "splash.html"):
+    for name in ("main.js", "menu.js", "ota.js", "runtime-port.js", "preload.js", "splash.html"):
         (desktop / name).write_text("// " + name, encoding="utf-8")
     (desktop / "assets").mkdir(exist_ok=True)
     (desktop / "assets" / "icon.png").write_bytes(b"PNG-stub")
@@ -206,7 +206,7 @@ def _snapshot_names(mod: ModuleType, tmp_path: Path) -> set[str]:
 def test_make_snapshot_carries_the_shell_beside_src(mod: ModuleType, tmp_path: Path) -> None:
     names = _snapshot_names(mod, tmp_path)
     assert "src/scistudio/__init__.py" in names
-    for name in ("main.js", "ota.js", "runtime-port.js", "preload.js", "splash.html"):
+    for name in ("main.js", "menu.js", "ota.js", "runtime-port.js", "preload.js", "splash.html"):
         assert f"shell/{name}" in names
 
 


### PR DESCRIPTION
## What

Give the desktop shell a real application menu instead of Electron's default
(File > Exit only):

- **File**: Projects Home (close the active project), New Project…, Save /
  Save As… (same accelerators as the frontend keybindings), Bring In My Work…,
  Exit.
- **Packages**: Package Manager… (opens the in-app Package Manager).
- **Help**: Learning Center, Check for Updates… (runs the OTA update check).
- Standard Edit / View / Window role menus stay so text editing, zoom, and
  window management keep working; macOS gets the app menu and Close.

## How

- `desktop/menu.js` builds the menu template as a pure, testable module;
  `desktop/main.js` installs it and forwards clicks to the renderer over the
  `scistudio:menu-action` IPC channel.
- `desktop/preload.js` exposes `scistudioDesktop.onMenuAction` on the bridge
  (typed in `frontend/src/types/desktop.d.ts`).
- `frontend/src/App.parts/useDesktopMenuActions.ts` dispatches menu actions
  onto the same handlers the toolbar uses.
- Package Manager / Bring-in-my-work dialog open state moved from Toolbar-local
  `useState` into the UI store slice so the menu can open them.
- `desktop/package.json` `files` gains `menu.js` so packaged builds include it.

## Tests

- `desktop/test/menu.test.js` — template structure, click dispatch, macOS
  variant, accelerator parity with the renderer keybindings.
- `frontend/src/App.parts/__tests__/useDesktopMenuActions.test.tsx` — dispatch,
  store side effects, no-project gating, bridge-absent no-op.

Gate record: .workflow/records/2159-desktop-menu-bar.json

Closes #2159
