### PR TITLE
fix(#2179): let a shell prove itself before it is called known-good

### DIFF
--- a/.workflow/records/2179-fix-2179-shell-known-good.json
+++ b/.workflow/records/2179-fix-2179-shell-known-good.json
@@ -1,7 +1,76 @@
 {
   "base_ref": null,
   "branch": "fix/2179-shell-known-good",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-25T23:58:02.411096Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:ed4c194d4c6e570d2d0df22f6ceed7c77922ffacdbf12c105de8cf3d820d3f33",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T23:58:02.487576Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-25T23:58:13.395895Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0ab66f76e8956f3ab676631e3fd45f5a32d5aa14619d81840730217c0f6f910c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-25T23:58:13.471953Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -23,7 +92,184 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-25T23:58:13.533195Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.547203Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.564401Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.578145Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.591967Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.605767Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.620138Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.634103Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.648004Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.661279Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:13.676020Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.286654Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.302400Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.317829Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.332933Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.347308Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.365365Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.381881Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.396374Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.411777Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.426483Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-25T23:58:28.442675Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -33,18 +279,78 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "62e3e5131",
+    "changed_files": [
+      ".workflow/records/2179-fix-2179-shell-known-good.json",
+      "desktop/main.js",
+      "desktop/test/bootstrap.test.js",
+      "desktop/test/shell-known-good.test.js",
+      "docs/specs/desktop-shell-ota-hot-update.md"
+    ],
+    "diff_fingerprint": "sha256:6bcf36ae87f318d87d95ed2e9c1e79c9256bceea2a01e6c781e2ad410792b28d",
+    "head": "HEAD",
+    "head_sha": "0534f016e",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Also submit a PR for the OTA upgrade bug found while reviewing PR 2171.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-25T23:58:13.676052Z",
+      "diff_fingerprint": "sha256:6bcf36ae87f318d87d95ed2e9c1e79c9256bceea2a01e6c781e2ad410792b28d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-25T23:58:28.442709Z",
+      "diff_fingerprint": "sha256:6bcf36ae87f318d87d95ed2e9c1e79c9256bceea2a01e6c781e2ad410792b28d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2179-fix-2179-shell-known-good",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "commit_hygiene",
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
@@ -76,7 +382,7 @@
     }
   ],
   "session_id": "e37fdc4d-f6a2-443e-8a2b-25b01d037eea",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2179-fix-2179-shell-known-good.json
