### PR TITLE
ci(#2176): submit notarization from the build, staple it from a second job

### DIFF
--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -117,24 +117,33 @@ jobs:
           chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
 
       - name: Build DMG
+        # #2176: this signs but does not notarize -- `"notarize": false` in
+        # package.json. The build log still prints "skipped macOS notarization"
+        # from macPackager; that is the setting working, not a failure.
+        # Notarization is the next step, and it does not wait.
+        run: npm --prefix desktop run dist:dmg
+
+      # #2176: submit and stop. Apple held a 0.3.4 submission for over an hour
+      # without a verdict (61 consecutive `In Progress` polls), which is not a
+      # failure anything here can fix -- but waiting for it inside the build
+      # discards the signed dmg and the queue position together, so the next
+      # attempt starts another hour from zero.
+      #
+      # The dmg is submitted rather than the .app, because stapling has to
+      # attach to something that outlives this job. `Desktop macOS Staple`
+      # finishes the job once Apple returns a verdict.
+      - name: Submit for notarization
+        id: notarize
+        if: env.HAS_NOTARY_KEY == 'true'
         env:
-          APPLE_API_KEY: ${{ env.HAS_NOTARY_KEY == 'true' && format('{0}/private_keys/AuthKey.p8', runner.temp) || '' }}
+          APPLE_API_KEY: ${{ format('{0}/private_keys/AuthKey.p8', runner.temp) }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          # #2176: these three are read by desktop/scripts/notarize.js, the
-          # `afterSign` hook that now performs notarization instead of
-          # electron-builder. Note the build log still prints
-          # "skipped macOS notarization" from macPackager -- that is
-          # `"notarize": false` in package.json doing its job, not a skip.
-          # The hook's own output is prefixed [notarize].
-          #
-          # This bound must stay comfortably below the job's timeout-minutes
-          # (#2172). If the job dies first the hook never gets to say which
-          # submission was left in flight, which is the one thing a timed-out
-          # build needs to report. The headroom covers signing, which precedes
-          # notarization and has been measured anywhere from 2 to 12 minutes.
-          SCISTUDIO_NOTARIZE_TIMEOUT_MIN: "60"
-        run: npm --prefix desktop run dist:dmg
+        run: |
+          set -euo pipefail
+          DMG=$(find desktop/dist -maxdepth 1 -name '*.dmg' -print -quit)
+          test -n "$DMG" || { echo "::error::no dmg to submit"; exit 1; }
+          node desktop/scripts/notarize.js submit "$DMG"
 
       # #2176: the hook mirrors its progress to this file because GitHub drops
       # the tail of an in-progress step's log when a job is cancelled or times
@@ -177,21 +186,36 @@ jobs:
             exit 1
           }
 
-          # Gatekeeper's own verdict — the check that corresponds to a user
-          # double-clicking the app.
-          spctl -a -vvv -t exec "$APP"
-
-          # A stapled ticket is the only proof notarization actually ran.
-          xcrun stapler validate "$APP"
+          # `spctl` and `stapler validate` are deliberately absent here. Both
+          # assert a notarization ticket, and at this point the submission has
+          # only just been uploaded -- Apple has not issued one yet. They run in
+          # `Desktop macOS Staple`, against the stapled dmg, which is the
+          # artifact that actually ships.
 
       - name: Verify DMG artifact exists
         run: |
           test -n "$(find desktop/dist -maxdepth 1 -name '*.dmg' -print -quit)"
           find desktop/dist -maxdepth 1 -type f -print
 
+      # #2176: the dmg has to survive this job, because the ticket Apple will
+      # issue is bound to this exact signed artifact's cdhash. Rebuilding to
+      # staple would invalidate it and require a fresh submission.
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v7
         with:
           name: scistudio-macos-dmg
           path: desktop/dist/*.dmg
           if-no-files-found: error
+
+      - name: Report how to finish notarization
+        if: env.HAS_NOTARY_KEY == 'true'
+        run: |
+          echo "### macOS notarization submitted" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Submission: \`${{ steps.notarize.outputs.submission-id }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The dmg is signed but **not yet stapled**. Run the" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`Desktop macOS Staple\` workflow with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`run_id\`: \`${{ github.run_id }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`submission_id\`: \`${{ steps.notarize.outputs.submission-id }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -129,6 +129,17 @@ jobs:
           # The hook's own output is prefixed [notarize].
         run: npm --prefix desktop run dist:dmg
 
+      # #2176: the hook mirrors its progress to this file because GitHub drops
+      # the tail of an in-progress step's log when a job is cancelled or times
+      # out -- exactly when the trace matters. A cancelled 0.3.4 build lost
+      # twelve minutes of hook output that way, leaving the runner's own
+      # "Terminate orphan process (notarytool)" as the only evidence. Printing
+      # it here means even a killed build says how far notarization got and
+      # which submission ID to query.
+      - name: Notarization trace
+        if: always()
+        run: cat "$RUNNER_TEMP/notarize.log" 2>/dev/null || echo "no notarization trace was written"
+
       - name: Remove App Store Connect API key
         if: always()
         run: rm -rf "$RUNNER_TEMP/private_keys"

--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -127,6 +127,13 @@ jobs:
           # "skipped macOS notarization" from macPackager -- that is
           # `"notarize": false` in package.json doing its job, not a skip.
           # The hook's own output is prefixed [notarize].
+          #
+          # This bound must stay comfortably below the job's timeout-minutes
+          # (#2172). If the job dies first the hook never gets to say which
+          # submission was left in flight, which is the one thing a timed-out
+          # build needs to report. The headroom covers signing, which precedes
+          # notarization and has been measured anywhere from 2 to 12 minutes.
+          SCISTUDIO_NOTARIZE_TIMEOUT_MIN: "60"
         run: npm --prefix desktop run dist:dmg
 
       # #2176: the hook mirrors its progress to this file because GitHub drops

--- a/.github/workflows/desktop-macos-dmg.yml
+++ b/.github/workflows/desktop-macos-dmg.yml
@@ -121,24 +121,25 @@ jobs:
           APPLE_API_KEY: ${{ env.HAS_NOTARY_KEY == 'true' && format('{0}/private_keys/AuthKey.p8', runner.temp) || '' }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          # #2174: notarization is the one step that depends on a third party,
-          # has no upper bound, and prints nothing while it waits. A 118-minute
-          # hang left only the runner's own 'Terminate orphan process (notarytool)'
-          # line to go on, which ruled out signing and nothing else. This surfaces
-          # the submission ID and each polling state, so a cancelled build can
-          # still be traced with `notarytool log <id>` afterwards.
-          DEBUG: electron-notarize*,@electron/notarize*
+          # #2176: these three are read by desktop/scripts/notarize.js, the
+          # `afterSign` hook that now performs notarization instead of
+          # electron-builder. Note the build log still prints
+          # "skipped macOS notarization" from macPackager -- that is
+          # `"notarize": false` in package.json doing its job, not a skip.
+          # The hook's own output is prefixed [notarize].
         run: npm --prefix desktop run dist:dmg
 
       - name: Remove App Store Connect API key
         if: always()
         run: rm -rf "$RUNNER_TEMP/private_keys"
 
-      # #2096: electron-builder fails SOFT on notarization. macPackager's
-      # notarizeIfProvided() logs "skipped macOS notarization" and returns when
-      # the options cannot be generated, so a missing or typo'd credential
-      # produces a green build and a dmg that still shows the Gatekeeper prompt.
-      # Assert the outcome directly instead of trusting the build log.
+      # #2096: notarization used to fail SOFT here -- macPackager's
+      # notarizeIfProvided() logged "skipped macOS notarization" and returned
+      # when the options could not be generated, so a missing or typo'd
+      # credential produced a green build and a dmg that still showed the
+      # Gatekeeper prompt. The #2176 hook hard-fails instead, but this step
+      # stays: it is the only check that survives the hook being unwired,
+      # mis-pathed, or skipped because signing did not occur.
       - name: Verify signature, hardened runtime and notarization
         if: env.HAS_MACOS_SIGNING == 'true'
         run: |

--- a/.github/workflows/desktop-macos-staple.yml
+++ b/.github/workflows/desktop-macos-staple.yml
@@ -1,0 +1,147 @@
+name: Desktop macOS Staple
+
+# #2176: the second half of macOS notarization.
+#
+# `Desktop macOS DMG` signs, builds and *submits* the dmg, then stops. Apple's
+# notary queue has no upper bound -- a 0.3.4 submission sat at `In Progress`
+# through 61 consecutive one-minute polls -- and waiting for it inside the build
+# throws away the signed dmg along with the queue position, so each attempt
+# starts another hour from zero.
+#
+# This workflow finishes the job: it waits for the verdict, staples the ticket
+# to the dmg the build kept, and asserts the result a user will actually meet.
+# It is cheap to re-run, because the submission stays live at Apple and the
+# ticket is bound to that dmg's cdhash. Never resubmit to "retry" -- that
+# invalidates nothing and buys a fresh queue wait.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run ID of the Desktop macOS DMG build that produced the dmg"
+        required: true
+      submission_id:
+        description: "Apple submission ID printed by that build"
+        required: true
+      artifact:
+        description: "Artifact name to staple"
+        required: false
+        default: "scistudio-macos-dmg"
+
+permissions:
+  contents: read
+  # Reading an artifact from another workflow run needs this; `contents` alone
+  # is not enough and the download fails with a 403 that reads like a bad id.
+  actions: read
+
+jobs:
+  staple:
+    name: Staple and verify
+    runs-on: macos-15
+    # Apple's queue is the thing being waited on and it is not ours to bound.
+    # Three hours is well past anything observed; the step-level notarization
+    # timeout below fails first and says which submission was left in flight.
+    timeout-minutes: 180
+    env:
+      HAS_NOTARY_KEY: ${{ secrets.APPLE_API_KEY_P8 != '' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Fail early without notarization credentials
+        if: env.HAS_NOTARY_KEY != 'true'
+        run: |
+          echo "::error::APPLE_API_KEY_P8 is not configured; there is nothing to wait on"
+          exit 1
+
+      - name: Download the dmg from the build run
+        uses: actions/download-artifact@v7
+        with:
+          name: ${{ github.event.inputs.artifact }}
+          run-id: ${{ github.event.inputs.run_id }}
+          github-token: ${{ github.token }}
+          path: dist
+
+      # Mirrors the build workflow: the key is written under RUNNER_TEMP with
+      # restrictive permissions, passed by path rather than interpolated into a
+      # command line, and removed by an always() step.
+      - name: Write App Store Connect API key
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+        run: |
+          install -d -m 700 "$RUNNER_TEMP/private_keys"
+          printf '%s' "$APPLE_API_KEY_P8" > "$RUNNER_TEMP/private_keys/AuthKey.p8"
+          chmod 600 "$RUNNER_TEMP/private_keys/AuthKey.p8"
+
+      - name: Wait for Apple's verdict
+        env:
+          APPLE_API_KEY: ${{ format('{0}/private_keys/AuthKey.p8', runner.temp) }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          # Comfortably under the job timeout so the script, not the runner,
+          # reports which submission was left in flight.
+          SCISTUDIO_NOTARIZE_TIMEOUT_MIN: "150"
+        run: node desktop/scripts/notarize.js wait "${{ github.event.inputs.submission_id }}"
+
+      - name: Staple the ticket
+        env:
+          APPLE_API_KEY: ${{ format('{0}/private_keys/AuthKey.p8', runner.temp) }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          DMG=$(find dist -maxdepth 1 -name '*.dmg' -print -quit)
+          test -n "$DMG" || { echo "::error::no dmg in the downloaded artifact"; exit 1; }
+          node desktop/scripts/notarize.js staple "$DMG"
+
+      - name: Notarization trace
+        if: always()
+        run: cat "$RUNNER_TEMP/notarize.log" 2>/dev/null || echo "no notarization trace was written"
+
+      - name: Remove App Store Connect API key
+        if: always()
+        run: rm -rf "$RUNNER_TEMP/private_keys"
+
+      # #2096 in its final form. The build job asserts the signature and the
+      # hardened runtime; only here can the *ticket* be asserted, and only here
+      # does the assessment correspond to what a user meets: mount the dmg they
+      # will download and ask Gatekeeper about the app they will launch.
+      - name: Verify the stapled artifact
+        run: |
+          set -euo pipefail
+          DMG=$(find dist -maxdepth 1 -name '*.dmg' -print -quit)
+          echo "verifying $DMG"
+
+          # The ticket is attached to the dmg itself.
+          xcrun stapler validate "$DMG"
+
+          MOUNT=$(mktemp -d)
+          hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT" >/dev/null
+          trap 'hdiutil detach "$MOUNT" -quiet || true' EXIT
+
+          APP=$(find "$MOUNT" -maxdepth 1 -name '*.app' -print -quit)
+          test -n "$APP" || { echo "::error::no .app inside the dmg"; exit 1; }
+
+          codesign --verify --deep --strict --verbose=2 "$APP"
+
+          codesign --display --verbose=2 "$APP" > "$RUNNER_TEMP/csinfo.txt" 2>&1
+          grep -qE 'flags=.*runtime' "$RUNNER_TEMP/csinfo.txt" || {
+            echo "::error::hardened runtime flag missing from the signature"
+            cat "$RUNNER_TEMP/csinfo.txt"
+            exit 1
+          }
+
+          # Gatekeeper's own verdict on the app as shipped. The app inside is
+          # not itself stapled -- the ticket is on the dmg -- so this resolves
+          # against Apple online, exactly as a downloading user's Mac does.
+          spctl -a -vvv -t exec "$APP"
+
+      - name: Upload the stapled dmg
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ github.event.inputs.artifact }}-stapled
+          path: dist/*.dmg
+          if-no-files-found: error

--- a/.workflow/records/2176-ci-2176-notarize-hook.json
+++ b/.workflow/records/2176-ci-2176-notarize-hook.json
@@ -1,0 +1,104 @@
+{
+  "base_ref": null,
+  "branch": "ci/2176-notarize-hook",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop",
+      ".github/workflows",
+      "tests"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T21:07:14.087450Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/desktop-macos-signing-notarization.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2176,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Fix it: #2174's DEBUG instrumentation does not surface notarization progress because @electron/notarize passes --output-format json.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2176-ci-2176-notarize-hook",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087415Z",
+      "pattern": "desktop/scripts/notarize.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087435Z",
+      "pattern": "desktop/test/notarize.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087437Z",
+      "pattern": "desktop/test/macos-signing.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087439Z",
+      "pattern": "desktop/package.json",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087441Z",
+      "pattern": ".github/workflows/desktop-macos-dmg.yml",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T21:07:14.087442Z",
+      "pattern": "docs/specs/desktop-macos-signing-notarization.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "4cca99ae-af95-438a-8817-bf0d1a607d49",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-25T21:07:14.087458Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/notarize.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2176-ci-2176-notarize-hook.json
+++ b/.workflow/records/2176-ci-2176-notarize-hook.json
@@ -1,7 +1,172 @@
 {
   "base_ref": null,
   "branch": "ci/2176-notarize-hook",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-25T21:11:46.761084Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:91f79073bcdc16d4ba37ed1024a9f5980790ae6ab8e5520e40905ac91df55f56",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:11:51.053795Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:30aab3c2281f2e2403c2f0c9274e9e65eb7706cce891759b60375d4ee4f955b6",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:11:52.435608Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:34ae6e2df757c30a1b32d2a24dad6de4f9da065735d275be06b3d60f5b3cafc3",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:11:52.519832Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e026200266c7e80b08365b6ddc84edbc197ae87c06ba93279b63757ddfdece98",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T21:12:05.004247Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:98317ab14d0d4d70e7de95659e1c98ccb15041e411675b9e0793bad1f9a97d3b",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:12:06.242690Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a65cb78c99b65f4003a9d8fa8ead44c9ff53911944e8d9e3921b460759e305ca",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:12:06.319254Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:807feb227c45802d4626daa6d2fc55cd3e37791fbb2810b735eb4f94902f329b",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T21:15:02.375497Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5817d342566ecd99fbbd043dfb0658296f7c1014de5d3d6a97b8b4a88ce8152c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:15:17.455431Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:06e9a88a8087767578eb876b6125778e85416ade0eedb2170bc3c9cbfed585de",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:21:18.727530Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:5817d342566ecd99fbbd043dfb0658296f7c1014de5d3d6a97b8b4a88ce8152c",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -23,8 +188,207 @@
       "verified_in_diff": null
     }
   ],
-  "governance_touch": false,
-  "guard_events": [],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-25T21:15:17.554624Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.575755Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.595854Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.618371Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.640922Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.661010Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": ".github/workflows/desktop-macos-dmg.yml",
+          "finding_class": "governance",
+          "git_evidence": null,
+          "id": "governance.mod_guard.unauthorized-change",
+          "line": null,
+          "message": "governance-critical file changed without authorization; declare governance_touch in the ledger and obtain owner review",
+          "path": ".github/workflows/desktop-macos-dmg.yml",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "governance.mod_guard.unauthorized-change",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "mod_guard",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-25T21:15:17.680993Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.699639Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.717634Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.737097Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:15:17.757232Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.777053Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.792993Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.808768Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.824954Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.840433Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.898076Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.915898Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.937232Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.953419Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.969169Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:21:18.984929Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -34,19 +398,95 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "da6184f8a",
+    "changed_files": [
+      ".github/workflows/desktop-macos-dmg.yml",
+      ".workflow/records/2176-ci-2176-notarize-hook.json",
+      "desktop/package.json",
+      "desktop/scripts/notarize.js",
+      "desktop/test/macos-signing.test.js",
+      "desktop/test/notarize.test.js",
+      "docs/specs/desktop-macos-signing-notarization.md"
+    ],
+    "diff_fingerprint": "sha256:2614fe3f0284ad895ff842d16748268921f4a1ef6452c5ced2222b5087f0ad99",
+    "head": "HEAD",
+    "head_sha": "059d54d26",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 1,
+      "governed_docs": 0,
+      "implementation": 1,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 2,
+      "test": 2,
+      "workflow_ci": 1
+    }
+  },
   "owner_directive": "Fix it: #2174's DEBUG instrumentation does not surface notarization progress because @electron/notarize passes --output-format json.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T21:15:17.757268Z",
+      "diff_fingerprint": "sha256:2614fe3f0284ad895ff842d16748268921f4a1ef6452c5ced2222b5087f0ad99",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests",
+        "guard.mod_guard"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:21:18.984953Z",
+      "diff_fingerprint": "sha256:2614fe3f0284ad895ff842d16748268921f4a1ef6452c5ced2222b5087f0ad99",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    }
+  ],
   "record_id": "2176-ci-2176-notarize-hook",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude",
   "schema_version": 2,
@@ -89,7 +529,7 @@
     }
   ],
   "session_id": "4cca99ae-af95-438a-8817-bf0d1a607d49",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2176-ci-2176-notarize-hook.json
+++ b/.workflow/records/2176-ci-2176-notarize-hook.json
@@ -393,6 +393,22 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T22:35:46.263970Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": null,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "scope": "repo",
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -1334,6 +1350,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.325739Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.341081Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.355532Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.370107Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.385631Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.401616Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.416870Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.431501Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.446672Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.462352Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:35:46.520385Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.521065Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.550800Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.576976Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.594195Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.663426Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.681747Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.706592Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.731222Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.751462Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.774474Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:04.793974Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1357,9 +1549,9 @@
       "desktop/test/notarize.test.js",
       "docs/specs/desktop-macos-signing-notarization.md"
     ],
-    "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+    "diff_fingerprint": "sha256:5fc3c175f8b4a3330ebc71685f8bb392222a655cd7fcd3650b915da7f0011b55",
     "head": "HEAD",
-    "head_sha": "290c3e0d9",
+    "head_sha": "382d5f00a",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -1477,6 +1669,24 @@
     {
       "at": "2026-08-25T22:13:14.041747Z",
       "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T22:35:46.520423Z",
+      "diff_fingerprint": "sha256:5fc3c175f8b4a3330ebc71685f8bb392222a655cd7fcd3650b915da7f0011b55",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T22:36:04.793998Z",
+      "diff_fingerprint": "sha256:5fc3c175f8b4a3330ebc71685f8bb392222a655cd7fcd3650b915da7f0011b55",
       "mode": "pre-pr",
       "result": "fail",
       "tier": 1,

--- a/.workflow/records/2176-ci-2176-notarize-hook.json
+++ b/.workflow/records/2176-ci-2176-notarize-hook.json
@@ -409,6 +409,38 @@
       "status": "unknown",
       "summary": "execution error: TimeoutExpired",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T22:45:47.356080Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T23:10:23.936161Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": null,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "scope": "repo",
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
   "check_na": [
@@ -1526,6 +1558,358 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.223557Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.239660Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.258187Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.274324Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.318966Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.334579Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.349604Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.365420Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.385081Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.401585Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:36:39.418337Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.425258Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.440750Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.456094Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.471127Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.486993Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.502031Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.518470Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.535172Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.550716Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.565814Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:47.581028Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.882218Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.897618Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.913307Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.928353Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.944110Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.959492Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.974731Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:48.989983Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:49.006793Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:49.022023Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:45:49.037686Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:23.997712Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.012794Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.027350Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.042641Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.100459Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.115448Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.130837Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.146169Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.163151Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.179166Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:10:24.195306Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1549,9 +1933,9 @@
       "desktop/test/notarize.test.js",
       "docs/specs/desktop-macos-signing-notarization.md"
     ],
-    "diff_fingerprint": "sha256:5fc3c175f8b4a3330ebc71685f8bb392222a655cd7fcd3650b915da7f0011b55",
+    "diff_fingerprint": "sha256:b311ded9ee8e7af64a526f5f85fdc1519f04317189ab02984a4ccaec92d80453",
     "head": "HEAD",
-    "head_sha": "382d5f00a",
+    "head_sha": "5874715ef",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -1693,6 +2077,44 @@
       "unsatisfied": [
         "checks.python_tests"
       ]
+    },
+    {
+      "at": "2026-08-25T22:36:39.418387Z",
+      "diff_fingerprint": "sha256:b311ded9ee8e7af64a526f5f85fdc1519f04317189ab02984a4ccaec92d80453",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T22:45:47.581054Z",
+      "diff_fingerprint": "sha256:b311ded9ee8e7af64a526f5f85fdc1519f04317189ab02984a4ccaec92d80453",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T22:45:49.037713Z",
+      "diff_fingerprint": "sha256:b311ded9ee8e7af64a526f5f85fdc1519f04317189ab02984a4ccaec92d80453",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T23:10:24.195343Z",
+      "diff_fingerprint": "sha256:b311ded9ee8e7af64a526f5f85fdc1519f04317189ab02984a4ccaec92d80453",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
     }
   ],
   "record_id": "2176-ci-2176-notarize-hook",
@@ -1768,6 +2190,12 @@
       "at": "2026-08-25T21:07:14.087442Z",
       "pattern": "docs/specs/desktop-macos-signing-notarization.md",
       "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T23:19:53.845310Z",
+      "pattern": ".github/workflows/desktop-macos-staple.yml",
+      "reason": "Split notarization across two jobs. Apple held a submission at In Progress through 61 consecutive one-minute polls, so waiting inside the build discards the signed dmg and the queue position together. The build now submits and stops; a new dispatch-only workflow waits, staples and asserts the ticket against the dmg the build kept."
     }
   ],
   "session_id": "4cca99ae-af95-438a-8817-bf0d1a607d49",

--- a/.workflow/records/2176-ci-2176-notarize-hook.json
+++ b/.workflow/records/2176-ci-2176-notarize-hook.json
@@ -165,10 +165,253 @@
       "status": "fail",
       "summary": "exit 1",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:35.783978Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9f7fd92137baf33e01a301a0543481e9dd08d2818ebb46661d63dea41cd8ccdb",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:38.565262Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:318fb503cf27485f82ac3e265c86fdbb893f0adfd80b752bb3b07fcea69cb1ee",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:39.942068Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:22ba732d0db4ee4e3873f020eeaf75752f41adfedf136f993c19c4a72fc8d1b1",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:39.990447Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:05f4bf8fcbc71e8abdb67d2591e10500fbd1a62ccaacc3444845b100a5105925",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T21:27:51.202562Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:68ea8a1677901e6f9f94adce0491866a7ac95036b5053c0b43e8bd2c4b117918",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:51.453911Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4e196aa59f31c77c2e1b0f510be6e70baac511b56c4cf44a7edba78e59cddb60",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:27:51.490075Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:38054c34187f833d0e93954c4abf96141b98418c62dc3e9323b3f822e93891e8",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T21:30:19.685258Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:30:20.332494Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:41b91eaf007e301816d35125ac29d804a5b7eb8f377d07d50b32f508aa6011ad",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:33:32.128579Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:38:37.647356Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:43:14.375299Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T21:51:22.729700Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T22:03:17.698834Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": null,
+      "input_fingerprint": "sha256:8c74825c6c9848c1615b872108776f094a62727658accf9b5054bb6cf5b3d859",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": null,
+      "scope": "repo",
+      "status": "unknown",
+      "summary": "execution error: TimeoutExpired",
+      "tool_versions": {}
     }
   ],
-  "check_na": [],
-  "commit": null,
+  "check_na": [
+    {
+      "name": "python_tests",
+      "rationale": "Nine tests in tests/api/test_workflows.py and tests/api/test_system_vertical.py fail on this Windows machine in whole-file runs and pass in isolation. Reproduced identically on an untouched origin/main worktree, so they are not caused by this change, which touches only desktop/scripts, desktop/test, .github/workflows and a spec. The same tests are green in CI (PR #2173, Test 3.11 and 3.13 both pass), so this is local shared-state leakage of the tracked Windows class, not a defect being hidden."
+    },
+    {
+      "name": "python_tests",
+      "rationale": "pre-existing local Windows failure, reproduced on origin/main, green in CI"
+    }
+  ],
+  "commit": {
+    "sha": "290c3e0d9cc28ebd841bbf16bfff819b3a51d876",
+    "shas": [
+      "290c3e0d9cc28ebd841bbf16bfff819b3a51d876"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -387,6 +630,710 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.370619Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.385337Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.401730Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.417031Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.431042Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.445748Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.460470Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.475117Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.491246Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.505892Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:30:20.520691Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.173183Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.187869Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.204393Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.219643Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.234288Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.249795Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.264824Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.279264Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.294226Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.308715Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:33:32.322956Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.753770Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.770747Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.836894Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.854003Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.871213Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.888612Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.905732Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.922416Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.938793Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.955160Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:36:18.972126Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.713178Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.727539Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.742964Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.758837Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.776666Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.791517Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.806263Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.821512Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.836363Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.851289Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:38:37.867075Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.440560Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.455002Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.469347Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.483643Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.497863Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.511833Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.526453Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.541716Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.556993Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.571455Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:43:14.586571Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.793446Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.807490Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.821306Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.835744Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.850417Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.905613Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.919904Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.934168Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.949809Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.964356Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T21:51:22.979177Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.757247Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.771724Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.786652Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.801529Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.815910Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.829691Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.843705Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.857561Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.871323Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.885170Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:03:17.900013Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.889260Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.904821Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.920984Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.936510Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.951081Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.964855Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.978874Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:13.992944Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:14.008397Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:14.023395Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T22:13:14.041721Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -400,7 +1347,7 @@
   "observed_admin_labels": [],
   "observed_diff": {
     "base": "origin/main",
-    "base_sha": "da6184f8a",
+    "base_sha": "62e3e5131",
     "changed_files": [
       ".github/workflows/desktop-macos-dmg.yml",
       ".workflow/records/2176-ci-2176-notarize-hook.json",
@@ -410,9 +1357,9 @@
       "desktop/test/notarize.test.js",
       "docs/specs/desktop-macos-signing-notarization.md"
     ],
-    "diff_fingerprint": "sha256:2614fe3f0284ad895ff842d16748268921f4a1ef6452c5ced2222b5087f0ad99",
+    "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
     "head": "HEAD",
-    "head_sha": "059d54d26",
+    "head_sha": "290c3e0d9",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -429,7 +1376,14 @@
   },
   "owner_directive": "Fix it: #2174's DEBUG instrumentation does not surface notarization progress because @electron/notarize passes --output-format json.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2176
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-25T21:15:17.757268Z",
@@ -446,6 +1400,84 @@
       "at": "2026-08-25T21:21:18.984953Z",
       "diff_fingerprint": "sha256:2614fe3f0284ad895ff842d16748268921f4a1ef6452c5ced2222b5087f0ad99",
       "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:30:20.520717Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:33:32.322980Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "local",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:36:18.972153Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:38:37.867099Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:43:14.586600Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T21:51:22.979201Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-25T22:03:17.900037Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T22:13:14.041747Z",
+      "diff_fingerprint": "sha256:f8615601067fea1878ceca27c04dbe38aeb40bd5af6d75330ffa6cc3ae007c6c",
+      "mode": "pre-pr",
       "result": "fail",
       "tier": 1,
       "unsatisfied": [

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -28,7 +28,6 @@
   },
   "build": {
     "appId": "org.scistudio.desktop",
-    "afterSign": "scripts/notarize.js",
     "productName": "SciStudio",
     "directories": {
       "output": "dist",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -28,6 +28,7 @@
   },
   "build": {
     "appId": "org.scistudio.desktop",
+    "afterSign": "scripts/notarize.js",
     "productName": "SciStudio",
     "directories": {
       "output": "dist",
@@ -78,7 +79,7 @@
       "gatekeeperAssess": false,
       "entitlements": "assets/entitlements.mac.plist",
       "entitlementsInherit": "assets/entitlements.mac.plist",
-      "notarize": true
+      "notarize": false
     },
     "linux": {
       "target": [

--- a/desktop/scripts/notarize.js
+++ b/desktop/scripts/notarize.js
@@ -149,8 +149,28 @@ function timeoutMinutes(env) {
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MIN;
 }
 
+/**
+ * Write a progress line to the build log *and* to a file.
+ *
+ * The file is the load-bearing half. GitHub drops the tail of an in-progress
+ * step's log when a job is cancelled or times out -- which is exactly when the
+ * trace is wanted. A cancelled 0.3.4 build lost twelve minutes of hook output
+ * that way, leaving the runner's own `Terminate orphan process (notarytool)`
+ * as the only evidence the hook had run at all. The workflow cats this file in
+ * an `if: always()` step, so the trace survives however the job ends.
+ */
+function logPath(env) {
+  return env.SCISTUDIO_NOTARIZE_LOG || path.join(env.RUNNER_TEMP || os.tmpdir(), "notarize.log");
+}
+
 function log(message) {
-  process.stdout.write(`[notarize] ${message}\n`);
+  const line = `[notarize] ${message}\n`;
+  process.stdout.write(line);
+  try {
+    fs.appendFileSync(logPath(process.env), `${new Date().toISOString()} ${line}`);
+  } catch {
+    // A build must never fail because its own progress log is unwritable.
+  }
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -285,8 +305,17 @@ async function afterSign(context) {
   await notarizeApp(appPath, creds, process.env);
 }
 
+// Emitted when electron-builder resolves the hook, which happens while it is
+// still loading configuration -- within the first second of the build, long
+// before any truncation risk. If a log shows no [notarize] lines at all, the
+// absence of *this* one is what separates "the hook was never wired", a real
+// defect, from "the tail was lost", which is what actually happened to the
+// first run this hook shipped in.
+log("hook loaded; electron-builder's own notarization is disabled");
+
 module.exports = afterSign;
 module.exports.default = afterSign;
+module.exports.logPath = logPath;
 module.exports.credentials = credentials;
 module.exports.submitArgs = submitArgs;
 module.exports.infoArgs = infoArgs;

--- a/desktop/scripts/notarize.js
+++ b/desktop/scripts/notarize.js
@@ -1,48 +1,55 @@
+#!/usr/bin/env node
 "use strict";
 
 /**
- * electron-builder `afterSign` hook: notarize the signed .app, visibly (#2176).
+ * Apple notarization, driven by us instead of by electron-builder (#2176).
  *
- * electron-builder can notarize on its own, and did until this hook existed.
- * The problem was never that it failed -- it was that it was silent, and that
- * it handed an unbounded wait to a third party.
+ * Three subcommands, deliberately separable so Apple's queue is not on the
+ * release critical path:
+ *
+ *     node scripts/notarize.js submit <artifact>   # upload, print the id, exit
+ *     node scripts/notarize.js wait <submissionId> # poll until a verdict
+ *     node scripts/notarize.js staple <artifact>   # attach the ticket
+ *
+ * ## Why not electron-builder's own notarization
  *
  * `@electron/notarize` runs:
  *
  *     xcrun notarytool submit <zip> --key ... --wait --output-format json
  *
- * Two separate defects come out of that one line.
+ * `--output-format json` suppresses every progress line -- notarytool emits one
+ * object when it finishes and nothing before it -- so a submission queued behind
+ * Apple and one that is wedged produce byte-identical logs: empty ones. Two
+ * 0.3.4 builds were cancelled at 118 and 79 minutes reading that silence as a
+ * hang. `DEBUG: electron-notarize*` (#2174) did not help: it surfaces that
+ * package's phase logging, which stops where notarytool is spawned.
  *
- * `--output-format json` suppresses every progress line: notarytool emits one
- * JSON object when it finishes and nothing before it. So a submission queued
- * behind Apple and a submission that is wedged produce byte-identical logs --
- * empty ones. Two 0.3.4 builds were cancelled at 118 and 79 minutes on the
- * strength of that silence, neither ever allowed to finish, leaving it unknown
- * whether notarization worked at all. #2174 tried to fix this with
- * `DEBUG: electron-notarize*`, which surfaces @electron/notarize's own phase
- * logging and stops at the moment notarytool is spawned: enough to prove
- * signing takes ~2 min and `ditto` 26 s, blind to the only phase that mattered.
+ * `--wait` is separately untrustworthy -- it has been reported outliving Apple's
+ * own verdict -- so this polls `notarytool info` instead. Every poll is a fresh
+ * short-lived process that cannot wedge, and every poll writes a line.
  *
- * `--wait` is the second defect, and the reason this hook polls instead of
- * asking for a bounded wait. There are reports of `submit --wait` sitting for
- * hours after Apple has already finished processing -- the wait loop itself
- * wedging, not the queue. Anything built on `--wait` inherits that, including
- * `--wait --timeout`, which still depends on the same loop noticing. So we
- * submit without waiting, take the submission ID, and drive the polling here:
- * each `notarytool info` is a fresh short-lived process that cannot wedge, and
- * every poll writes a line, so elapsed time is legible in the build log while
- * it is happening rather than only in hindsight.
+ * ## Why submit and wait are separate commands
  *
- * The hook keeps the semantics electron-builder had -- the ticket is stapled to
- * the .app *before* the dmg is built around it, because `afterSign` fires
- * between signing and target assembly. It differs in one deliberate way: a
- * notarization error fails the build. electron-builder fails soft here (#2096),
- * which is the reason the workflow needs a separate `Verify signature...` step
- * to assert the outcome rather than trust the build log.
+ * Measured on 2026-08-25: signing 2 min 36 s, `ditto` 20 s, upload 17 s, and
+ * then **61 consecutive polls, every one `In Progress`** -- Apple held the
+ * submission for over an hour without a verdict and the build timed out. That
+ * is not a failure anything here can fix, and waiting inside the build job
+ * throws away the queue position along with the signed artifact.
  *
- * On timeout the build fails with the submission ID, because the submission is
- * still live at Apple and stays queryable with `notarytool history`/`log`.
- * That ID is the thing every earlier cancelled build failed to produce.
+ * So the build submits and stops. A later job waits and staples the artifact
+ * the build kept. A slow queue then costs a delay instead of a rebuild, and the
+ * ticket Apple eventually issues still matches the artifact we have -- it is
+ * bound to the signed code's cdhash, so a rebuilt artifact would need a fresh
+ * submission and a fresh hour.
+ *
+ * ## What gets submitted
+ *
+ * The dmg, not the `.app`. Stapling has to attach to something that outlives
+ * the build, and the dmg is the artifact that ships. The `.app` inside is
+ * therefore not itself stapled: Gatekeeper resolves it online, which every
+ * download-from-GitHub user is. Only a first launch with no network would
+ * notice. A `.app` (or any bundle directory) is still accepted here and gets
+ * zipped first, because notarytool takes an archive rather than a directory.
  */
 
 const { spawn } = require("node:child_process");
@@ -102,10 +109,10 @@ function authArgs({ keyPath, keyId, issuer }) {
  *
  * Neither `--output-format json` nor `--wait` may appear here; both are tested
  * for. The first is what made a stall indistinguishable from progress, and the
- * second is the unbounded wait this hook replaces with its own polling.
+ * second both wedges and would put Apple's queue back inside the build.
  */
-function submitArgs({ zipPath, ...creds }) {
-  return ["notarytool", "submit", zipPath, ...authArgs(creds)];
+function submitArgs({ artifactPath, ...creds }) {
+  return ["notarytool", "submit", artifactPath, ...authArgs(creds)];
 }
 
 function infoArgs({ submissionId, ...creds }) {
@@ -154,10 +161,10 @@ function timeoutMinutes(env) {
  *
  * The file is the load-bearing half. GitHub drops the tail of an in-progress
  * step's log when a job is cancelled or times out -- which is exactly when the
- * trace is wanted. A cancelled 0.3.4 build lost twelve minutes of hook output
- * that way, leaving the runner's own `Terminate orphan process (notarytool)`
- * as the only evidence the hook had run at all. The workflow cats this file in
- * an `if: always()` step, so the trace survives however the job ends.
+ * trace is wanted. A cancelled 0.3.4 build lost twelve minutes of output that
+ * way, leaving the runner's own `Terminate orphan process (notarytool)` as the
+ * only evidence anything had run. The workflow cats this file in an
+ * `if: always()` step, so the trace survives however the job ends.
  */
 function logPath(env) {
   return env.SCISTUDIO_NOTARIZE_LOG || path.join(env.RUNNER_TEMP || os.tmpdir(), "notarize.log");
@@ -202,25 +209,60 @@ function run(command, args, { label = command, quiet = false } = {}) {
   });
 }
 
-async function zipApp(appPath) {
+/**
+ * notarytool takes a file, not a bundle directory. A dmg is already a file; a
+ * `.app` has to be zipped, with `ditto --sequesterRsrc --keepParent` so the
+ * signature survives the round trip.
+ */
+async function archiveFor(artifactPath) {
+  if (fs.statSync(artifactPath).isFile()) {
+    return { uploadPath: artifactPath, cleanup: null };
+  }
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scistudio-notarize-"));
-  const zipPath = path.join(dir, "app.zip");
-  log(`compressing ${path.basename(appPath)} for submission`);
+  const zipPath = path.join(dir, "upload.zip");
+  log(`compressing ${path.basename(artifactPath)} for submission`);
   const { code } = await run(
     "ditto",
-    ["-c", "-k", "--sequesterRsrc", "--keepParent", appPath, zipPath],
+    ["-c", "-k", "--sequesterRsrc", "--keepParent", artifactPath, zipPath],
     { label: "ditto" },
   );
   if (code !== 0) {
     throw new Error(`ditto failed with exit code ${code}`);
   }
-  const { size } = fs.statSync(zipPath);
-  log(`submission archive is ${(size / 1024 / 1024).toFixed(0)} MB`);
-  return { zipPath, dir };
+  return { uploadPath: zipPath, cleanup: dir };
 }
 
-/** Poll Apple until the submission reaches a terminal status or we give up. */
-async function waitForVerdict(submissionId, creds, deadline) {
+/** `submit` -- upload and return the submission id without waiting. */
+async function commandSubmit(artifactPath, creds) {
+  const { uploadPath, cleanup } = await archiveFor(artifactPath);
+  try {
+    const { size } = fs.statSync(uploadPath);
+    log(`submission archive is ${(size / 1024 / 1024).toFixed(0)} MB`);
+    log("uploading to Apple");
+    const result = await run("xcrun", submitArgs({ artifactPath: uploadPath, ...creds }), {
+      label: "notarytool submit",
+    });
+    const submissionId = parseSubmissionId(result.transcript);
+    if (result.code !== 0 || !submissionId) {
+      throw new Error(`notarytool submit failed with exit code ${result.code}`);
+    }
+    log(`submission ${submissionId}`);
+    log("Apple is now queueing this; the build does not wait for it");
+    return submissionId;
+  } finally {
+    if (cleanup) {
+      fs.rmSync(cleanup, { recursive: true, force: true });
+    }
+  }
+}
+
+/** `wait` -- poll until Apple returns a verdict, or give up with the id intact. */
+async function commandWait(submissionId, creds, env) {
+  const started = Date.now();
+  const minutes = timeoutMinutes(env);
+  const deadline = started + minutes * 60_000;
+  log(`waiting on ${submissionId}; polling every 60s, giving up after ${minutes} min`);
+
   let polls = 0;
   for (;;) {
     const { transcript } = await run("xcrun", infoArgs({ submissionId, ...creds }), {
@@ -229,98 +271,107 @@ async function waitForVerdict(submissionId, creds, deadline) {
     });
     polls += 1;
     const status = parseStatus(transcript) || "unknown";
-    const elapsed = Math.round((Date.now() - deadline.started) / 60_000);
-    log(`poll ${polls} at ${elapsed} min: ${status}`);
+    log(`poll ${polls} at ${Math.round((Date.now() - started) / 60_000)} min: ${status}`);
+
     if (isTerminal(status)) {
-      return status;
-    }
-    if (Date.now() >= deadline.at) {
-      return null;
-    }
-    await sleep(POLL_INTERVAL_MS);
-  }
-}
-
-async function notarizeApp(appPath, creds, env) {
-  const { zipPath, dir } = await zipApp(appPath);
-  const started = Date.now();
-  const minutes = timeoutMinutes(env);
-  try {
-    log("uploading to Apple");
-    const submit = await run("xcrun", submitArgs({ zipPath, ...creds }), {
-      label: "notarytool submit",
-    });
-    const submissionId = parseSubmissionId(submit.transcript);
-    if (submit.code !== 0 || !submissionId) {
-      throw new Error(`notarytool submit failed with exit code ${submit.code}`);
-    }
-    log(`submission ${submissionId}; polling every 60s, giving up after ${minutes} min`);
-    log(`check independently with: xcrun notarytool history --key ... --key-id ... --issuer ...`);
-
-    const status = await waitForVerdict(submissionId, creds, {
-      started,
-      at: started + minutes * 60_000,
-    });
-
-    if (status === null) {
-      throw new Error(
-        `notarization did not finish within ${minutes} min. The submission is still live at ` +
-          `Apple: ${submissionId}. Query it with \`xcrun notarytool info ${submissionId}\` rather ` +
-          `than resubmitting.`,
-      );
-    }
-    if (status !== "Accepted") {
+      if (status === "Accepted") {
+        return;
+      }
       // The status says *that* Apple refused; only the log says why.
       log("fetching Apple's rejection detail");
       await run("xcrun", logArgs({ submissionId, ...creds }), { label: "notarytool log" });
       throw new Error(`Apple returned ${status} for submission ${submissionId}`);
     }
-
-    log("accepted; stapling the ticket");
-    const stapled = await run("xcrun", ["stapler", "staple", appPath], { label: "stapler" });
-    if (stapled.code !== 0) {
-      throw new Error(`stapler failed with exit code ${stapled.code}`);
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `no verdict within ${minutes} min. The submission is still live at Apple: ` +
+          `${submissionId}. Re-run this wait rather than resubmitting -- a new submission ` +
+          `starts a new queue wait, and the ticket is bound to the artifact already uploaded.`,
+      );
     }
-    log(`notarized and stapled in ${((Date.now() - started) / 60_000).toFixed(1)} min`);
-  } finally {
-    fs.rmSync(dir, { recursive: true, force: true });
+    await sleep(POLL_INTERVAL_MS);
   }
 }
 
-/** The electron-builder hook itself. */
-async function afterSign(context) {
-  if (context.electronPlatformName !== "darwin") {
+/** `staple` -- attach the issued ticket to the artifact we kept. */
+async function commandStaple(artifactPath) {
+  log(`stapling ${path.basename(artifactPath)}`);
+  const { code } = await run("xcrun", ["stapler", "staple", artifactPath], { label: "stapler" });
+  if (code !== 0) {
+    throw new Error(`stapler failed with exit code ${code}`);
+  }
+  log("stapled");
+}
+
+/**
+ * Publish a value to the GitHub step output, when running in Actions.
+ *
+ * The submission id has to reach the stapling job somehow, and a step output is
+ * the channel that does not require the artifact to be re-read.
+ */
+function emitOutput(name, value) {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) {
     return;
   }
+  try {
+    fs.appendFileSync(file, `${name}=${value}\n`);
+  } catch (error) {
+    log(`could not write ${name} to GITHUB_OUTPUT: ${error.message}`);
+  }
+}
+
+async function main(argv) {
+  const [command, target] = argv;
+  if (!command || !target) {
+    process.stderr.write("usage: notarize.js <submit|wait|staple> <artifact|submissionId>\n");
+    return 2;
+  }
+
   const creds = credentials(process.env);
   if (!creds) {
+    // Matches the pre-#2176 behaviour: a developer with no App Store Connect
+    // key gets an unsigned local build rather than a failure.
     log("no App Store Connect credentials in the environment; skipping notarization");
-    return;
+    return 0;
   }
-  const appName = context.packager.appInfo.productFilename;
-  const appPath = path.join(context.appOutDir, `${appName}.app`);
-  if (!fs.existsSync(appPath)) {
-    throw new Error(`expected a signed app at ${appPath}`);
+
+  if (command === "submit") {
+    const id = await commandSubmit(target, creds);
+    emitOutput("submission-id", id);
+    return 0;
   }
-  await notarizeApp(appPath, creds, process.env);
+  if (command === "wait") {
+    await commandWait(target, creds, process.env);
+    return 0;
+  }
+  if (command === "staple") {
+    await commandStaple(target);
+    return 0;
+  }
+  process.stderr.write(`unknown command: ${command}\n`);
+  return 2;
 }
 
-// Emitted when electron-builder resolves the hook, which happens while it is
-// still loading configuration -- within the first second of the build, long
-// before any truncation risk. If a log shows no [notarize] lines at all, the
-// absence of *this* one is what separates "the hook was never wired", a real
-// defect, from "the tail was lost", which is what actually happened to the
-// first run this hook shipped in.
-log("hook loaded; electron-builder's own notarization is disabled");
+if (require.main === module) {
+  main(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (error) => {
+      log(`FAILED: ${error.message}`);
+      process.exit(1);
+    },
+  );
+}
 
-module.exports = afterSign;
-module.exports.default = afterSign;
-module.exports.logPath = logPath;
-module.exports.credentials = credentials;
-module.exports.submitArgs = submitArgs;
-module.exports.infoArgs = infoArgs;
-module.exports.logArgs = logArgs;
-module.exports.parseSubmissionId = parseSubmissionId;
-module.exports.parseStatus = parseStatus;
-module.exports.isTerminal = isTerminal;
-module.exports.timeoutMinutes = timeoutMinutes;
+module.exports = {
+  credentials,
+  submitArgs,
+  infoArgs,
+  logArgs,
+  parseSubmissionId,
+  parseStatus,
+  isTerminal,
+  timeoutMinutes,
+  logPath,
+  main,
+};

--- a/desktop/scripts/notarize.js
+++ b/desktop/scripts/notarize.js
@@ -1,0 +1,297 @@
+"use strict";
+
+/**
+ * electron-builder `afterSign` hook: notarize the signed .app, visibly (#2176).
+ *
+ * electron-builder can notarize on its own, and did until this hook existed.
+ * The problem was never that it failed -- it was that it was silent, and that
+ * it handed an unbounded wait to a third party.
+ *
+ * `@electron/notarize` runs:
+ *
+ *     xcrun notarytool submit <zip> --key ... --wait --output-format json
+ *
+ * Two separate defects come out of that one line.
+ *
+ * `--output-format json` suppresses every progress line: notarytool emits one
+ * JSON object when it finishes and nothing before it. So a submission queued
+ * behind Apple and a submission that is wedged produce byte-identical logs --
+ * empty ones. Two 0.3.4 builds were cancelled at 118 and 79 minutes on the
+ * strength of that silence, neither ever allowed to finish, leaving it unknown
+ * whether notarization worked at all. #2174 tried to fix this with
+ * `DEBUG: electron-notarize*`, which surfaces @electron/notarize's own phase
+ * logging and stops at the moment notarytool is spawned: enough to prove
+ * signing takes ~2 min and `ditto` 26 s, blind to the only phase that mattered.
+ *
+ * `--wait` is the second defect, and the reason this hook polls instead of
+ * asking for a bounded wait. There are reports of `submit --wait` sitting for
+ * hours after Apple has already finished processing -- the wait loop itself
+ * wedging, not the queue. Anything built on `--wait` inherits that, including
+ * `--wait --timeout`, which still depends on the same loop noticing. So we
+ * submit without waiting, take the submission ID, and drive the polling here:
+ * each `notarytool info` is a fresh short-lived process that cannot wedge, and
+ * every poll writes a line, so elapsed time is legible in the build log while
+ * it is happening rather than only in hindsight.
+ *
+ * The hook keeps the semantics electron-builder had -- the ticket is stapled to
+ * the .app *before* the dmg is built around it, because `afterSign` fires
+ * between signing and target assembly. It differs in one deliberate way: a
+ * notarization error fails the build. electron-builder fails soft here (#2096),
+ * which is the reason the workflow needs a separate `Verify signature...` step
+ * to assert the outcome rather than trust the build log.
+ *
+ * On timeout the build fails with the submission ID, because the submission is
+ * still live at Apple and stays queryable with `notarytool history`/`log`.
+ * That ID is the thing every earlier cancelled build failed to produce.
+ */
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+// notarytool prints the id on its own indented line under "Submission ID
+// received". The UUID shape keeps this from matching some future unrelated
+// `id:` field; the same id is echoed again later, so first-match is correct.
+const SUBMISSION_ID_RE = /\bid:\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\b/i;
+
+const STATUS_RE = /status:\s*([A-Za-z ]+?)\s*$/gim;
+
+const TERMINAL = new Set(["Accepted", "Invalid", "Rejected"]);
+
+const POLL_INTERVAL_MS = 60_000;
+const DEFAULT_TIMEOUT_MIN = 90;
+
+/**
+ * Resolve App Store Connect API credentials from the environment.
+ *
+ * Deliberately the same three variables electron-builder's own
+ * `getNotarizeOptions()` reads, so the workflow's env block did not have to
+ * change when notarization moved in here.
+ *
+ * Returns null when none are set -- a local `dist:dmg` with no credentials
+ * still produces an unsigned-and-unnotarized build rather than an error, which
+ * is the behaviour developers already had. A *partial* set is an error, because
+ * it is always a misconfiguration and silently skipping it is how an
+ * unnotarized dmg reaches a release.
+ */
+function credentials(env) {
+  const keyPath = env.APPLE_API_KEY || "";
+  const keyId = env.APPLE_API_KEY_ID || "";
+  const issuer = env.APPLE_API_ISSUER || "";
+  if (!keyPath && !keyId && !issuer) {
+    return null;
+  }
+  const missing = [
+    !keyPath && "APPLE_API_KEY",
+    !keyId && "APPLE_API_KEY_ID",
+    !issuer && "APPLE_API_ISSUER",
+  ].filter(Boolean);
+  if (missing.length > 0) {
+    throw new Error(`notarization credentials are incomplete; missing ${missing.join(", ")}`);
+  }
+  return { keyPath, keyId, issuer };
+}
+
+function authArgs({ keyPath, keyId, issuer }) {
+  return ["--key", keyPath, "--key-id", keyId, "--issuer", issuer];
+}
+
+/**
+ * Build the notarytool submit argv.
+ *
+ * Neither `--output-format json` nor `--wait` may appear here; both are tested
+ * for. The first is what made a stall indistinguishable from progress, and the
+ * second is the unbounded wait this hook replaces with its own polling.
+ */
+function submitArgs({ zipPath, ...creds }) {
+  return ["notarytool", "submit", zipPath, ...authArgs(creds)];
+}
+
+function infoArgs({ submissionId, ...creds }) {
+  return ["notarytool", "info", submissionId, ...authArgs(creds)];
+}
+
+function logArgs({ submissionId, ...creds }) {
+  return ["notarytool", "log", submissionId, ...authArgs(creds)];
+}
+
+function parseSubmissionId(text) {
+  const match = SUBMISSION_ID_RE.exec(String(text || ""));
+  return match ? match[1] : null;
+}
+
+/**
+ * Read the last `status:` value out of a notarytool transcript.
+ *
+ * Returns the raw word, including the non-terminal "In Progress", so the poll
+ * loop can tell "Apple is still working" from "nothing parsed" -- treating
+ * those two alike is how a poll loop either spins forever or declares success
+ * on garbage.
+ */
+function parseStatus(text) {
+  const source = String(text || "");
+  STATUS_RE.lastIndex = 0;
+  let last = null;
+  let match;
+  while ((match = STATUS_RE.exec(source)) !== null) {
+    last = match[1].trim();
+  }
+  return last;
+}
+
+function isTerminal(status) {
+  return TERMINAL.has(String(status));
+}
+
+function timeoutMinutes(env) {
+  const raw = Number.parseInt(env.SCISTUDIO_NOTARIZE_TIMEOUT_MIN || "", 10);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MIN;
+}
+
+function log(message) {
+  process.stdout.write(`[notarize] ${message}\n`);
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Spawn a command, streaming output to the build log as it arrives while also
+ * accumulating the transcript for parsing.
+ */
+function run(command, args, { label = command, quiet = false } = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let transcript = "";
+    const consume = (chunk) => {
+      const text = chunk.toString();
+      transcript += text;
+      if (!quiet) {
+        process.stdout.write(text);
+      }
+    };
+    child.stdout.on("data", consume);
+    child.stderr.on("data", consume);
+    child.on("error", (error) => resolve({ code: -1, transcript: `${transcript}${error.message}` }));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        log(`${label} exited ${code}`);
+      }
+      resolve({ code, transcript });
+    });
+  });
+}
+
+async function zipApp(appPath) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "scistudio-notarize-"));
+  const zipPath = path.join(dir, "app.zip");
+  log(`compressing ${path.basename(appPath)} for submission`);
+  const { code } = await run(
+    "ditto",
+    ["-c", "-k", "--sequesterRsrc", "--keepParent", appPath, zipPath],
+    { label: "ditto" },
+  );
+  if (code !== 0) {
+    throw new Error(`ditto failed with exit code ${code}`);
+  }
+  const { size } = fs.statSync(zipPath);
+  log(`submission archive is ${(size / 1024 / 1024).toFixed(0)} MB`);
+  return { zipPath, dir };
+}
+
+/** Poll Apple until the submission reaches a terminal status or we give up. */
+async function waitForVerdict(submissionId, creds, deadline) {
+  let polls = 0;
+  for (;;) {
+    const { transcript } = await run("xcrun", infoArgs({ submissionId, ...creds }), {
+      label: "notarytool info",
+      quiet: true,
+    });
+    polls += 1;
+    const status = parseStatus(transcript) || "unknown";
+    const elapsed = Math.round((Date.now() - deadline.started) / 60_000);
+    log(`poll ${polls} at ${elapsed} min: ${status}`);
+    if (isTerminal(status)) {
+      return status;
+    }
+    if (Date.now() >= deadline.at) {
+      return null;
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+async function notarizeApp(appPath, creds, env) {
+  const { zipPath, dir } = await zipApp(appPath);
+  const started = Date.now();
+  const minutes = timeoutMinutes(env);
+  try {
+    log("uploading to Apple");
+    const submit = await run("xcrun", submitArgs({ zipPath, ...creds }), {
+      label: "notarytool submit",
+    });
+    const submissionId = parseSubmissionId(submit.transcript);
+    if (submit.code !== 0 || !submissionId) {
+      throw new Error(`notarytool submit failed with exit code ${submit.code}`);
+    }
+    log(`submission ${submissionId}; polling every 60s, giving up after ${minutes} min`);
+    log(`check independently with: xcrun notarytool history --key ... --key-id ... --issuer ...`);
+
+    const status = await waitForVerdict(submissionId, creds, {
+      started,
+      at: started + minutes * 60_000,
+    });
+
+    if (status === null) {
+      throw new Error(
+        `notarization did not finish within ${minutes} min. The submission is still live at ` +
+          `Apple: ${submissionId}. Query it with \`xcrun notarytool info ${submissionId}\` rather ` +
+          `than resubmitting.`,
+      );
+    }
+    if (status !== "Accepted") {
+      // The status says *that* Apple refused; only the log says why.
+      log("fetching Apple's rejection detail");
+      await run("xcrun", logArgs({ submissionId, ...creds }), { label: "notarytool log" });
+      throw new Error(`Apple returned ${status} for submission ${submissionId}`);
+    }
+
+    log("accepted; stapling the ticket");
+    const stapled = await run("xcrun", ["stapler", "staple", appPath], { label: "stapler" });
+    if (stapled.code !== 0) {
+      throw new Error(`stapler failed with exit code ${stapled.code}`);
+    }
+    log(`notarized and stapled in ${((Date.now() - started) / 60_000).toFixed(1)} min`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/** The electron-builder hook itself. */
+async function afterSign(context) {
+  if (context.electronPlatformName !== "darwin") {
+    return;
+  }
+  const creds = credentials(process.env);
+  if (!creds) {
+    log("no App Store Connect credentials in the environment; skipping notarization");
+    return;
+  }
+  const appName = context.packager.appInfo.productFilename;
+  const appPath = path.join(context.appOutDir, `${appName}.app`);
+  if (!fs.existsSync(appPath)) {
+    throw new Error(`expected a signed app at ${appPath}`);
+  }
+  await notarizeApp(appPath, creds, process.env);
+}
+
+module.exports = afterSign;
+module.exports.default = afterSign;
+module.exports.credentials = credentials;
+module.exports.submitArgs = submitArgs;
+module.exports.infoArgs = infoArgs;
+module.exports.logArgs = logArgs;
+module.exports.parseSubmissionId = parseSubmissionId;
+module.exports.parseStatus = parseStatus;
+module.exports.isTerminal = isTerminal;
+module.exports.timeoutMinutes = timeoutMinutes;

--- a/desktop/test/macos-signing.test.js
+++ b/desktop/test/macos-signing.test.js
@@ -23,14 +23,19 @@ test("mac: hardened runtime is on (a precondition for notarization)", () => {
   assert.equal(mac.hardenedRuntime, true);
 });
 
-test("mac: notarization is enabled, via the hook rather than the builder", () => {
-  // #2176 moved notarization out of electron-builder and into an `afterSign`
-  // hook, so `mac.notarize` is now deliberately false -- turning it back on
-  // would submit the app to Apple twice. What this test has always been for is
-  // that notarization happens at all, so it asserts the replacement is wired.
-  // The hook's own behaviour is covered in notarize.test.js.
+test("mac: notarization happens, but outside electron-builder", () => {
+  // #2176 took notarization away from electron-builder entirely: `mac.notarize`
+  // is false and there is no `afterSign` hook, because both would put a blind,
+  // unbounded `--wait --output-format json` submission back inside the build.
+  // What this test has always been for is that notarization happens at all, so
+  // it asserts the replacement is wired -- in the workflow, not the config.
   assert.equal(mac.notarize, false);
-  assert.equal(pkg.build.afterSign, "scripts/notarize.js");
+  assert.equal(pkg.build.afterSign, undefined);
+  const wf = fs.readFileSync(
+    path.join(desktopRoot, "..", ".github", "workflows", "desktop-macos-dmg.yml"),
+    "utf8",
+  );
+  assert.match(wf, /notarize\.js submit/);
 });
 
 test("mac: entitlements and entitlementsInherit point at the same file", () => {

--- a/desktop/test/macos-signing.test.js
+++ b/desktop/test/macos-signing.test.js
@@ -23,8 +23,14 @@ test("mac: hardened runtime is on (a precondition for notarization)", () => {
   assert.equal(mac.hardenedRuntime, true);
 });
 
-test("mac: notarization is enabled", () => {
-  assert.equal(mac.notarize, true);
+test("mac: notarization is enabled, via the hook rather than the builder", () => {
+  // #2176 moved notarization out of electron-builder and into an `afterSign`
+  // hook, so `mac.notarize` is now deliberately false -- turning it back on
+  // would submit the app to Apple twice. What this test has always been for is
+  // that notarization happens at all, so it asserts the replacement is wired.
+  // The hook's own behaviour is covered in notarize.test.js.
+  assert.equal(mac.notarize, false);
+  assert.equal(pkg.build.afterSign, "scripts/notarize.js");
 });
 
 test("mac: entitlements and entitlementsInherit point at the same file", () => {

--- a/desktop/test/notarize.test.js
+++ b/desktop/test/notarize.test.js
@@ -52,7 +52,7 @@ test("the submit argv never asks for JSON output", () => {
   // Reintroducing `--output-format json` -- by hand, or by letting
   // electron-builder notarize again -- restores the exact blindness that cost
   // two cancelled builds. It is the one flag that must never come back.
-  const args = notarize.submitArgs({ zipPath: "/tmp/app.zip", ...CREDS });
+  const args = notarize.submitArgs({ artifactPath: "/tmp/SciStudio.dmg", ...CREDS });
   assert.ok(!args.includes("--output-format"), `--output-format present: ${args.join(" ")}`);
   assert.ok(!args.includes("json"), `json output requested: ${args.join(" ")}`);
 });
@@ -61,9 +61,9 @@ test("the submit argv does not wait; polling is this hook's job", () => {
   // `--wait` hands an unbounded wait to a process that has been observed
   // wedging after Apple already returned a verdict. Submitting and polling
   // separately means every check is a fresh, short-lived process.
-  const args = notarize.submitArgs({ zipPath: "/tmp/app.zip", ...CREDS });
+  const args = notarize.submitArgs({ artifactPath: "/tmp/SciStudio.dmg", ...CREDS });
   assert.ok(!args.includes("--wait"), `--wait present: ${args.join(" ")}`);
-  assert.deepEqual(args.slice(0, 3), ["notarytool", "submit", "/tmp/app.zip"]);
+  assert.deepEqual(args.slice(0, 3), ["notarytool", "submit", "/tmp/SciStudio.dmg"]);
   assert.equal(args[args.indexOf("--key") + 1], CREDS.keyPath);
   assert.equal(args[args.indexOf("--key-id") + 1], CREDS.keyId);
   assert.equal(args[args.indexOf("--issuer") + 1], CREDS.issuer);
@@ -165,20 +165,19 @@ test("the trace is mirrored to a file, defaulting under the runner temp dir", ()
   assert.ok(notarize.logPath({}).endsWith("notarize.log"));
 });
 
-test("the notarization bound sits below the job's own timeout", () => {
-  // Two equal bounds race, and the job wins: it is killed before the hook can
-  // say which submission was left in flight -- the one thing a timed-out build
-  // needs to report. The headroom also has to cover signing, which precedes
-  // notarization and has been measured at anywhere from 2 to 12 minutes.
+test("the notarization bound sits below the staple job's own timeout", () => {
+  // Two equal bounds race, and the job wins: it is killed before the script can
+  // say which submission was left in flight -- the one thing a timed-out wait
+  // needs to report, since re-waiting is free and resubmitting costs an hour.
   const wf = fs.readFileSync(
-    path.join(__dirname, "..", "..", ".github", "workflows", "desktop-macos-dmg.yml"),
+    path.join(__dirname, "..", "..", ".github", "workflows", "desktop-macos-staple.yml"),
     "utf8",
   );
   const job = Number(/timeout-minutes:\s*(\d+)/.exec(wf)?.[1]);
-  const hook = Number(/SCISTUDIO_NOTARIZE_TIMEOUT_MIN:\s*"?(\d+)"?/.exec(wf)?.[1]);
-  assert.ok(Number.isFinite(job), "the macOS job has no timeout-minutes");
-  assert.ok(Number.isFinite(hook), "the build step does not bound notarization");
-  assert.ok(hook + 15 <= job, `notarization bound ${hook} leaves no headroom under job timeout ${job}`);
+  const bound = Number(/SCISTUDIO_NOTARIZE_TIMEOUT_MIN:\s*"?(\d+)"?/.exec(wf)?.[1]);
+  assert.ok(Number.isFinite(job), "the staple job has no timeout-minutes");
+  assert.ok(Number.isFinite(bound), "the staple job does not bound the wait");
+  assert.ok(bound + 15 <= job, `wait bound ${bound} leaves no headroom under job timeout ${job}`);
 });
 
 test("the workflow prints the trace however the job ends", () => {
@@ -227,28 +226,76 @@ test("a complete credential set is accepted", () => {
 });
 
 // --------------------------------------------------------------------------
-// Wiring. A correct hook nobody calls is worth nothing.
+// The split. Apple's queue must not be able to fail a build.
 // --------------------------------------------------------------------------
 
-test("the hook is wired as afterSign and points at a file that exists", () => {
-  assert.equal(pkg.build.afterSign, "scripts/notarize.js");
-  assert.ok(fs.existsSync(path.join(__dirname, "..", pkg.build.afterSign)));
-  assert.equal(typeof notarize, "function");
+const workflow = (name) =>
+  fs.readFileSync(path.join(__dirname, "..", "..", ".github", "workflows", name), "utf8");
+
+test("electron-builder does not notarize, and no hook re-adds it", () => {
+  // `notarize: true` would put a blind `--wait --output-format json` submission
+  // back inside the build -- the exact thing measured holding a build for 61
+  // minutes. An `afterSign` hook would do the same at a different seam.
+  assert.equal(pkg.build.mac.notarize, false);
+  assert.equal(pkg.build.afterSign, undefined);
 });
 
-test("electron-builder's own notarization is off, so Apple is asked once", () => {
-  // Leaving `notarize: true` alongside the hook submits the same app twice --
-  // once blind, once visible -- and doubles an already unbounded wait.
-  assert.equal(pkg.build.mac.notarize, false);
+test("the build submits and does not wait", () => {
+  // Waiting here discards the signed dmg *and* the queue position when Apple is
+  // slow, so the next attempt starts another hour from zero.
+  const wf = workflow("desktop-macos-dmg.yml");
+  assert.match(wf, /notarize\.js submit/);
+  assert.ok(!/notarize\.js wait/.test(wf), "the build workflow waits on Apple");
+  assert.ok(!/notarize\.js staple/.test(wf), "the build workflow staples before a ticket exists");
+});
+
+test("the build keeps the dmg, because the ticket is bound to it", () => {
+  // Apple issues the ticket against this artifact's cdhash. A rebuild to staple
+  // would invalidate it and need a fresh submission.
+  const wf = workflow("desktop-macos-dmg.yml");
+  assert.match(wf, /upload-artifact/);
+  assert.match(wf, /desktop\/dist\/\*\.dmg/);
+});
+
+test("the build cannot assert a ticket it has not been issued", () => {
+  // `spctl` and `stapler validate` both check for a notarization ticket. Run in
+  // the build they would fail every time now that submission does not wait.
+  const wf = workflow("desktop-macos-dmg.yml");
+  const verify = wf
+    .slice(wf.indexOf("Verify signature"), wf.indexOf("Verify DMG artifact"))
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("#"))
+    .join("\n");
+  assert.ok(!/stapler validate/.test(verify), "the build validates a ticket that cannot exist yet");
+  assert.ok(!/spctl/.test(verify), "the build runs spctl before notarization completes");
+});
+
+test("the staple workflow waits, staples, and asserts the ticket", () => {
+  const wf = workflow("desktop-macos-staple.yml");
+  assert.match(wf, /notarize\.js wait/);
+  assert.match(wf, /notarize\.js staple/);
+  assert.match(wf, /stapler validate/);
+  assert.match(wf, /spctl/);
+  // Resubmitting is the one thing that must not happen on a retry: it buys a
+  // fresh queue wait and invalidates nothing.
+  assert.ok(!/notarize\.js submit/.test(wf), "the staple workflow resubmits instead of waiting");
+});
+
+test("the staple workflow can read another run's artifact", () => {
+  // Downloading across runs needs `actions: read`; `contents` alone fails with a
+  // 403 that reads like a bad run id.
+  const wf = workflow("desktop-macos-staple.yml");
+  assert.match(wf, /actions:\s*read/);
+  assert.match(wf, /run-id:/);
 });
 
 test("the hardened runtime stays on", () => {
-  // Apple refuses to notarize without it, so a regression here would surface as
-  // a notarization rejection rather than as a config error.
+  // Apple refuses to notarize without it, so a regression would surface as a
+  // rejection an hour later rather than as a config error.
   assert.equal(pkg.build.mac.hardenedRuntime, true);
 });
 
-test("the hook is a build tool and does not ship inside the app", () => {
+test("the notarization script is a build tool and does not ship inside the app", () => {
   // `files` is the asar allowlist. Shipping build scripts would put the
   // notarization argv, and the shape of our credentials handling, in every
   // user's install for no reason.

--- a/desktop/test/notarize.test.js
+++ b/desktop/test/notarize.test.js
@@ -150,6 +150,34 @@ test("a nonsensical timeout falls back to the default rather than to zero", () =
 });
 
 // --------------------------------------------------------------------------
+// Where the trace survives. The build log is not enough.
+// --------------------------------------------------------------------------
+
+test("the trace is mirrored to a file, defaulting under the runner temp dir", () => {
+  // GitHub drops the tail of an in-progress step's log when a job is cancelled
+  // or times out -- exactly when the trace is wanted. The first cancelled run
+  // of this hook lost twelve minutes of output that way, leaving the runner's
+  // own "Terminate orphan process (notarytool)" as the only evidence it had
+  // run. The workflow cats this file in an `if: always()` step.
+  assert.equal(notarize.logPath({ RUNNER_TEMP: "/tmp/runner" }), path.join("/tmp/runner", "notarize.log"));
+  assert.equal(notarize.logPath({ SCISTUDIO_NOTARIZE_LOG: "/x/y.log" }), "/x/y.log");
+  // No RUNNER_TEMP off-CI: still a real path, never undefined.
+  assert.ok(notarize.logPath({}).endsWith("notarize.log"));
+});
+
+test("the workflow prints the trace however the job ends", () => {
+  // A trace written to a file nobody reads is no better than one that was lost.
+  const wf = fs.readFileSync(
+    path.join(__dirname, "..", "..", ".github", "workflows", "desktop-macos-dmg.yml"),
+    "utf8",
+  );
+  const step = wf.slice(wf.indexOf("- name: Notarization trace"));
+  assert.ok(step.length > 0, "the workflow has no step printing the notarization trace");
+  assert.match(step.slice(0, 200), /if:\s*always\(\)/);
+  assert.match(step.slice(0, 300), /notarize\.log/);
+});
+
+// --------------------------------------------------------------------------
 // Credentials.
 // --------------------------------------------------------------------------
 

--- a/desktop/test/notarize.test.js
+++ b/desktop/test/notarize.test.js
@@ -165,6 +165,22 @@ test("the trace is mirrored to a file, defaulting under the runner temp dir", ()
   assert.ok(notarize.logPath({}).endsWith("notarize.log"));
 });
 
+test("the notarization bound sits below the job's own timeout", () => {
+  // Two equal bounds race, and the job wins: it is killed before the hook can
+  // say which submission was left in flight -- the one thing a timed-out build
+  // needs to report. The headroom also has to cover signing, which precedes
+  // notarization and has been measured at anywhere from 2 to 12 minutes.
+  const wf = fs.readFileSync(
+    path.join(__dirname, "..", "..", ".github", "workflows", "desktop-macos-dmg.yml"),
+    "utf8",
+  );
+  const job = Number(/timeout-minutes:\s*(\d+)/.exec(wf)?.[1]);
+  const hook = Number(/SCISTUDIO_NOTARIZE_TIMEOUT_MIN:\s*"?(\d+)"?/.exec(wf)?.[1]);
+  assert.ok(Number.isFinite(job), "the macOS job has no timeout-minutes");
+  assert.ok(Number.isFinite(hook), "the build step does not bound notarization");
+  assert.ok(hook + 15 <= job, `notarization bound ${hook} leaves no headroom under job timeout ${job}`);
+});
+
 test("the workflow prints the trace however the job ends", () => {
   // A trace written to a file nobody reads is no better than one that was lost.
   const wf = fs.readFileSync(

--- a/desktop/test/notarize.test.js
+++ b/desktop/test/notarize.test.js
@@ -1,0 +1,212 @@
+"use strict";
+
+// Notarization visibility invariants (issue #2176).
+//
+// The bug these guard against is not a crash -- it is silence, and a wait with
+// no upper bound. When notarytool runs with `--output-format json` it prints
+// nothing until it finishes, so a build queued behind Apple and a build that is
+// wedged produce the same empty log; and `submit --wait` has been reported to
+// sit for hours after Apple has already finished, so the wait itself is not
+// trustworthy either. Two 0.3.4 macOS builds were cancelled at 118 and 79
+// minutes on that evidence, neither ever finishing.
+//
+// Nothing here talks to Apple. The pure argv/parsing helpers are tested
+// directly; the wiring that decides whether the hook runs at all is asserted
+// against package.json, because a hook that is present but unreferenced fails
+// exactly as quietly as the problem it replaces.
+//
+// Run with: npm --prefix desktop test   (uses the Node built-in test runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const notarize = require("../scripts/notarize.js");
+const pkg = require("../package.json");
+
+const CREDS = { keyPath: "/tmp/AuthKey.p8", keyId: "264X72XYKB", issuer: "abc-123" };
+
+// `notarytool submit` in its real shape: the id arrives, the process exits.
+const SUBMITTED = `Conducting pre-submission checks for app.zip and initiating connection to the Apple notary service...
+Submission ID received
+  id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
+Upload progress: 100.00% (312 MB of 312 MB)
+Successfully uploaded file
+  id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
+  path: /tmp/app.zip
+`;
+
+const info = (status) => `Successfully received submission info
+  createdDate: 2026-08-25T20:49:30.000Z
+  id: 2efe2717-52ef-43a5-96dc-0797e4ca1041
+  name: app.zip
+  status: ${status}
+`;
+
+// --------------------------------------------------------------------------
+// The argv. This is the whole point of the change.
+// --------------------------------------------------------------------------
+
+test("the submit argv never asks for JSON output", () => {
+  // Reintroducing `--output-format json` -- by hand, or by letting
+  // electron-builder notarize again -- restores the exact blindness that cost
+  // two cancelled builds. It is the one flag that must never come back.
+  const args = notarize.submitArgs({ zipPath: "/tmp/app.zip", ...CREDS });
+  assert.ok(!args.includes("--output-format"), `--output-format present: ${args.join(" ")}`);
+  assert.ok(!args.includes("json"), `json output requested: ${args.join(" ")}`);
+});
+
+test("the submit argv does not wait; polling is this hook's job", () => {
+  // `--wait` hands an unbounded wait to a process that has been observed
+  // wedging after Apple already returned a verdict. Submitting and polling
+  // separately means every check is a fresh, short-lived process.
+  const args = notarize.submitArgs({ zipPath: "/tmp/app.zip", ...CREDS });
+  assert.ok(!args.includes("--wait"), `--wait present: ${args.join(" ")}`);
+  assert.deepEqual(args.slice(0, 3), ["notarytool", "submit", "/tmp/app.zip"]);
+  assert.equal(args[args.indexOf("--key") + 1], CREDS.keyPath);
+  assert.equal(args[args.indexOf("--key-id") + 1], CREDS.keyId);
+  assert.equal(args[args.indexOf("--issuer") + 1], CREDS.issuer);
+});
+
+test("info and log target one submission with the same credentials", () => {
+  const id = "2efe2717-52ef-43a5-96dc-0797e4ca1041";
+  assert.deepEqual(
+    notarize.infoArgs({ submissionId: id, ...CREDS }).slice(0, 3),
+    ["notarytool", "info", id],
+  );
+  assert.deepEqual(
+    notarize.logArgs({ submissionId: id, ...CREDS }).slice(0, 3),
+    ["notarytool", "log", id],
+  );
+  for (const args of [
+    notarize.infoArgs({ submissionId: id, ...CREDS }),
+    notarize.logArgs({ submissionId: id, ...CREDS }),
+  ]) {
+    assert.equal(args[args.indexOf("--issuer") + 1], CREDS.issuer);
+  }
+});
+
+// --------------------------------------------------------------------------
+// Reading the transcript.
+// --------------------------------------------------------------------------
+
+test("the submission id is recovered from the submit transcript", () => {
+  // This id is what makes a timed-out or failed build investigable afterwards
+  // via `notarytool info/log <id>` -- the capability #2174 claimed to add and
+  // did not. Every build cancelled so far failed to produce one.
+  assert.equal(notarize.parseSubmissionId(SUBMITTED), "2efe2717-52ef-43a5-96dc-0797e4ca1041");
+});
+
+test("a transcript with no id yields null rather than a bad id", () => {
+  assert.equal(notarize.parseSubmissionId("Conducting pre-submission checks...\n"), null);
+  assert.equal(notarize.parseSubmissionId(""), null);
+  assert.equal(notarize.parseSubmissionId(undefined), null);
+});
+
+test("an in-progress poll is reported as in progress, not as unparseable", () => {
+  // The poll loop has to tell "Apple is still working" from "nothing parsed".
+  // Collapsing those either spins forever or declares success on garbage.
+  assert.equal(notarize.parseStatus(info("In Progress")), "In Progress");
+  assert.equal(notarize.isTerminal("In Progress"), false);
+});
+
+test("terminal verdicts are recognised", () => {
+  for (const status of ["Accepted", "Invalid", "Rejected"]) {
+    assert.equal(notarize.parseStatus(info(status)), status);
+    assert.equal(notarize.isTerminal(status), true);
+  }
+});
+
+test("an absent verdict is not mistaken for success", () => {
+  // notarytool exits 0 for a submission Apple rejected, so a missing status
+  // must never read as Accepted.
+  assert.equal(notarize.parseStatus("Waiting for processing to complete.\n"), null);
+  assert.equal(notarize.parseStatus(""), null);
+  assert.equal(notarize.isTerminal(null), false);
+  assert.equal(notarize.isTerminal("unknown"), false);
+});
+
+test("the last status wins when a transcript carries several", () => {
+  const transcript = `${info("In Progress")}${info("Accepted")}`;
+  assert.equal(notarize.parseStatus(transcript), "Accepted");
+});
+
+// --------------------------------------------------------------------------
+// The bound. A wait with no deadline is the thing being removed.
+// --------------------------------------------------------------------------
+
+test("polling is bounded by default and overridable", () => {
+  assert.equal(notarize.timeoutMinutes({}), 90);
+  assert.equal(notarize.timeoutMinutes({ SCISTUDIO_NOTARIZE_TIMEOUT_MIN: "20" }), 20);
+});
+
+test("a nonsensical timeout falls back to the default rather than to zero", () => {
+  // A zero or negative bound would abandon every submission on the first poll,
+  // and an unparseable one must not silently mean "no timeout" either.
+  for (const value of ["", "0", "-5", "abc", "  "]) {
+    assert.equal(notarize.timeoutMinutes({ SCISTUDIO_NOTARIZE_TIMEOUT_MIN: value }), 90, value);
+  }
+});
+
+// --------------------------------------------------------------------------
+// Credentials.
+// --------------------------------------------------------------------------
+
+test("an empty environment skips notarization instead of failing", () => {
+  // A developer running `dist:dmg` locally has no App Store Connect key. That
+  // has always produced an unsigned build, not an error, and must keep doing so.
+  assert.equal(notarize.credentials({}), null);
+  assert.equal(notarize.credentials({ APPLE_API_KEY: "", APPLE_API_KEY_ID: "" }), null);
+});
+
+test("a partial credential set is an error, never a silent skip", () => {
+  // Half-configured secrets are always a mistake, and skipping quietly is how
+  // an unnotarized dmg reaches a release (#2096). electron-builder threw here
+  // too; the behaviour is preserved deliberately.
+  assert.throws(
+    () => notarize.credentials({ APPLE_API_KEY_ID: "X", APPLE_API_ISSUER: "Y" }),
+    /APPLE_API_KEY\b/,
+  );
+  assert.throws(() => notarize.credentials({ APPLE_API_KEY: "/tmp/k.p8" }), /APPLE_API_KEY_ID/);
+});
+
+test("a complete credential set is accepted", () => {
+  assert.deepEqual(
+    notarize.credentials({
+      APPLE_API_KEY: "/tmp/k.p8",
+      APPLE_API_KEY_ID: "264X72XYKB",
+      APPLE_API_ISSUER: "abc-123",
+    }),
+    { keyPath: "/tmp/k.p8", keyId: "264X72XYKB", issuer: "abc-123" },
+  );
+});
+
+// --------------------------------------------------------------------------
+// Wiring. A correct hook nobody calls is worth nothing.
+// --------------------------------------------------------------------------
+
+test("the hook is wired as afterSign and points at a file that exists", () => {
+  assert.equal(pkg.build.afterSign, "scripts/notarize.js");
+  assert.ok(fs.existsSync(path.join(__dirname, "..", pkg.build.afterSign)));
+  assert.equal(typeof notarize, "function");
+});
+
+test("electron-builder's own notarization is off, so Apple is asked once", () => {
+  // Leaving `notarize: true` alongside the hook submits the same app twice --
+  // once blind, once visible -- and doubles an already unbounded wait.
+  assert.equal(pkg.build.mac.notarize, false);
+});
+
+test("the hardened runtime stays on", () => {
+  // Apple refuses to notarize without it, so a regression here would surface as
+  // a notarization rejection rather than as a config error.
+  assert.equal(pkg.build.mac.hardenedRuntime, true);
+});
+
+test("the hook is a build tool and does not ship inside the app", () => {
+  // `files` is the asar allowlist. Shipping build scripts would put the
+  // notarization argv, and the shape of our credentials handling, in every
+  // user's install for no reason.
+  assert.ok(!pkg.build.files.some((f) => String(f).includes("scripts/")));
+});

--- a/docs/specs/desktop-macos-signing-notarization.md
+++ b/docs/specs/desktop-macos-signing-notarization.md
@@ -72,8 +72,8 @@ All four steps are necessary. Signing alone does not remove the prompt.
 |---|---|---|
 | Developer ID signature | `mac.identity` (auto-detected from the keychain) | Must be a **Developer ID Application** certificate — not "Apple Development", not a Mac App Store certificate |
 | Hardened runtime | `mac.hardenedRuntime: true` | Apple refuses to notarize without it |
-| Notarization | `build.afterSign: scripts/notarize.js` | electron-builder's native `mac.notarize` was used until #2176 and is now deliberately `false`; see section 6.5 |
-| Stapling | performed by the same hook | Without a stapled ticket the **first launch needs network access** to reach Apple, so an offline first run still prompts |
+| Notarization | the `Desktop macOS DMG` workflow submits; `mac.notarize` is deliberately `false` | electron-builder's native path waits on Apple inside the build, which has no upper bound; see section 6.5 |
+| Stapling | the `Desktop macOS Staple` workflow, once Apple returns a verdict | Without a stapled ticket the **first launch needs network access** to reach Apple, so an offline first run still prompts |
 
 `mac.gatekeeperAssess` stays `false`. It controls a local `spctl` assessment
 electron-builder runs on the build machine; it does not affect what ships, and
@@ -239,63 +239,6 @@ signing was expected:
 
 Any of these failing fails the build.
 
-### 6.5 Notarization runs from a hook, and polls rather than waits (#2176)
-
-`mac.notarize` is `false`. Notarization is performed by an `afterSign` hook,
-`desktop/scripts/notarize.js`, which electron-builder invokes between signing
-the `.app` and assembling the dmg around it — so the ticket is still stapled
-before the dmg exists, exactly as the native path did.
-
-The move was forced by two properties of the command `@electron/notarize`
-issues:
-
-```
-xcrun notarytool submit <zip> --key ... --wait --output-format json
-```
-
-**`--output-format json` makes a stall indistinguishable from progress.**
-notarytool emits one JSON object when it finishes and nothing before it. A
-submission sitting in Apple's queue and a submission that is wedged therefore
-produce byte-identical logs: empty ones. Two 0.3.4 builds were cancelled at 118
-and 79 minutes reading that silence as a hang, and because neither was allowed
-to finish it remained unknown whether notarization worked at all.
-
-`DEBUG: electron-notarize*` (#2174) did not fix this. It surfaces that
-package's own phase logging, which stops at the moment notarytool is spawned.
-That bounded the problem usefully — packaging plus signing measured ~2 min and
-`ditto` 26 s, ruling out everything before submission — but it cannot see the
-one phase that matters.
-
-**`--wait` is not a trustworthy bound.** It has been reported sitting for hours
-after Apple had already returned a verdict, so the wait loop itself can wedge;
-`--timeout` would still depend on that same loop noticing.
-
-So the hook submits *without* waiting, keeps the submission ID, and drives the
-polling itself: `notarytool info` every 60 s, bounded at 90 minutes
-(`SCISTUDIO_NOTARIZE_TIMEOUT_MIN` overrides). Each poll is a fresh short-lived
-process that cannot wedge, and each writes a line, so elapsed time is legible
-while the build is running rather than only in hindsight.
-
-Three behaviours are deliberate:
-
-- **A rejection fails the build.** notarytool exits 0 for a submission Apple
-  refused — the submission completed, the verdict was `Invalid` — so the status
-  line decides, not the exit status. On rejection the hook runs
-  `notarytool log <id>` first, because the status says only *that* Apple
-  refused.
-- **A timeout fails the build carrying the submission ID.** The submission stays
-  live at Apple, so the ID keeps it queryable with `notarytool info`/`history`
-  instead of forcing a blind resubmit. Every build cancelled before #2176 failed
-  to produce one.
-- **Missing credentials skip; partial credentials fail.** A developer with no
-  App Store Connect key still gets an unsigned local build, which is the
-  behaviour section 6.2 describes. A half-configured set is always a
-  misconfiguration, and electron-builder threw there too.
-
-The build log still prints `skipped macOS notarization` from
-`macPackager.notarizeIfProvided()`. That is `mac.notarize: false` working as
-intended, not a skip; the hook's own output is prefixed `[notarize]`.
-
 ### 6.4 Local build
 
 For a one-off local build on macOS, the same credentials work as environment
@@ -313,12 +256,95 @@ npm --prefix desktop run dist:dmg
 The Developer ID Application certificate must be in the local keychain;
 electron-builder selects it automatically.
 
+`dist:dmg` signs but does not notarize (section 6.5), so a local dmg still
+meets Gatekeeper until the two remaining phases are run by hand:
+
+```sh
+node desktop/scripts/notarize.js submit desktop/dist/SciStudio-*.dmg   # prints the id
+node desktop/scripts/notarize.js wait <submission-id>
+node desktop/scripts/notarize.js staple desktop/dist/SciStudio-*.dmg
+```
+
+`wait` is safe to re-run and safe to interrupt. Re-submitting is not: the ticket
+is bound to that dmg's cdhash, so a second submission buys a second queue wait
+and invalidates nothing.
+
+### 6.5 Notarization is submitted by the build and finished separately (#2176)
+
+`mac.notarize` is `false` and there is no `afterSign` hook. electron-builder
+signs; `desktop/scripts/notarize.js` does everything else, in two phases that
+run in different jobs.
+
+**Why it left electron-builder.** `@electron/notarize` runs
+
+```
+xcrun notarytool submit <zip> --key ... --wait --output-format json
+```
+
+and both flags are load-bearing mistakes for us. `--output-format json`
+suppresses every progress line — notarytool emits one object at the end and
+nothing before it — so a submission queued behind Apple and one that is wedged
+produce byte-identical logs: empty ones. Two 0.3.4 builds were cancelled at 118
+and 79 minutes reading that silence as a hang. `DEBUG: electron-notarize*`
+(#2174) did not fix it: that surfaces the package's own phase logging, which
+stops where notarytool is spawned. `--wait` is separately untrustworthy — it has
+been reported outliving Apple's own verdict — so the script polls
+`notarytool info` instead, one fresh short-lived process per minute, each
+writing a line.
+
+**Why it is split across two jobs.** Measured on 2026-08-25 with that
+instrumentation: signing 2 min 36 s, `ditto` 20 s, upload 17 s — and then
+**61 consecutive polls, every one `In Progress`**. Apple held the submission for
+over an hour without a verdict.
+
+That is not a failure anything here can fix. What *was* fixable is the cost:
+waiting inside the build discarded the signed dmg together with the queue
+position, so each attempt began another hour from zero. So:
+
+| Job | Does |
+|---|---|
+| `Desktop macOS DMG` | sign, build the dmg, submit it, upload it, print the submission ID — then stop |
+| `Desktop macOS Staple` | wait for the verdict, staple the ticket to that dmg, assert the result |
+
+A slow queue now costs a delay rather than a rebuild. Re-running the staple
+workflow is free; **resubmitting is not** — the ticket is bound to the signed
+artifact's cdhash, so a rebuilt dmg needs a fresh submission and a fresh wait,
+and the old one was never invalid.
+
+**What is submitted.** The dmg, not the `.app`. Stapling has to attach to
+something that outlives the build, and the dmg is what ships. The `.app` inside
+is therefore not itself stapled: Gatekeeper resolves it online, which every
+download-from-GitHub user is. Only a first launch with no network would notice,
+and that is the trade the split buys.
+
+**Where the assertions live.** The build job can only assert what exists at
+build time — the signature and the hardened runtime. `spctl` and
+`xcrun stapler validate` both require a ticket, so they run in the staple job,
+against the shipped dmg and the app mounted from it. That is also the more
+faithful check: it asks Gatekeeper about the app a user will actually launch.
+
+**Where the trace lives.** The script mirrors every line to
+`$RUNNER_TEMP/notarize.log`, and both workflows print it in an `if: always()`
+step. GitHub drops the tail of an in-progress step's log when a job is cancelled
+or times out — exactly when the trace is wanted. A cancelled build lost twelve
+minutes of output that way, leaving the runner's own
+`Terminate orphan process (notarytool)` as the only evidence anything had run.
+
+**Failure behaviour.** A rejection fails the job: notarytool exits 0 for a
+submission Apple *refused* — it completed, the verdict was `Invalid` — so the
+status line decides, not the exit status, and `notarytool log <id>` runs first
+because the status says only *that* Apple refused. A timeout fails carrying the
+submission ID, which keeps the submission queryable instead of forcing a blind
+resubmit. Missing credentials skip; partial credentials fail, because a
+half-configured set is always a misconfiguration.
+
 ## 7. Verification
 
 Automated, any platform — `desktop/test/macos-signing.test.js`:
 
-- `hardenedRuntime` is on, `mac.notarize` is `false`, and `build.afterSign`
-  points at `scripts/notarize.js` (#2176).
+- `hardenedRuntime` is on, `mac.notarize` is `false`, and there is no
+  `build.afterSign` — notarization is driven by the workflows, not by
+  electron-builder (#2176).
 - `entitlements` and `entitlementsInherit` are set and identical (section 3.2).
 - The configured entitlements path exists. electron-builder returns an
   explicitly configured entitlements path verbatim rather than resolving it

--- a/docs/specs/desktop-macos-signing-notarization.md
+++ b/docs/specs/desktop-macos-signing-notarization.md
@@ -72,8 +72,8 @@ All four steps are necessary. Signing alone does not remove the prompt.
 |---|---|---|
 | Developer ID signature | `mac.identity` (auto-detected from the keychain) | Must be a **Developer ID Application** certificate — not "Apple Development", not a Mac App Store certificate |
 | Hardened runtime | `mac.hardenedRuntime: true` | Apple refuses to notarize without it |
-| Notarization | `mac.notarize: true` | electron-builder 26.15.3 supports this natively; `@electron/notarize` is already a transitive dependency |
-| Stapling | automatic after notarization | Without a stapled ticket the **first launch needs network access** to reach Apple, so an offline first run still prompts |
+| Notarization | `build.afterSign: scripts/notarize.js` | electron-builder's native `mac.notarize` was used until #2176 and is now deliberately `false`; see section 6.5 |
+| Stapling | performed by the same hook | Without a stapled ticket the **first launch needs network access** to reach Apple, so an offline first run still prompts |
 
 `mac.gatekeeperAssess` stays `false`. It controls a local `spctl` assessment
 electron-builder runs on the build machine; it does not affect what ships, and
@@ -219,7 +219,13 @@ fully green PR.
 
 `macPackager.notarizeIfProvided()` logs `skipped macOS notarization` and returns
 when its options cannot be generated. A missing or mistyped credential therefore
-yields a **green build and a dmg that still shows the Gatekeeper prompt**.
+yielded a **green build and a dmg that still shows the Gatekeeper prompt**.
+
+The #2176 hook hard-fails instead, so that specific hole is closed at the
+source. The verification step still runs, because it is the only check that
+survives the hook being unwired, mis-pathed, or skipped because signing did not
+occur — and it asserts the shipped artifact rather than the build's account of
+itself.
 
 The workflow closes that hole with a verification step that runs whenever
 signing was expected:
@@ -232,6 +238,63 @@ signing was expected:
 - `xcrun stapler validate` — a stapled ticket is the only proof notarization ran
 
 Any of these failing fails the build.
+
+### 6.5 Notarization runs from a hook, and polls rather than waits (#2176)
+
+`mac.notarize` is `false`. Notarization is performed by an `afterSign` hook,
+`desktop/scripts/notarize.js`, which electron-builder invokes between signing
+the `.app` and assembling the dmg around it — so the ticket is still stapled
+before the dmg exists, exactly as the native path did.
+
+The move was forced by two properties of the command `@electron/notarize`
+issues:
+
+```
+xcrun notarytool submit <zip> --key ... --wait --output-format json
+```
+
+**`--output-format json` makes a stall indistinguishable from progress.**
+notarytool emits one JSON object when it finishes and nothing before it. A
+submission sitting in Apple's queue and a submission that is wedged therefore
+produce byte-identical logs: empty ones. Two 0.3.4 builds were cancelled at 118
+and 79 minutes reading that silence as a hang, and because neither was allowed
+to finish it remained unknown whether notarization worked at all.
+
+`DEBUG: electron-notarize*` (#2174) did not fix this. It surfaces that
+package's own phase logging, which stops at the moment notarytool is spawned.
+That bounded the problem usefully — packaging plus signing measured ~2 min and
+`ditto` 26 s, ruling out everything before submission — but it cannot see the
+one phase that matters.
+
+**`--wait` is not a trustworthy bound.** It has been reported sitting for hours
+after Apple had already returned a verdict, so the wait loop itself can wedge;
+`--timeout` would still depend on that same loop noticing.
+
+So the hook submits *without* waiting, keeps the submission ID, and drives the
+polling itself: `notarytool info` every 60 s, bounded at 90 minutes
+(`SCISTUDIO_NOTARIZE_TIMEOUT_MIN` overrides). Each poll is a fresh short-lived
+process that cannot wedge, and each writes a line, so elapsed time is legible
+while the build is running rather than only in hindsight.
+
+Three behaviours are deliberate:
+
+- **A rejection fails the build.** notarytool exits 0 for a submission Apple
+  refused — the submission completed, the verdict was `Invalid` — so the status
+  line decides, not the exit status. On rejection the hook runs
+  `notarytool log <id>` first, because the status says only *that* Apple
+  refused.
+- **A timeout fails the build carrying the submission ID.** The submission stays
+  live at Apple, so the ID keeps it queryable with `notarytool info`/`history`
+  instead of forcing a blind resubmit. Every build cancelled before #2176 failed
+  to produce one.
+- **Missing credentials skip; partial credentials fail.** A developer with no
+  App Store Connect key still gets an unsigned local build, which is the
+  behaviour section 6.2 describes. A half-configured set is always a
+  misconfiguration, and electron-builder threw there too.
+
+The build log still prints `skipped macOS notarization` from
+`macPackager.notarizeIfProvided()`. That is `mac.notarize: false` working as
+intended, not a skip; the hook's own output is prefixed `[notarize]`.
 
 ### 6.4 Local build
 
@@ -254,7 +317,8 @@ electron-builder selects it automatically.
 
 Automated, any platform — `desktop/test/macos-signing.test.js`:
 
-- `hardenedRuntime` is on and `notarize` is enabled.
+- `hardenedRuntime` is on, `mac.notarize` is `false`, and `build.afterSign`
+  points at `scripts/notarize.js` (#2176).
 - `entitlements` and `entitlementsInherit` are set and identical (section 3.2).
 - The configured entitlements path exists. electron-builder returns an
   explicitly configured entitlements path verbatim rather than resolving it


### PR DESCRIPTION
## Problem

`#2174` added `DEBUG: electron-notarize*` so a notarization stall could be
diagnosed, and the step comment claimed it "surfaces the submission ID and each
polling state". It does not. `@electron/notarize` runs:

```
xcrun notarytool submit <zip> --key ... --wait --output-format json
```

**`--output-format json` suppresses every progress line.** notarytool emits one
object when it finishes and nothing before it, so a submission queued behind
Apple and one that is wedged produce byte-identical logs: empty ones. Two 0.3.4
builds were cancelled at 118 and 79 minutes reading that silence as a hang.
`DEBUG` surfaces `@electron/notarize`'s own phase logging, which stops where
notarytool is spawned — useful (it proved packaging plus signing takes ~2 min
and `ditto` 26 s) but blind to the phase that mattered.

**`--wait` is separately untrustworthy** — reported outliving Apple's own
verdict — so `--timeout` would not have been a bound either.

## What the instrumentation then measured

The first build that actually ran this code produced the number the design
turns on:

```
22:05:07  signing
22:07:43  signed        (2 min 36 s)
22:08:03  zipped        (20 s, 239 MB)
22:08:20  uploaded      (17 s)  submission 67b87358-…
22:08:20  poll  1 at  0 min: In Progress
   …      61 consecutive polls, every one In Progress
23:08:50  poll 61 at 61 min: In Progress   → timed out
```

Apple held the submission for over an hour without a verdict. Nothing here can
fix that. What *was* fixable is the cost of waiting for it: the build died
holding the signed dmg **and** the queue position, so the next attempt started
another hour from zero — and the ticket Apple would eventually issue had nothing
left to attach to, since it is bound to the signed artifact's cdhash.

## Change

Notarization leaves electron-builder entirely (`mac.notarize: false`, no
`afterSign`) and is driven by `desktop/scripts/notarize.js`, a three-subcommand
CLI split across two jobs:

| Job | Does |
|---|---|
| `Desktop macOS DMG` | sign, build the dmg, **submit it**, upload it, print the submission ID — then stop |
| `Desktop macOS Staple` (new, `workflow_dispatch`) | wait for the verdict, staple the ticket to that dmg, assert the result |

Polling is ours: `notarytool info` once a minute, each poll a fresh short-lived
process that cannot wedge, each writing a line. Re-running the staple workflow
is free. **Resubmitting is the one thing that must not be done to "retry"** — it
buys a fresh queue wait and invalidates nothing.

Three consequences worth stating:

* **The dmg is submitted, not the `.app`.** Stapling has to attach to something
  that outlives the build. The `.app` inside is therefore not itself stapled:
  Gatekeeper resolves it online, which every download-from-GitHub user is. Only
  an offline first launch would notice.
* **The build job no longer runs `spctl` or `stapler validate`.** Both assert a
  ticket that does not exist yet. They move to the staple job, where they run
  against the shipped dmg and the app mounted from it — the more faithful check,
  since it asks Gatekeeper about the app a user will launch.
* **A rejection fails the job.** notarytool exits 0 for a submission Apple
  *refused*, so the status line decides, not the exit status, and
  `notarytool log <id>` runs first because the status says only *that* Apple
  refused.

## The trace outlives the job

The script mirrors every line to `$RUNNER_TEMP/notarize.log`, printed by an
`if: always()` step in both workflows. GitHub drops the tail of an in-progress
step's log when a job is cancelled or times out — exactly when the trace is
wanted. An earlier cancelled build lost twelve minutes of output that way,
leaving the runner's own `Terminate orphan process (notarytool)` as the only
evidence anything had run.

## Tests

131 pass. They assert the split rather than restating it:

* `--output-format` and `--wait` can never come back in the submit argv.
* The build workflow runs `submit` and neither `wait` nor `staple`, keeps the
  dmg, and asserts no ticket.
* The staple workflow waits, staples, validates — and never resubmits.
* `In Progress` is distinguished from an unparseable status; an absent status is
  not read as success; the wait bound cannot degrade to zero and sits below the
  job timeout.

Verified by reintroducing the original defects: the guards fail.

## Note on the gate

`checks.python_tests` fails locally on this machine and passes in CI. Root cause
found while preparing this PR and **not fixed here**: `tests/api/helpers.py`
hardcodes wall-clock budgets (5 s / 10 s / 5 s) that assume an unloaded machine.
Raising the workflow one to 60 s takes the full suite from 7 failures to 1,
which is the evidence that they are failure-detection bounds, not performance
assertions. Pre-flight was skipped with owner authorization; a separate PR will
fix the budgets.

Closes #2176
