### PR TITLE
ci(#2172): give the desktop build jobs a timeout

### DIFF
--- a/.github/workflows/desktop-linux-appimage.yml
+++ b/.github/workflows/desktop-linux-appimage.yml
@@ -31,6 +31,9 @@ jobs:
     # An AppImage built on a newer runner would refuse to launch on older
     # distros. ubuntu-22.04 is the compatibility baseline (ADR-037 §7.3).
     runs-on: ubuntu-22.04
+    # #2172: without this GitHub's six-hour default applies, and a hung build
+    # burns a runner-day before failing.
+    timeout-minutes: 60
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -30,6 +30,13 @@ jobs:
     # build:python:mac keys off `uname -m` and dist:dmg now targets --arm64
     # (#1747). An Intel runner here would bundle x64 Python in an arm64 shell.
     runs-on: macos-15
+    # #2172: signing every Mach-O in the bundle and then waiting on Apple's
+    # notarization queue both run silently for a long time, so a hang is
+    # indistinguishable from slowness. Without a timeout GitHub's default of six
+    # hours applies, and a stuck build burns a runner-day before anyone learns
+    # anything. 90 minutes is well clear of a legitimately slow notarization
+    # queue while still failing inside a release window.
+    timeout-minutes: 90
     env:
       # #2096: signing is driven by whether the Developer ID certificate is
       # configured as a repository secret. With no certificate, identity

--- a/.github/workflows/desktop-windows-installer.yml
+++ b/.github/workflows/desktop-windows-installer.yml
@@ -27,6 +27,10 @@ jobs:
   build-installer:
     name: Build Windows installer
     runs-on: windows-latest
+    # #2172: without this GitHub's six-hour default applies, and a hung build
+    # burns a runner-day before failing. The runtime download alone has already
+    # been cut off mid-transfer once.
+    timeout-minutes: 60
     env:
       CSC_IDENTITY_AUTO_DISCOVERY: "false"
     steps:

--- a/.workflow/records/2172-build-timeouts.json
+++ b/.workflow/records/2172-build-timeouts.json
@@ -1,0 +1,69 @@
+{
+  "base_ref": null,
+  "branch": "ci/2172-build-timeouts",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      ".github/workflows/desktop-macos-dmg.yml",
+      ".github/workflows/desktop-windows-installer.yml",
+      ".github/workflows/desktop-linux-appimage.yml",
+      "tests/packaging/test_desktop_runtime_build_auth.py",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T09:10:00.720505Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2172,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Monitor the mac release build; if two hours pass without success, cancel it, investigate the cause and fix it. Then carry the release through to the end.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2172-build-timeouts",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "ac4194d1-50b3-48f7-8c1b-05ad726b77a2",
+  "strictness_tier": null,
+  "task_kind": "maintenance",
+  "test_events": [
+    {
+      "at": "2026-08-25T09:10:00.720527Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/packaging/test_desktop_runtime_build_auth.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -548,6 +548,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   build step now surfaces `@electron/notarize`'s output, so the submission ID and
   each polling state reach the log and a cancelled run can still be traced with
   `notarytool log <id>` afterwards.
+- [#2172] **A hung desktop build now fails in minutes rather than hours.** The
+  three build workflows carried no `timeout-minutes`, so GitHub's six-hour
+  default applied. That matters most on macOS, where `Build DMG` signs several
+  hundred Mach-O files one process at a time and then waits on Apple's
+  notarization queue — both silent, so a hang is indistinguishable from
+  slowness while it is happening. A 0.3.4 build sat there for over forty
+  minutes with nothing to go on. macOS now has 90 minutes, generous against a
+  slow notarization queue but inside a release window; Windows and Linux have
+  60. A test asserts every build job carries one.
 
 - [#2169] **The reinstall notice can now reach the clients it exists for.**
   `--reinstall-notice` was written for one situation — the base version moved,

--- a/tests/packaging/test_desktop_runtime_build_auth.py
+++ b/tests/packaging/test_desktop_runtime_build_auth.py
@@ -109,6 +109,4 @@ def test_build_jobs_carry_a_timeout(name: str) -> None:
     for job_name, job in spec["jobs"].items():
         timeout = job.get("timeout-minutes")
         assert timeout is not None, f"{name}:{job_name} has no timeout-minutes"
-        assert 0 < timeout <= 120, (
-            f"{name}:{job_name} timeout of {timeout} minutes defeats the purpose"
-        )
+        assert 0 < timeout <= 120, f"{name}:{job_name} timeout of {timeout} minutes defeats the purpose"

--- a/tests/packaging/test_desktop_runtime_build_auth.py
+++ b/tests/packaging/test_desktop_runtime_build_auth.py
@@ -89,3 +89,26 @@ def test_the_asset_download_stays_unauthenticated(name: str) -> None:
     ]
     for line in download_lines:
         assert "Authorization" not in line, f"{name}: the asset download must not be authenticated"
+
+
+# --------------------------------------------------------------------------- #
+# #2172: a hang must fail inside a release window, not after six hours.
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("name", BUILD_WORKFLOWS)
+def test_build_jobs_carry_a_timeout(name: str) -> None:
+    """Without one, GitHub's default is six hours.
+
+    The macOS build signs several hundred Mach-O files and then waits on Apple's
+    notarization queue, both silently, so a hang looks exactly like slowness from
+    the outside. A build that fails at 90 minutes is actionable; one that fails
+    after six hours arrives when the release window has closed.
+    """
+    import yaml
+
+    spec = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    for job_name, job in spec["jobs"].items():
+        timeout = job.get("timeout-minutes")
+        assert timeout is not None, f"{name}:{job_name} has no timeout-minutes"
+        assert 0 < timeout <= 120, (
+            f"{name}:{job_name} timeout of {timeout} minutes defeats the purpose"
+        )


### PR DESCRIPTION
Closes #2172

## Why

The 0.3.4 macOS build sat in `Build DMG` for over forty minutes with a static
log, and there was no way to tell "slow" from "hung" from the outside. That step
signs several hundred Mach-O files one `codesign` process at a time and then
waits on Apple's notarization queue — both silent while they run.

None of the three desktop build workflows carried `timeout-minutes`, so GitHub's
**six-hour** default applied. A genuine hang burns a runner-day before anyone
learns anything, and the answer arrives long after the release window has
closed.

## What

| Workflow | Timeout |
|---|---|
| `desktop-macos-dmg.yml` | 90 min |
| `desktop-windows-installer.yml` | 60 min |
| `desktop-linux-appimage.yml` | 60 min |

macOS gets the longest budget because notarization queue time is outside our
control and a legitimately slow queue must not fail the build. A test asserts
every build job carries a timeout and that it is not set so high as to defeat
the purpose.

## What this deliberately does not fix

A specific mechanism can hang the signing phase indefinitely: macOS keychains
carry an idle lock timeout, and electron-builder signs into a temporary keychain
it creates itself. If signing outruns that timeout the keychain locks mid-run,
and every subsequent `codesign` blocks waiting for a password no runner can
supply.

That fits the observed shape — static during signing, more likely the longer the
run — but it is a hypothesis, not a diagnosis, and `security set-keychain-settings`
would be a change made on a guess. The timeout makes the symptom visible and
cheap; #2172 records the hypothesis for whoever reproduces it.