+++ b/.workflow/records/2179-fix-2179-shell-known-good.json
@@ -1,0 +1,91 @@
+{
+  "base_ref": null,
+  "branch": "fix/2179-shell-known-good",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "desktop",
+      "docs/specs"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-25T23:56:36.908133Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/desktop-shell-ota-hot-update.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2179,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Also submit a PR for the OTA upgrade bug found while reviewing PR 2171.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2179-fix-2179-shell-known-good",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-25T23:56:36.908102Z",
+      "pattern": "desktop/main.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T23:56:36.908122Z",
+      "pattern": "desktop/test/shell-known-good.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T23:56:36.908124Z",
+      "pattern": "desktop/test/bootstrap.test.js",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-25T23:56:36.908126Z",
+      "pattern": "docs/specs/desktop-shell-ota-hot-update.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "e37fdc4d-f6a2-443e-8a2b-25b01d037eea",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-25T23:56:36.908140Z",
+      "class": null,
+      "kind": "path",
+      "path": "desktop/test/shell-known-good.test.js",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -292,11 +292,35 @@ function effectiveBuild() {
   return Math.max(baselineVersion().build, active ? active.build : 0);
 }
 
+// #2179: set when the shell itself fails after the backend is already
+// answering. `recordKnownGood` is what disarms the loader's crash-loop
+// quarantine, so it must not fire while this holds a reason.
+let shellFault = null;
+
+function noteShellFault(reason) {
+  if (shellFault) {
+    return;
+  }
+  shellFault = reason;
+  safeError(`[scistudio] shell fault: ${reason}`);
+}
+
 function recordKnownGood(build) {
-  // #2097: the runtime answered, so the shell that got us here booted cleanly.
-  // Clearing the loader's crash-loop marker here (rather than merely on
+  // #2097: clearing the loader's crash-loop marker here (rather than merely on
   // startup) is what makes "this shell build never reached readiness" mean
   // exactly that.
+  //
+  // #2179: it used to fire as soon as the backend answered. But the readiness
+  // probe validates the *Python runtime*, and this vouches for the *Electron
+  // shell* -- two halves of one snapshot that fail independently. A patch that
+  // broke the preload, the window, or the menu still got recorded as good, so
+  // the quarantine never engaged and the next launch loaded it again. It now
+  // runs only once the renderer has painted, and refuses outright while a shell
+  // fault stands.
+  if (shellFault) {
+    safeError(`[scistudio] not recording build ${build} as known-good: ${shellFault}`);
+    return;
+  }
   try {
     host().clearBootAttempt();
   } catch (error) {
@@ -1225,7 +1249,11 @@ async function pageHasRendered(window) {
     .catch(() => false);
 }
 
-function loadBeforeShowing(window, url, attempt = 0) {
+// #2179: `onRendered` is called only on the path that proves the shell worked --
+// the renderer finished loading *and* painted. The retry and error-page paths
+// deliberately do not call it: a window showing an error page is not evidence
+// that this shell build is worth rolling back to.
+function loadBeforeShowing(window, url, attempt = 0, onRendered = null) {
   const show = () => {
     if (!window.isDestroyed() && !window.isVisible()) {
       window.show();
@@ -1239,10 +1267,13 @@ function loadBeforeShowing(window, url, attempt = 0) {
     const rendered = await pageHasRendered(window);
     if (rendered || attempt >= 1) {
       show();
+      if (rendered && typeof onRendered === "function") {
+        onRendered();
+      }
       return;
     }
     safeError("[scistudio] blank first paint before window show; retrying once");
-    loadBeforeShowing(window, cacheBustedUrl(url, attempt + 1), attempt + 1);
+    loadBeforeShowing(window, cacheBustedUrl(url, attempt + 1), attempt + 1, onRendered);
   });
 
   window.webContents.once("did-fail-load", (_event, _code, _description, validatedUrl) => {
@@ -1252,7 +1283,7 @@ function loadBeforeShowing(window, url, attempt = 0) {
       return;
     }
     safeError(`[scistudio] failed to load ${validatedUrl}; retrying once`);
-    loadBeforeShowing(window, cacheBustedUrl(url, attempt + 1), attempt + 1);
+    loadBeforeShowing(window, cacheBustedUrl(url, attempt + 1), attempt + 1, onRendered);
   });
 
   window.loadURL(url);
@@ -1426,6 +1457,16 @@ function createWindow(url) {
     mainWindow = null;
   });
 
+  // #2179: Electron reports a preload that threw, and nothing here used to
+  // listen. The main window is sandboxed, so its preload gets a restricted
+  // `require` -- a shell patch that adds a relative import to preload.js aborts
+  // before `contextBridge.exposeInMainWorld`, `window.scistudioDesktop`
+  // disappears, and every bridge with it. None of that stops the backend
+  // answering, so without this the broken build was recorded as known-good.
+  mainWindow.webContents.on("preload-error", (_event, preloadPath, error) => {
+    noteShellFault(`preload ${path.basename(preloadPath)} failed: ${error.message}`);
+  });
+
   // #1741: capture renderer-process console output so frontend logs persist in
   // a packaged app, where beta testers have no DevTools to read.
   mainWindow.webContents.on("console-message", (_event, level, message, lineNumber, sourceId) => {
@@ -1436,7 +1477,9 @@ function createWindow(url) {
     );
   });
 
-  loadBeforeShowing(mainWindow, url);
+  // #2179: the shell has proved itself only now -- window created, preload
+  // clean, renderer painted. This is what disarms the crash-loop quarantine.
+  loadBeforeShowing(mainWindow, url, 0, () => recordKnownGood(effectiveBuild()));
 }
 
 function stopRuntime() {
@@ -1497,9 +1540,9 @@ function start(injectedHost) {
       // #1986: the runtime answered on this port, so it is worth reusing next
       // launch to keep the renderer origin (and its persisted UI state) stable.
       rememberRuntimePort(runtimePortModule.boundPortFromReady(ready));
-      // #1775: the runtime reached ready, so whatever patch is active booted
-      // cleanly; remember it as the rollback target for future launches.
-      recordKnownGood(effectiveBuild());
+      // #1775/#2179: the runtime reaching ready says the *backend* half of the
+      // patch works. The shell half is vouched for from createWindow, once the
+      // renderer has actually painted.
       await clearCacheOnBuildChange();
       Menu.setApplicationMenu(buildAppMenu());
       const url = launchUrl(ready.url);

--- a/desktop/test/bootstrap.test.js
+++ b/desktop/test/bootstrap.test.js
@@ -101,16 +101,21 @@ test("the loader records the boot attempt before requiring the shell", () => {
   assert.ok(recordAt < startAt, "recordBootAttempt must precede startShell");
 });
 
-test("the shell clears the boot marker only once the runtime is up", () => {
-  // Clearing it any earlier would make the marker mean "we tried" rather than
+test("the shell clears the boot marker only from the known-good path", () => {
+  // Clearing it anywhere else would make the marker mean "we tried" rather than
   // "we succeeded", and a crash-looping shell would never be refused.
+  // #2179 moved *when* that path runs -- it now waits for the renderer to paint
+  // rather than for the backend to answer -- but the marker must still be
+  // cleared from recordKnownGood and nowhere else.
   const main = read("main.js");
   const clearAt = main.indexOf("host().clearBootAttempt()");
   assert.ok(clearAt > 0, "main.js must clear the marker");
-  assert.match(
-    main.slice(Math.max(0, clearAt - 400), clearAt),
-    /function recordKnownGood/,
-    "the marker must be cleared from recordKnownGood, which runs after HTTP readiness"
+  const declAt = main.lastIndexOf("function recordKnownGood", clearAt);
+  assert.ok(declAt > 0 && declAt < clearAt, "the marker must be cleared from recordKnownGood");
+  assert.equal(
+    main.slice(declAt, clearAt).indexOf("\nfunction "),
+    -1,
+    "another function declaration sits between recordKnownGood and the clear"
   );
 });
 

--- a/desktop/test/shell-known-good.test.js
+++ b/desktop/test/shell-known-good.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+// What "this shell build is good" is allowed to mean (issue #2179).
+//
+// `recordKnownGood` clears the loader's crash-loop marker and fixes the current
+// build as the rollback target. It used to fire the moment the backend answered
+// HTTP readiness -- but that probe validates the **Python runtime**, while the
+// call vouches for the **Electron shell**. They are two halves of one OTA
+// snapshot and they fail independently.
+//
+// Everything the shell does happens after that point: the window is created,
+// the preload runs, the renderer paints, the menu is built. A patch that broke
+// any of it was still recorded as good, so the quarantine never engaged, the
+// loader never fell back, and the next launch loaded the same broken build.
+// Found while reviewing #2171, whose sandboxed preload gains a relative
+// `require` that Electron cannot resolve -- `window.scistudioDesktop` vanishes
+// and the backend answers anyway.
+//
+// These are source-level assertions for the same reason bootstrap.test.js's
+// are: main.js `require("electron")`, which only resolves inside a real
+// Electron process. They are aimed at the specific regressions that would be
+// silent in production rather than at coverage.
+//
+// Run with: npm --prefix desktop test   (uses the Node built-in test runner).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const main = fs.readFileSync(path.join(__dirname, "..", "main.js"), "utf8");
+
+// Comments describe the very thing these tests forbid, so scan code only.
+const code = main
+  .split("\n")
+  .filter((line) => !line.trim().startsWith("//") && !line.trim().startsWith("*"))
+  .join("\n");
+
+test("readiness alone no longer records the shell as known-good", () => {
+  // The regression this guards is a one-line move back: putting the call next
+  // to waitForHttpReady again restores exactly the blind spot.
+  const readyAt = code.indexOf("await waitForHttpReady");
+  // lastIndexOf: `function createWindow(url)` is declared earlier in the file.
+  const windowAt = code.lastIndexOf("createWindow(url);");
+  assert.ok(readyAt > 0 && windowAt > readyAt, "the boot path changed shape");
+  const between = code.slice(readyAt, windowAt);
+  assert.ok(
+    !between.includes("recordKnownGood("),
+    "recordKnownGood runs before the window exists, so it cannot know the shell worked",
+  );
+});
+
+test("the shell is vouched for only after the renderer paints", () => {
+  // loadBeforeShowing's callback fires on the rendered path only. The retry and
+  // error-page paths deliberately do not: a window showing an error page is not
+  // evidence this build is worth rolling back to.
+  assert.match(code, /loadBeforeShowing\(mainWindow, url, 0, \(\) => recordKnownGood\(/);
+  assert.match(code, /if \(rendered && typeof onRendered === "function"\)/);
+});
+
+test("a preload that throws is treated as a shell fault", () => {
+  // Electron emits this and nothing used to listen. The main window is
+  // sandboxed, so its preload gets a restricted `require`; a relative import
+  // added by a patch aborts it before contextBridge.exposeInMainWorld.
+  assert.match(code, /webContents\.on\("preload-error"/);
+  assert.match(code, /noteShellFault\(/);
+});
+
+test("recordKnownGood refuses while a fault stands", () => {
+  // Without this the listener would only log: the marker would still clear and
+  // the broken build would still become the rollback target.
+  const start = code.indexOf("function recordKnownGood(");
+  assert.ok(start > 0, "recordKnownGood is gone");
+  const body = code.slice(start, code.indexOf("\n}", start));
+  const guard = body.indexOf("if (shellFault)");
+  const clear = body.indexOf("clearBootAttempt");
+  const write = body.indexOf("knownGoodPath()");
+  assert.ok(guard > 0, "recordKnownGood does not check for a shell fault");
+  assert.ok(guard < clear, "the fault check must precede clearing the boot marker");
+  assert.ok(guard < write, "the fault check must precede writing the known-good build");
+});
+
+test("the fault is sticky, so a later success cannot erase an earlier failure", () => {
+  // A preload error followed by a successful paint is still a broken shell.
+  const start = code.indexOf("function noteShellFault(");
+  assert.ok(start > 0, "noteShellFault is gone");
+  const body = code.slice(start, code.indexOf("\n}", start));
+  assert.match(body, /if \(shellFault\)\s*\{\s*return;/);
+});
+
+test("the main window is still sandboxed", () => {
+  // The premise of the preload-error guard. If sandbox were turned off the
+  // relative-require failure would disappear along with the isolation that
+  // makes it worth having.
+  const at = code.indexOf("preload: path.join(__dirname");
+  assert.ok(at > 0, "the main window no longer sets a preload");
+  const prefs = code.slice(at - 400, at);
+  assert.match(prefs, /sandbox: true/);
+  assert.match(prefs, /contextIsolation: true/);
+});

--- a/docs/specs/desktop-shell-ota-hot-update.md
+++ b/docs/specs/desktop-shell-ota-hot-update.md
@@ -156,11 +156,35 @@ can still show a dialog. **A bad shell patch kills the main process**, so nothin
 is left running to recover, and the guard has to be on disk.
 
 `userData/shell-boot-attempt.json` names the shell build the loader is about to
-require. It is written **before** the `require` and cleared only when the runtime
-reaches HTTP readiness — from `recordKnownGood()`, which already marks the
-backend patch good at exactly that point. A marker still naming the candidate
-means the previous attempt at that build died before readiness, so it is refused
-in favour of the baseline.
+require. It is written **before** the `require` and cleared only from
+`recordKnownGood()`. A marker still naming the candidate means the previous
+attempt at that build never got that far, so it is refused in favour of the
+baseline.
+
+**What counts as "that far" changed in #2179.** `recordKnownGood()` originally
+fired the moment the runtime answered HTTP readiness. But that probe validates
+the *Python backend*, and the call vouches for the *Electron shell* — two halves
+of one snapshot that fail independently. Everything the shell does happens after
+that point: the window is created, the preload runs, the renderer paints. A
+patch that broke any of it was still recorded as good, so the quarantine never
+engaged, the loader never fell back, and the next launch loaded it again.
+
+It now runs from `createWindow`, on the path where the renderer has actually
+painted, and refuses outright while a **shell fault** stands. One fault source
+exists so far: Electron's `preload-error`, which fires when a preload script
+throws. The main window is sandboxed, so its preload gets a restricted
+`require` — a patch that adds a relative import there aborts before
+`contextBridge.exposeInMainWorld`, taking `window.scistudioDesktop` and every
+bridge with it, while the backend answers exactly as usual. That is the shape of
+failure the readiness probe could never see, and it is not hypothetical: it is
+what #2171 would have shipped.
+
+The fault is sticky within a launch: a preload error followed by a successful
+paint is still a broken shell.
+
+The retry and error-page paths in `loadBeforeShowing` deliberately do **not**
+vouch. A window showing an error page is not evidence that this shell build is
+worth rolling back to.
 
 Only a patch is ever refused. The baseline is the fallback itself; refusing it
 would turn one bad patch into an unstartable app.
@@ -178,8 +202,8 @@ and it is cleared only when
   so a reinstall is a fresh start and the quarantine never becomes a permanent
   refusal of all future updates.
 
-The second door matters as much as the first: the baseline reaches readiness too
-and calls `recordKnownGood()`, so the host's `clearBootAttempt` is guarded by
+The second door matters as much as the first: the baseline paints too and calls
+`recordKnownGood()`, so the host's `clearBootAttempt` is guarded by
 `mayClearShellMarker` and does nothing unless the shell that came up *is* the
 patch the marker names.
 


### PR DESCRIPTION
## Problem

`recordKnownGood()` clears the loader's crash-loop marker and fixes the current
build as the rollback target. It fired the moment the backend answered:

```js
await waitForHttpReady(ready.url);
rememberRuntimePort(...);
recordKnownGood(effectiveBuild());   // the window does not exist yet
const url = launchUrl(ready.url);
createWindow(url);
```

The readiness probe validates the **Python backend**. The call vouches for the
**Electron shell**. Two halves of one OTA snapshot, delivered together, failing
independently.

Everything the shell does happens after that line — window creation, preload,
renderer paint, menu construction — and none of it was guarded. A shell patch
that broke any of it was still recorded as good, so:

* the crash-loop quarantine never engaged,
* the loader never fell back to the baseline shell,
* the broken build became the rollback target, and
* the next launch loaded it again.

## Not hypothetical

#2171 adds `desktop/menu.js` and has `preload.js` do `require("./menu")`. The
main window is `sandbox: true`, and a sandboxed preload's `require` cannot
resolve a relative path — it throws before `contextBridge.exposeInMainWorld`, so
`window.scistudioDesktop` disappears, taking the new menu actions *and* the
pre-existing Package Manager relaunch bridge with it.

The backend answers exactly as usual. Nothing in the rollback machinery would
have noticed. That defect belongs to #2171 and is being fixed there; this PR is
about the machinery that should have caught it.

## Change

**Listen for the signal that already existed.** Electron fires `preload-error`
on `webContents` when a preload throws, and nothing consumed it. It now records
a sticky shell fault — a preload error followed by a successful paint is still a
broken shell.

**Refuse to vouch while a fault stands.** The check sits at the top of
`recordKnownGood()`, before clearing the marker rather than after; otherwise the
listener would only log while the broken build still became the rollback target.

**Require evidence the shell worked.** The call moves out of the boot path into
`createWindow`, onto `loadBeforeShowing`'s rendered path. The retry and
error-page paths deliberately do not vouch: a window showing an error page is
not evidence a build is worth rolling back to.

The bound cuts both ways — a shell that is merely *slow* must still be recorded,
or a healthy build gets quarantined next launch for no reason. Hence keying on
`rendered`, which the existing blank-first-paint retry already computes, rather
than on a timeout.

## Tests

Source-level, for the same reason `bootstrap.test.js`'s are: `main.js`
`require("electron")`, which only resolves inside a real Electron process. They
target the regressions that would be silent in production:

* `recordKnownGood` is absent between `waitForHttpReady` and `createWindow(url)`
  — the one-line move that restores the blind spot.
* The vouch happens only on the `rendered` path.
* `preload-error` is listened for, and the fault check precedes **both** the
  marker clear and the known-good write.
* The fault is sticky.
* The main window is still sandboxed — the premise the preload guard rests on.

Verified by reintroducing both defects: 2 tests fail. Suite 112/112.

`bootstrap.test.js`'s "clears the boot marker only once the runtime is up" is
updated rather than deleted: its intent — the marker is cleared from
`recordKnownGood` and nowhere else — still holds, but *when* that path runs has
changed.

Closes #2179
