### PR TITLE
chore(#2183): land the reinstall notice 0.3.3 users are actually seeing

### DIFF
--- a/.workflow/records/2183-chore-2183-reinstall-notice-copy.json
+++ b/.workflow/records/2183-chore-2183-reinstall-notice-copy.json
@@ -1,7 +1,92 @@
 {
   "base_ref": null,
   "branch": "chore/2183-reinstall-notice-copy",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-26T00:17:50.473659Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d96e4fe5fffbbc482db7bd1e3cab7d0d49bd04dfab1a956d3de2f7a3991ed8fb",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T00:17:50.499205Z",
+      "command": "ruff format tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:42ba6cec5b346b9382d2291047b8d87fa03307608650221b811fb8f8f752fa48",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T00:18:01.490562Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a56ebc04798b5b2a56d855d4c0c229fcf2a90ae2abe8de2871eda82cdac79aec",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T00:18:01.514847Z",
+      "command": "ruff check tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:78c013c310f33b320bea97f0307d9b4b4de6643f60a57e42f4a82cdbacf69399",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T00:18:10.862321Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0731f37aee38e42789047afb09e8f934d6ee59305ebd971bf6708e04d68282d1",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -23,7 +108,297 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-26T00:18:10.923140Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:10.939090Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:10.954183Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:10.968828Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:10.984481Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {
+            "closed": [],
+            "issue_number": 2183
+          },
+          "expected": null,
+          "file": "",
+          "finding_class": "issue_link",
+          "git_evidence": null,
+          "id": "issue_link.missing-closing-keyword",
+          "line": null,
+          "message": "PR body must close every delivered gate issue",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "issue_link.missing-closing-keyword",
+          "severity": "error",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "issue_link",
+      "status": "fail"
+    },
+    {
+      "at": "2026-08-26T00:18:10.999275Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:11.015121Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:11.032368Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:11.048140Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:11.063521Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:11.079523Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.687943Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.703715Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.719723Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.735997Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.754854Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.771730Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.789609Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.806467Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.822550Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.838397Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:28.855403Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:37.993248Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.009106Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.024329Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.039134Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.053383Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.067866Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.083402Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.097855Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.113501Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.130152Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T00:18:38.146471Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -33,18 +408,87 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "4b52615da",
+    "changed_files": [
+      ".workflow/records/2183-chore-2183-reinstall-notice-copy.json",
+      "scripts/templates/reinstall-notice.html",
+      "tests/scripts/test_ota_publish.py"
+    ],
+    "diff_fingerprint": "sha256:ebbec915ee2be6882de6bcd242a845f3288a6aba927ea9006a584f6eeee8a90d",
+    "head": "HEAD",
+    "head_sha": "d16cfbb63",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Open a PR to land the reinstall notice copy that was actually shipped.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T00:18:11.079555Z",
+      "diff_fingerprint": "sha256:ebbec915ee2be6882de6bcd242a845f3288a6aba927ea9006a584f6eeee8a90d",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "guard.issue_link"
+      ]
+    },
+    {
+      "at": "2026-08-26T00:18:28.855438Z",
+      "diff_fingerprint": "sha256:ebbec915ee2be6882de6bcd242a845f3288a6aba927ea9006a584f6eeee8a90d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T00:18:38.146504Z",
+      "diff_fingerprint": "sha256:ebbec915ee2be6882de6bcd242a845f3288a6aba927ea9006a584f6eeee8a90d",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2183-chore-2183-reinstall-notice-copy",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
+    "checks": [
+      "commit_hygiene",
+      "format_check",
+      "full_audit",
+      "lint_format",
+      "python_tests"
+    ],
     "docs": [],
-    "guards": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
     "tests": []
   },
   "runtime": "claude",
