### PR TITLE
ci(#2174): surface notarization output so a stall can be diagnosed

### DIFF
--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -114,6 +114,13 @@ jobs:
           APPLE_API_KEY: ${{ env.HAS_NOTARY_KEY == 'true' && format('{0}/private_keys/AuthKey.p8', runner.temp) || '' }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # #2174: notarization is the one step that depends on a third party,
+          # has no upper bound, and prints nothing while it waits. A 118-minute
+          # hang left only the runner's own 'Terminate orphan process (notarytool)'
+          # line to go on, which ruled out signing and nothing else. This surfaces
+          # the submission ID and each polling state, so a cancelled build can
+          # still be traced with `notarytool log <id>` afterwards.
+          DEBUG: electron-notarize*,@electron/notarize*
         run: npm --prefix desktop run dist:dmg
 
       - name: Remove App Store Connect API key

--- a/.workflow/records/2174-notarize-visibility.json
+++ b/.workflow/records/2174-notarize-visibility.json
@@ -1,0 +1,66 @@
+{
+  "base_ref": null,
+  "branch": "ci/2174-notarize-visibility",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      ".github/workflows/desktop-macos-dmg.yml",
+      "CHANGELOG.md"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T10:26:01.778012Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2174,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Investigate the cause of the hung mac build and fix it.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2174-notarize-visibility",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "f278e086-9117-40bd-996a-edd6393c1d75",
+  "strictness_tier": null,
+  "task_kind": "maintenance",
+  "test_events": [
+    {
+      "at": "2026-08-25T10:26:01.778035Z",
+      "class": "implementation",
+      "kind": "na",
+      "path": null,
+      "rationale": "This turns on a debug environment variable in one workflow step. There is nothing to assert that would not simply restate the line, and the behaviour it changes -- what a third-party tool prints during a release build -- cannot be exercised in the test suite. Its verification is the next macOS build's log.",
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2174] **A stalled notarization now leaves evidence behind.** Notarization is
+  the one release step that depends on a third party, has no upper bound on how
+  long it may take, and prints nothing while it waits — which makes it both the
+  step most in need of observability and the least observable one. A macOS build
+  that hung for 118 minutes produced exactly one usable line, and only from the
+  runner's own cleanup: `Terminate orphan process (notarytool)`. That ruled out
+  the signing phase and nothing else, leaving "never uploaded" and "uploaded and
+  Apple never answered" indistinguishable, though they have different fixes. The
+  build step now surfaces `@electron/notarize`'s output, so the submission ID and
+  each polling state reach the log and a cancelled run can still be traced with
+  `notarytool log <id>` afterwards.
+
 - [#2169] **The reinstall notice can now reach the clients it exists for.**
   `--reinstall-notice` was written for one situation — the base version moved,
   older clients cannot reach the new build over the air, and they must be told


### PR DESCRIPTION
Closes #2174

## Why

The 0.3.4 macOS build sat in `Build DMG` for 118 minutes and was cancelled. The
only usable evidence came from the runner's own cleanup, not from the tool:

```
Terminate orphan process: pid (43019) (notarytool)
```

That ruled out the signing phase — signing had finished, `notarytool` was
running — and nothing else. Across two hours `notarytool` printed **zero**
lines, so two possibilities with different fixes stayed indistinguishable:

- the submission never uploaded, or
- it uploaded and Apple's queue never returned a verdict.

Notarization is the one release step that depends on a third party, has no upper
bound on how long it may take, and produces no output while it waits. It is
simultaneously the step most in need of observability and the least observable
thing in the pipeline.

## What

`DEBUG` scoped to `@electron/notarize` on the `Build DMG` step, so the
submission ID and each polling state reach the log.

The submission ID is the part that matters: with it, `notarytool log <id>` and
`notarytool history` can be queried afterwards from any machine holding the
credentials, long after the runner is gone. Without it, a cancelled build takes
its own evidence with it — which is exactly what happened here.

## No test

This turns on a debug environment variable in one workflow step. Anything
asserted would restate the line, and what it changes — what a third-party tool
prints during a release build — cannot be exercised in the suite. Its
verification is the next macOS build's log. Recorded as a `test_na` in the
ledger rather than left implicit.

## Related

- #2172 gives the job a timeout, bounding the cost of a hang without explaining
  one. This is the other half.