@@ -64,7 +508,7 @@
     }
   ],
   "session_id": "d0ea9d7a-32ba-4923-be1b-7206fc4935a3",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "maintenance",
   "test_events": [
     {

--- a/.workflow/records/2183-chore-2183-reinstall-notice-copy.json
+++ b/.workflow/records/2183-chore-2183-reinstall-notice-copy.json
@@ -1,0 +1,79 @@
+{
+  "base_ref": null,
+  "branch": "chore/2183-reinstall-notice-copy",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "scripts/templates",
+      "tests/scripts"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-26T00:16:57.722204Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "The notice page's contract is unchanged -- same placeholders, same clipboard behaviour, same delivery as a mandatory patch. docs/specs/desktop-shell-ota-hot-update.md section 8.1 describes that contract, not the wording, and the template's own comment states the wording is expected to be edited per release.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2183,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Open a PR to land the reinstall notice copy that was actually shipped.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2183-chore-2183-reinstall-notice-copy",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-26T00:16:57.722166Z",
+      "pattern": "scripts/templates/reinstall-notice.html",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T00:16:57.722188Z",
+      "pattern": "tests/scripts/test_ota_publish.py",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "d0ea9d7a-32ba-4923-be1b-7206fc4935a3",
+  "strictness_tier": null,
+  "task_kind": "maintenance",
+  "test_events": [
+    {
+      "at": "2026-08-26T00:16:57.722213Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/scripts/test_ota_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/scripts/templates/reinstall-notice.html
+++ b/scripts/templates/reinstall-notice.html
@@ -41,9 +41,39 @@
         color: var(--fg);
         font: 16px/1.6 -apple-system, "Segoe UI", system-ui, sans-serif;
       }
-      .card { max-width: 34rem; text-align: center; }
+      .card { max-width: 42rem; text-align: center; }
       h1 { font-size: 1.5rem; margin: 0 0 0.75rem; }
       p { color: var(--muted); margin: 0 0 1.75rem; }
+      /* The release summary is a long list, so it reads left-aligned even
+         though the card as a whole is centred around the address field. */
+      section { text-align: left; margin: 0 0 1.25rem; }
+      h2 {
+        font-size: 0.78rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--faint);
+        margin: 0 0 0.4rem;
+      }
+      ul { margin: 0; padding-left: 1.1rem; color: var(--muted); }
+      li { margin: 0 0 0.3rem; }
+      b { color: var(--fg); font-weight: 600; }
+      kbd {
+        font: inherit;
+        font-size: 0.85em;
+        padding: 0.05rem 0.35rem;
+        border: 1px solid var(--line);
+        border-radius: 4px;
+        background: var(--field);
+      }
+      .lede {
+        margin: 2rem 0 1.25rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--line);
+      }
+      /* `why` now introduces the page, so it carries no separator. The rule
+         moved onto `lede`, which is where the action block ends and the
+         release summary begins. */
+      .why { margin: 0 0 1.5rem; font-size: 0.95rem; }
       .row { display: flex; gap: 0.5rem; justify-content: center; flex-wrap: wrap; }
       input {
         flex: 1 1 20rem;
@@ -66,23 +96,74 @@
         cursor: pointer;
       }
       button:hover { background: var(--accent-hover); }
+      /* Sits directly above the address field: the instruction and the thing it
+         refers to must not be separated by anything the eye has to cross. */
+      .how { margin: 0 0 0.75rem; color: var(--fg); font-size: 0.95rem; }
       .status { height: 1.5rem; margin-top: 0.75rem; font-size: 0.9rem; color: var(--ok); }
       .version { margin-top: 2rem; font-size: 0.8rem; color: var(--faint); }
     </style>
   </head>
   <body>
     <div class="card">
-      <h1>Please download the latest SciStudio</h1>
-      <p>
-        This release changes parts of the app that cannot be delivered as an
-        update, so it needs to be installed once. Updates after this one apply
-        automatically.
+      <h1>SciStudio 0.3.4 is here</h1>
+
+      <p class="why">
+        This release changes how the app starts, which is the one part an update
+        cannot replace, so it needs installing once.
       </p>
+
+      <p class="how">
+        Copy this address into a browser to download the latest SciStudio.
+      </p>
+
       <div class="row">
         <input id="url" value="__DOWNLOAD_URL__" readonly aria-label="Download address" />
         <button id="copy" type="button">Copy</button>
       </div>
       <div class="status" id="status" role="status"></div>
+
+      <p class="lede">A major update. Here is what is new since your last update.</p>
+
+      <section>
+        <h2>Learning</h2>
+        <ul>
+          <li><b>Learning Center</b> — six core tutorials that are real, runnable
+            projects: your first workflow, what a type is, multimodal analysis
+            with git branches, what AI can and cannot do, a tour of SciStudio,
+            and starting a project of your own</li>
+          <li><b>Mio</b>, the built-in assistant, now guides you through them in
+            dialogue</li>
+          <li>The <b>Reading</b> tab opens the shipped user guide and API
+            reference in the app, instead of sending you to a browser</li>
+          <li>Packages can ship their own tutorials</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Left sidebar</h2>
+        <ul>
+          <li>Rebuilt as a VS Code-style icon rail. Click the active icon or
+            press <kbd>Ctrl</kbd>+<kbd>B</kbd> to collapse it</li>
+          <li>New <b>Workflows</b> section — every workflow in the project, with
+            its description, one click to open</li>
+          <li>New <b>Previewers</b> section — every registered previewer grouped
+            by where it came from, and you can choose which one renders a type,
+            per project or everywhere</li>
+          <li><b>Data types</b> and <b>Blocks</b> reload when you switch to them</li>
+        </ul>
+      </section>
+
+      <section>
+        <h2>Fixes</h2>
+        <ul>
+          <li>The Learning Center no longer reopens itself every launch</li>
+          <li>A project registry written by a newer build no longer blocks
+            startup</li>
+          <li>Re-running a block that writes an array no longer fails on
+            Windows</li>
+        </ul>
+      </section>
+
       <div class="version">__VERSION_LINE__</div>
     </div>
     <script>

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -276,6 +276,42 @@ def test_reinstall_notice_page_can_be_copied_from(mod: ModuleType) -> None:
     assert "clipboard.writeText" in html
 
 
+def test_reinstall_notice_leads_with_the_address(mod: ModuleType) -> None:
+    """The address comes before the release summary, not after it (#2183).
+
+    This page exists to hand over one address. The summary was added during the
+    0.3.4 migration and initially sat above it, so the only action the user has
+    to take waited behind three sections of release notes. Ordering is a layout
+    choice with no runtime signal, which is exactly the kind that gets undone by
+    accident in a later copy edit.
+    """
+    html = mod.render_reinstall_notice("https://example.test/download", "x")
+    address_at = html.index('id="url"')
+    summary_at = html.index("<h2>")
+    assert address_at < summary_at, "the release summary was moved above the address"
+
+
+def test_reinstall_notice_says_what_to_do_with_the_address(mod: ModuleType) -> None:
+    # A bare field and a Copy button do not say where to paste it. The page is
+    # shown inside the app, so "open this in a browser" is not obvious.
+    html = mod.render_reinstall_notice("https://example.test/download", "x")
+    assert "browser" in html.lower()
+
+
+def test_reinstall_notice_does_not_promise_notarization(mod: ModuleType) -> None:
+    """A drafted section claimed macOS builds open without a right-click.
+
+    The 0.3.4 dmgs ship signed but not stapled, so that is false until the
+    staple workflow has run and the release assets have been replaced. A notice
+    page is the wrong place to make a claim about the build the user is being
+    sent to download, since the page outlives whatever was true when it was
+    written.
+    """
+    html = mod.render_reinstall_notice("https://example.test/download", "x").lower()
+    assert "notarized" not in html
+    assert "right-click" not in html
+
+
 def test_snapshot_replaces_the_spa_with_the_notice(mod: ModuleType, tmp_path: Path) -> None:
     src = tmp_path / "backend" / "src"
     static = src / "scistudio" / "api" / "static"


### PR DESCRIPTION
## Problem

`scripts/templates/reinstall-notice.html` in this repository is **not** the page
0.3.3 users are seeing.

The 0.3.4 migration notice (OTA build 27, published 2026-08-26) was rewritten in
the publishing worktree during the release and never committed. A future publish
from a clean checkout would ship the short original page, and the divergence is
invisible: the publish succeeds either way and nothing compares the two.

It also made the shipped wording unreviewable — the text users actually read
existed only inside a `.tar.gz` on a GitHub release.

## What the shipped page carries

**A release summary** — Learning / Left sidebar / Fixes. Owner-approved copy.

Two further sections were drafted and cut. One claimed *"Signed and notarized on
macOS — no right-click to open"*, which is **false** for the 0.3.4 dmgs as they
shipped: they are signed but not yet stapled, so the first launch does need a
right-click until the staple workflow has run and the assets have been replaced.

**An instruction above the address** — "Copy this address into a browser to
download the latest SciStudio." The page exists to hand over an address and,
shown inside the app, never said where to put it.

**The address moved above the summary.** It sat below three sections of release
notes, so the one action the user has to take waited behind everything they
might want to read. The separator moved with it, to sit between the action block
and the summary rather than under the heading.

Styling to match: wider card, left-aligned lists, `<kbd>` key caps.

## Tests

Three, because two of these are layout decisions with no runtime signal — the
kind that get undone by accident in a later copy edit — and the third is a claim
that was true of an intention rather than of an artifact.

* the address precedes the summary
* the page says what to do with the address
* the page promises neither notarization nor a right-click-free launch, since a
  notice page outlives whatever was true about the build when it was written

Verified by reverting the layout and reintroducing the claim: 2 tests fail.

## Scope

The template and its tests. No contract change — same placeholders, same
clipboard behaviour, same delivery as a mandatory patch. The template's own
comment invites exactly this: *"Edit the wording freely — this is a template,
not shipped product code."*

Closes #2183
