### PR TITLE
fix(engine): remove memory_critical hard cap, add 1s polling retry for refused blocks (#2187)

### DIFF
--- a/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
+++ b/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
@@ -69,10 +69,212 @@
       "tool_versions": {
         "ruff": "0.15.15"
       }
+    },
+    {
+      "at": "2026-08-26T03:15:13.562430Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:02c3ee7cfabcebc907296c16739ca70d0fb6e6e13e6e6cf72bfcd15657ced363",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:15:16.675131Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7ee81a070b68f6ce03736001755c7eeab309b2db9c8c412e9987a05d24c7942f",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:15:18.057156Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:21833607779c22e0f493570f276d375a8470025d102f68ef240a6181157cf2ba",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:15:18.085958Z",
+      "command": "ruff format src/scistudio/engine/resources.py src/scistudio/engine/scheduler/__init__.py src/scistudio/engine/scheduler/_dispatch.py tests/engine/test_resources.py tests/engine/test_scheduler.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8c05818cacc61d4b95e0dba257ef5562285b904e08f7a468b8b60920905e781b",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T03:15:31.046454Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 1,
+      "input_fingerprint": "sha256:c6df171ca47183a02b82070565d443051de03609b6e233a961962fb71458da98",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "fail",
+      "summary": "exit 1",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:15:31.644329Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:46bc279af4b4177fa7902938ecf2c9301b1e076aa3bccffdeab97049b5b37aed",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:15:31.670125Z",
+      "command": "ruff check src/scistudio/engine/resources.py src/scistudio/engine/scheduler/__init__.py src/scistudio/engine/scheduler/_dispatch.py tests/engine/test_resources.py tests/engine/test_scheduler.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:589b5fe49e4b82c5b197df391140507de9b73f7e5458edb84526d005b92746ba",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T03:16:17.574872Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/engine tests/engine/test_resources.py tests/engine/test_scheduler.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b0174f1470ece61c85611ee629f43f1904cdff35f1231060a8f5f131d050dc4f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:16:22.896165Z",
+      "command": "mypy src/scistudio/engine/resources.py src/scistudio/engine/scheduler/__init__.py src/scistudio/engine/scheduler/_dispatch.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6a38182a55a44dc66d84d6e121ff49d99b5bacac46794ac78a8a4e5880fb32cb",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:17:08.978038Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b78a07e75d55f69c3a78484af19f6950e80c78e46c9446100e413034f44b6819",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:17:12.368930Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f50f96a0e2c97267e05e321a87400e7848274780b8a0ea1bf1cff08c10e5c3f2",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:17:27.437168Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:c5e0e96c610f63238c83a299416668d58dc788dac8ef2326eac6a92ed5240098",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "83ccc9b58fc5989f27dd8181595dc127ca5d92c5",
+    "shas": [
+      "83ccc9b58fc5989f27dd8181595dc127ca5d92c5"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -178,6 +380,462 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:22.961060Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:22.976596Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/resources.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/resources.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:22.993259Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.009805Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.025720Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.042362Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.059126Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.076172Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.092580Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.108916Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:16:23.128966Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.503289Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.568418Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/resources.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/resources.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.585057Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.602983Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.619134Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.635661Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.652953Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.669156Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.686076Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.704011Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:27.722463Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.837444Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.853136Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/resources.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/resources.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.868508Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.885450Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.901653Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.962937Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.978897Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:58.995113Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:59.012177Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:59.027802Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:17:59.046145Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -192,27 +850,42 @@
   "observed_diff": {
     "base": "origin/main",
     "base_sha": "094431972",
-    "changed_files": [],
-    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "changed_files": [
+      ".workflow/records/2187-guided-2187-memory-dispatch-gate.json",
+      "docs/adr/ADR-022-addendum1.md",
+      "src/scistudio/engine/resources.py",
+      "src/scistudio/engine/scheduler/__init__.py",
+      "src/scistudio/engine/scheduler/_dispatch.py",
+      "tests/engine/test_resources.py",
+      "tests/engine/test_scheduler.py"
+    ],
+    "diff_fingerprint": "sha256:5074721c3ae3e0577309801a5286bb128b9f56bf7f86cf5c0abaf53f6fc7e425",
     "head": "HEAD",
-    "head_sha": "094431972",
+    "head_sha": "83ccc9b58",
     "surfaces": {
-      "docs": 0,
+      "docs": 1,
       "frontend": 0,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 0,
+      "implementation": 3,
       "packaging": 0,
       "protected_architecture": 0,
-      "protected_core": 0,
-      "sentrux": 0,
-      "test": 0,
+      "protected_core": 3,
+      "sentrux": 6,
+      "test": 2,
       "workflow_ci": 0
     }
   },
   "owner_directive": "Remove the memory_critical (0.95) hard wall from ResourceManager.can_dispatch; make the high watermark a single 0.95 soft pause; add 1s polling retry for resource-refused READY blocks; OOM surfaced via worker exit -> block ERROR; no UI state changes",
   "persona": "live_implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2187
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-26T03:14:00.555527Z",
@@ -220,6 +893,32 @@
       "mode": "local",
       "result": "pass",
       "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T03:16:23.128997Z",
+      "diff_fingerprint": "sha256:abf0c254cb3306ace7478a5d9a408132c98858af2c033ec3a72e573b43119077",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.full_audit"
+      ]
+    },
+    {
+      "at": "2026-08-26T03:17:27.722500Z",
+      "diff_fingerprint": "sha256:5074721c3ae3e0577309801a5286bb128b9f56bf7f86cf5c0abaf53f6fc7e425",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T03:17:59.046182Z",
+      "diff_fingerprint": "sha256:5074721c3ae3e0577309801a5286bb128b9f56bf7f86cf5c0abaf53f6fc7e425",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
       "unsatisfied": []
     }
   ],
@@ -233,14 +932,23 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
     "checks": [
+      "architecture_tests",
       "commit_hygiene",
+      "deferral_discipline",
       "format_check",
       "full_audit",
-      "lint_format"
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
     ],
-    "docs": [],
+    "docs": [
+      "docs_required_or_na"
+    ],
     "guards": [
       "architecture_doc_guard",
       "core_change_guard",
@@ -254,7 +962,9 @@
       "test_engineer_scope_guard",
       "weakened_ci_check"
     ],
-    "tests": []
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "agents:kimi-code",
   "schema_version": 2,
@@ -303,7 +1013,7 @@
     }
   ],
   "session_id": "e926d42b-6097-495d-ae6f-b7e7ea3cfc41",
-  "strictness_tier": 2,
+  "strictness_tier": 1,
   "task_kind": "guided",
   "test_events": [
     {

--- a/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
+++ b/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
@@ -269,9 +269,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "83ccc9b58fc5989f27dd8181595dc127ca5d92c5",
+    "sha": "2ce9f6489",
     "shas": [
-      "83ccc9b58fc5989f27dd8181595dc127ca5d92c5"
+      "2ce9f6489"
     ],
     "trailers": []
   },
@@ -836,6 +836,310 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.749113Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.764535Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/resources.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/resources.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.779230Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.795155Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.812702Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.829611Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.846658Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.863636Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.879929Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.895737Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:05.915039Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:29.880679Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:29.898374Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/resources.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/resources.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/engine/scheduler/_dispatch.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/engine/scheduler/_dispatch.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:29.914317Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:29.930773Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:29.946245Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.010830Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.027445Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.087177Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.102024Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.116642Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:19:30.182303Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -848,7 +1152,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "09443197258f55d8b6f2990a0196901d64b75081",
     "base_sha": "094431972",
     "changed_files": [
       ".workflow/records/2187-guided-2187-memory-dispatch-gate.json",
@@ -859,9 +1163,9 @@
       "tests/engine/test_resources.py",
       "tests/engine/test_scheduler.py"
     ],
-    "diff_fingerprint": "sha256:5074721c3ae3e0577309801a5286bb128b9f56bf7f86cf5c0abaf53f6fc7e425",
+    "diff_fingerprint": "sha256:aa4fa7e2c3f22b787daceff9469ebabc70ccade998f0b5e4d57954aca47cfdec",
     "head": "HEAD",
-    "head_sha": "83ccc9b58",
+    "head_sha": "2ce9f6489",
     "surfaces": {
       "docs": 1,
       "frontend": 0,
@@ -883,7 +1187,7 @@
     "closes": [
       2187
     ],
-    "number": null,
+    "number": 2189,
     "url": null
   },
   "reconcile_events": [
@@ -916,6 +1220,22 @@
     {
       "at": "2026-08-26T03:17:59.046182Z",
       "diff_fingerprint": "sha256:5074721c3ae3e0577309801a5286bb128b9f56bf7f86cf5c0abaf53f6fc7e425",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T03:19:05.915071Z",
+      "diff_fingerprint": "sha256:aa4fa7e2c3f22b787daceff9469ebabc70ccade998f0b5e4d57954aca47cfdec",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T03:19:30.182341Z",
+      "diff_fingerprint": "sha256:aa4fa7e2c3f22b787daceff9469ebabc70ccade998f0b5e4d57954aca47cfdec",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
+++ b/.workflow/records/2187-guided-2187-memory-dispatch-gate.json
@@ -1,0 +1,326 @@
+{
+  "base_ref": null,
+  "branch": "guided-2187-memory-dispatch-gate",
+  "check_events": [
+    {
+      "at": "2026-08-26T03:13:46.338115Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f758b128a156a5cae07d13248d2c2af1e66530353ec499d0b3c1f253cf095526",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:13:46.392641Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T03:14:00.003765Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T03:14:00.054234Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/engine/resources.py",
+      "src/scistudio/engine/scheduler/_dispatch.py",
+      "tests/engine/test_resources.py"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-26T03:13:11.085171Z",
+      "owner_directive": "Remove memory_critical hard wall; single 0.95 high-watermark soft pause with active_count==0 bypass; 1s polling retry for resource-refused READY blocks; OOM via worker exit -> ERROR; no UI change",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-08-26T03:13:11.419570Z",
+      "owner_directive": "Remove memory_critical hard wall; single 0.95 soft watermark; 1s polling retry; OOM via Layer 3 ERROR",
+      "reason": "ADR-022/ADR-027 are agent_editable=false; documented the decision as new addendum ADR-022-addendum1.md instead of editing them; runtime recorded as agents:kimi-code (persona guard maps agents* -> .agents root)"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-26T03:13:11.085299Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-022-addendum1.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T03:13:11.419739Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/adr/ADR-022-addendum1.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-26T03:14:00.144913Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.166343Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.228278Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.299602Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.317875Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.380559Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.396538Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.462545Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.477338Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.539529Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T03:14:00.555476Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2187,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "094431972",
+    "changed_files": [],
+    "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "head": "HEAD",
+    "head_sha": "094431972",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 0,
+      "test": 0,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Remove the memory_critical (0.95) hard wall from ResourceManager.can_dispatch; make the high watermark a single 0.95 soft pause; add 1s polling retry for resource-refused READY blocks; OOM surfaced via worker exit -> block ERROR; no UI state changes",
+  "persona": "live_implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T03:14:00.555527Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "local",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2187-guided-2187-memory-dispatch-gate",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "commit_hygiene",
+      "format_check",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "agents:kimi-code",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085191Z",
+      "pattern": "src/scistudio/engine/resources.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085198Z",
+      "pattern": "src/scistudio/engine/scheduler/_dispatch.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085200Z",
+      "pattern": "src/scistudio/engine/scheduler/__init__.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085202Z",
+      "pattern": "tests/engine/test_resources.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085204Z",
+      "pattern": "tests/engine/test_scheduler.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.085205Z",
+      "pattern": "docs/adr/ADR-022-addendum1.md",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T03:13:11.419596Z",
+      "pattern": "docs/adr/ADR-022-addendum1.md",
+      "reason": "ADR-022/ADR-027 are agent_editable=false; documented the decision as new addendum ADR-022-addendum1.md instead of editing them; runtime recorded as agents:kimi-code (persona guard maps agents* -> .agents root)"
+    }
+  ],
+  "session_id": "e926d42b-6097-495d-ae6f-b7e7ea3cfc41",
+  "strictness_tier": 2,
+  "task_kind": "guided",
+  "test_events": [
+    {
+      "at": "2026-08-26T03:13:11.085309Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_resources.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T03:13:11.085314Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/engine/test_scheduler.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/adr/ADR-022-addendum1.md
+++ b/docs/adr/ADR-022-addendum1.md
@@ -1,0 +1,90 @@
+---
+adr: 22
+addendum: 1
+title: "Remove The memory_critical Hard Cap — Soft Watermark Plus Polling Retry"
+status: Proposed
+date_created: 2026-08-26
+date_accepted: null
+date_superseded: null
+
+supersedes: []
+superseded_by: null
+related: [22, 27]
+closes_issues: [2187]
+tracking_issue: 2187
+
+is_code_implementation: true
+governs:
+  modules:
+    - scistudio.engine.resources
+    - scistudio.engine.scheduler
+  contracts:
+    - scistudio.engine.resources.ResourceManager
+  entry_points: []
+  files:
+    - docs/adr/ADR-022-addendum1.md
+    - src/scistudio/engine/resources.py
+    - src/scistudio/engine/scheduler/__init__.py
+    - src/scistudio/engine/scheduler/_dispatch.py
+    - tests/engine/test_resources.py
+    - tests/engine/test_scheduler.py
+  excludes: []
+
+tests:
+  - tests/engine/test_resources.py
+  - tests/engine/test_scheduler.py
+agent_editable: true
+assisted_by:
+  - "kimi-cli"
+
+phase: implementation
+tags: [adr-022, runtime, resources, memory, scheduling]
+owner: "@jiazhenz026"
+co_authors: []
+language_source: en
+translations: []
+---
+
+# ADR-022 Addendum 1: Remove The memory_critical Hard Cap — Soft Watermark Plus Polling Retry
+
+## 1. Decision Summary
+
+`ResourceManager` no longer has a hard memory cap. The `memory_critical`
+constructor parameter and the `can_dispatch()` hard refusal at 95% system
+memory are removed. Memory gating is now a single soft high-watermark pause
+(default raised from 0.90 to 0.95) that throttles new dispatch only while
+other blocks are running; the `active_count == 0` bypass from #495 is kept.
+
+When `can_dispatch` refuses a block, the scheduler schedules a deduplicated
+1-second polling retry (`_schedule_resource_retry` /
+`_on_resource_retry_timer` in `engine/scheduler/_dispatch.py`, bound onto
+`DAGScheduler`) that re-runs `_dispatch_newly_ready` until dispatch succeeds,
+the block leaves READY, or the scheduler is disposed (`dispose()` cancels the
+pending timer).
+
+### 1.1 Problems Addressed
+
+| Problem | Risk | Addendum response | Detailed section |
+|---|---|---|---|
+| Hard refusal at `memory_critical` could stall a workflow forever: the only retry fired on terminal block events, and with `active_count == 0` none ever fire | Users watch a block sit in READY indefinitely with no log, event, or UI signal — even after memory pressure passes | Remove the hard cap; add a 1s polling retry for refused READY blocks | Section 2 |
+| Modern OSes fill RAM with reclaimable cache/standby memory | The 95% hard wall triggers under routine conditions, not just real exhaustion | Treat memory gating as soft back-pressure only; OOM is surfaced by Layer 3 as a block ERROR | Section 3 |
+
+## 2. Rationale
+
+Issue #2187. Per the owner directive, OOM handling belongs to the existing
+Layer 3 defense (ADR-022 §4): the OS kills the worker subprocess, the runner
+observes the non-zero exit, and the block transitions to ERROR where the UI
+surfaces it. A visible error is strictly better than a silent permanent
+stall.
+
+## 3. Consequences
+
+- The `ResourceManager.__init__` signature loses `memory_critical`; the
+  constructor sketch in ADR-027 ("Signature-Level Contracts") is superseded
+  for that constructor: soft watermark default 0.95, no critical parameter.
+- ADR-022 §8 verification guidance referring to "critical thresholds" and
+  the §9 consequence about "below the critical threshold" are superseded by
+  this addendum; the watermark itself and the three-layer defense model are
+  unchanged.
+- Back-pressure under sustained memory pressure now relies on the soft
+  watermark plus the polling retry rather than a hard refusal.

--- a/src/scistudio/engine/resources.py
+++ b/src/scistudio/engine/resources.py
@@ -119,8 +119,12 @@ class ResourceManager:
         - GPU: discrete slot counting (declaration-based)
         - CPU: discrete core counting (declaration-based)
         - Memory: OS-level check via psutil.virtual_memory().percent
-        - memory_high_watermark=0.80: pause dispatch above 80%
-        - memory_critical=0.95: never dispatch above 95%
+        - memory_high_watermark=0.95: soft pause on new dispatch above 95%
+          while other blocks are running. #2187 removed the former
+          ``memory_critical`` hard cap: a hard refusal could stall a READY
+          block forever (no retry fires when nothing else is running) while
+          modern OSes routinely sit near-full on cache/standby memory. OOM
+          is now surfaced by Layer 3 as a block ERROR instead.
 
     Layer 2 (block-internal): _auto_flush, LazyList, parallel_map(max_workers)
         -- operates independently, not managed here.
@@ -140,8 +144,7 @@ class ResourceManager:
         self,
         gpu_slots: int | None = None,
         cpu_workers: int = 4,
-        memory_high_watermark: float = 0.90,
-        memory_critical: float = 0.95,
+        memory_high_watermark: float = 0.95,
         event_bus: Any | None = None,
     ) -> None:
         # ADR-027 D10: None triggers auto-detect; explicit ints (including 0)
@@ -154,7 +157,6 @@ class ResourceManager:
         self.gpu_slots = gpu_slots
         self.max_cpu_workers = cpu_workers
         self.memory_high_watermark = memory_high_watermark
-        self.memory_critical = memory_critical
         self._gpu_in_use: int = 0
         self._cpu_in_use: int = 0
         self._allocations: dict[str, ResourceRequest] = {}
@@ -179,15 +181,19 @@ class ResourceManager:
         Returns False if:
         - GPU is required but all GPU slots are in use
         - Requested CPU cores would exceed the pool
-        - System memory percent >= memory_critical (always blocked)
-        - System memory percent > memory_high_watermark (paused) — but only
-          when ``active_count > 0``
+        - System memory percent > memory_high_watermark (soft pause) — but
+          only when ``active_count > 0``
 
         Deadlock prevention (#495): when ``active_count == 0`` (nothing is
-        currently executing), the high watermark is bypassed.  Only the
-        critical threshold (0.95) acts as a hard cap.  Without this, a
-        system whose baseline memory exceeds the watermark would refuse to
-        dispatch any block, guaranteeing deadlock.
+        currently executing), the high watermark is bypassed so at least one
+        block can start; the scheduler's 1s polling retry (#2187) re-attempts
+        soft-paused blocks even when no resource-freeing event fires.
+
+        #2187: there is deliberately no hard memory cap here. A hard refusal
+        at high memory permanently stalled workflows (modern OSes fill RAM
+        with reclaimable cache) with no user-visible signal; OOM is instead
+        surfaced by Layer 3 — the OS kills the worker subprocess and the
+        block transitions to ERROR.
 
         ADR-027 D10: when ``request.requires_gpu`` and ``self.gpu_slots == 0``,
         a single WARNING is logged (per ResourceManager instance) explaining
@@ -213,13 +219,10 @@ class ResourceManager:
         # CPU check
         if self._cpu_in_use + request.effective_cpu > self.max_cpu_workers:
             return False
-        # Memory check via psutil (ADR-022)
+        # Memory check via psutil (ADR-022): soft back-pressure only (#2187).
         mem_percent = psutil.virtual_memory().percent / 100.0
-        if mem_percent >= self.memory_critical:
-            return False
         # Deadlock prevention (#495): when nothing is running, skip the high
-        # watermark so at least one block can start.  The critical threshold
-        # above still acts as a hard cap.
+        # watermark so at least one block can start.
         if active_count == 0:
             return True
         return not mem_percent > self.memory_high_watermark

--- a/src/scistudio/engine/scheduler/__init__.py
+++ b/src/scistudio/engine/scheduler/__init__.py
@@ -155,6 +155,12 @@ class DAGScheduler:
         # and popped by that task's ``finally`` clause on exit.
         self._active_tasks: dict[str, asyncio.Task[None]] = {}
 
+        # #2187: pending polling-retry timer for resource-refused READY
+        # blocks. At most one TimerHandle is ever pending; ``_dispatch``
+        # schedules it on resource refusal and ``_on_resource_retry_timer``
+        # clears it when it fires. Cancelled by ``dispose()``.
+        self._resource_retry_handle: asyncio.TimerHandle | None = None
+
         self._completed_event = asyncio.Event()
         self._paused = False
         self._reset_lock = asyncio.Lock()
@@ -189,6 +195,11 @@ class DAGScheduler:
         """
         if self._disposed:
             return
+        # #2187: cancel any pending resource-retry timer so a disposed
+        # scheduler never fires a polling pass into a later run's event bus.
+        if self._resource_retry_handle is not None:
+            self._resource_retry_handle.cancel()
+            self._resource_retry_handle = None
         self._event_bus.unsubscribe(BLOCK_DONE, self._on_block_done)
         self._event_bus.unsubscribe(BLOCK_ERROR, self._on_block_error)
         self._event_bus.unsubscribe(CANCEL_BLOCK_REQUEST, self._on_cancel_block)
@@ -507,6 +518,8 @@ class DAGScheduler:
     _run_and_finalize = _dispatch_mod._run_and_finalize
     _run_interactive = _dispatch_mod._run_interactive
     _dispatch_newly_ready = _dispatch_mod._dispatch_newly_ready
+    _schedule_resource_retry = _dispatch_mod._schedule_resource_retry
+    _on_resource_retry_timer = _dispatch_mod._on_resource_retry_timer
     _instantiate_block = _dispatch_mod._instantiate_block
     _gather_inputs = _dispatch_mod._gather_inputs
 

--- a/src/scistudio/engine/scheduler/__init__.py
+++ b/src/scistudio/engine/scheduler/__init__.py
@@ -196,7 +196,7 @@ class DAGScheduler:
         if self._disposed:
             return
         # #2187: cancel any pending resource-retry timer so a disposed
-        # scheduler never fires a polling pass into a later run's event bus.
+        # scheduler never fires a polling pass into another run's event bus.
         if self._resource_retry_handle is not None:
             self._resource_retry_handle.cancel()
             self._resource_retry_handle = None

--- a/src/scistudio/engine/scheduler/_dispatch.py
+++ b/src/scistudio/engine/scheduler/_dispatch.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("scistudio.engine.scheduler")
 
+# #2187: polling interval for re-attempting resource-refused READY blocks.
+_RESOURCE_RETRY_INTERVAL_S = 1.0
+
 
 async def _emit_block_ready(self: DAGScheduler, node_id: str) -> None:
     """Emit ``BLOCK_READY`` after a block's IDLE->READY transition.
@@ -78,7 +81,9 @@ async def _dispatch(self: DAGScheduler, node_id: str) -> None:
     If ``_paused`` is True or ``ResourceManager.can_dispatch`` returns
     False, the block stays in its current state (READY) and the
     method returns without creating a task — it will be retried on
-    the next successor event via ``_dispatch_newly_ready``.
+    the next successor event via ``_dispatch_newly_ready`` and, for
+    resource refusals, by the 1s polling retry (#2187) so a refusal
+    can never silently stall the run when no terminal events fire.
     """
     if self._paused:
         return
@@ -92,7 +97,8 @@ async def _dispatch(self: DAGScheduler, node_id: str) -> None:
     #   trigger.
     if not self._resource_manager.can_dispatch(ResourceRequest(), active_count=len(self._active_tasks)):
         # Stay READY; retried by _dispatch_newly_ready on the next
-        # resource-freeing event (BLOCK_DONE).
+        # resource-freeing event (BLOCK_DONE) or by the polling retry (#2187).
+        self._schedule_resource_retry()
         return
 
     # A task already exists for this block — guard against double
@@ -190,6 +196,51 @@ async def _dispatch(self: DAGScheduler, node_id: str) -> None:
             name=f"dispatch:{node_id}",
         )
     self._active_tasks[node_id] = task
+
+
+def _schedule_resource_retry(self: DAGScheduler) -> None:
+    """Schedule a 1s polling retry for resource-refused READY blocks (#2187).
+
+    Terminal events (``BLOCK_DONE`` etc.) are the usual retry trigger via
+    ``_dispatch_newly_ready``, but when nothing is running a resource refusal
+    produces no further events and the block would stall in READY forever —
+    even after the memory pressure that caused the refusal has passed. A
+    single deduplicated timer re-runs ``_dispatch_newly_ready`` after
+    ``_RESOURCE_RETRY_INTERVAL_S``; if dispatch is refused again, ``_dispatch``
+    schedules the next poll, so the retry chain continues until dispatch
+    succeeds, the block leaves READY, or the scheduler is disposed.
+    """
+    if self._disposed:
+        return
+    if self._resource_retry_handle is not None:
+        # One pending retry covers all refused blocks; do not stack timers.
+        return
+    loop = asyncio.get_running_loop()
+    self._resource_retry_handle = loop.call_later(
+        _RESOURCE_RETRY_INTERVAL_S,
+        self._on_resource_retry_timer,
+    )
+
+
+def _consume_resource_retry_task(task: asyncio.Task[None]) -> None:
+    """Done callback for a polling pass: surface unexpected failures."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Resource retry pass failed", exc_info=exc)
+
+
+def _on_resource_retry_timer(self: DAGScheduler) -> None:
+    """Timer callback: fire one polling pass over refused READY blocks."""
+    self._resource_retry_handle = None
+    if self._disposed:
+        return
+    retry = asyncio.create_task(
+        self._dispatch_newly_ready(),
+        name=f"resource-retry:{self._workflow.id}",
+    )
+    retry.add_done_callback(_consume_resource_retry_task)
 
 
 async def _run_and_finalize(
@@ -667,8 +718,11 @@ def _gather_inputs(self: DAGScheduler, node_id: str) -> dict[str, Any]:
 async def _dispatch_newly_ready(self: DAGScheduler) -> None:
     """Dispatch blocks that became ready or were previously throttled.
 
-    Called from ``_on_block_done`` after
-    a terminal event. Scans the topological order for:
+    Called from ``_on_block_done`` after a terminal event, and from the
+    1s polling retry (#2187) that ``_dispatch`` schedules whenever
+    ``can_dispatch`` refuses a block — the poll covers the case where no
+    terminal event will fire because nothing is currently running.
+    Scans the topological order for:
 
     * IDLE blocks whose predecessors are all DONE — transition to
       READY and dispatch.

--- a/tests/engine/test_resources.py
+++ b/tests/engine/test_resources.py
@@ -68,18 +68,19 @@ class TestResourceManagerInit:
         rm = ResourceManager(gpu_slots=0)
         assert rm.gpu_slots == 0
         assert rm.max_cpu_workers == 4
-        assert rm.memory_high_watermark == 0.90
-        assert rm.memory_critical == 0.95
+        assert rm.memory_high_watermark == 0.95
+        # #2187: the memory_critical hard cap was removed — OOM is surfaced
+        # as a block ERROR via Layer 3 instead of a silent permanent stall.
+        assert not hasattr(rm, "memory_critical")
         assert rm._gpu_in_use == 0
         assert rm._cpu_in_use == 0
         assert rm._allocations == {}
 
     def test_custom_parameters(self):
-        rm = ResourceManager(gpu_slots=2, cpu_workers=8, memory_high_watermark=0.70, memory_critical=0.90)
+        rm = ResourceManager(gpu_slots=2, cpu_workers=8, memory_high_watermark=0.70)
         assert rm.gpu_slots == 2
         assert rm.max_cpu_workers == 8
         assert rm.memory_high_watermark == 0.70
-        assert rm.memory_critical == 0.90
 
 
 # ---------------------------------------------------------------------------
@@ -158,16 +159,14 @@ class TestCanDispatchMemory:
         with patch("psutil.virtual_memory", return_value=_mock_vm(80.0)):
             assert rm.can_dispatch(ResourceRequest(), active_count=1)
 
-    def test_above_critical(self):
-        rm = ResourceManager(gpu_slots=0, memory_critical=0.95)
+    def test_no_hard_memory_cap(self):
+        """#2187: memory_critical was removed — even at 96% the watermark is a
+        soft pause only: blocked while other blocks run, bypassed when idle.
+        """
+        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.95)
         with patch("psutil.virtual_memory", return_value=_mock_vm(96.0)):
             assert not rm.can_dispatch(ResourceRequest(), active_count=1)
-
-    def test_at_critical_boundary(self):
-        """At exactly critical should block (>= check)."""
-        rm = ResourceManager(gpu_slots=0, memory_critical=0.95)
-        with patch("psutil.virtual_memory", return_value=_mock_vm(95.0)):
-            assert not rm.can_dispatch(ResourceRequest(), active_count=1)
+            assert rm.can_dispatch(ResourceRequest(), active_count=0)
 
 
 # ---------------------------------------------------------------------------
@@ -400,35 +399,33 @@ class TestMaxInternalWorkers:
 
 class TestCanDispatchDeadlockPrevention:
     """When active_count == 0, the high watermark must be bypassed so that
-    at least one block can start.  Only the critical threshold blocks.
+    at least one block can start.  #2187: there is no longer a critical
+    hard cap — the watermark is the only memory gate and it is soft.
     """
 
     def test_active_count_zero_bypasses_watermark(self):
-        """Memory above watermark but below critical: allow when nothing running."""
-        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80, memory_critical=0.95)
+        """Memory above watermark: allow when nothing running."""
+        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80)
         with patch("psutil.virtual_memory", return_value=_mock_vm(85.0)):
             assert rm.can_dispatch(ResourceRequest(), active_count=0)
 
-    def test_active_count_zero_blocked_by_critical(self):
-        """Memory above critical: block even when nothing running."""
-        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80, memory_critical=0.95)
-        with patch("psutil.virtual_memory", return_value=_mock_vm(96.0)):
-            assert not rm.can_dispatch(ResourceRequest(), active_count=0)
-
-    def test_active_count_zero_at_critical_boundary(self):
-        """Exactly at critical: block even when nothing running (>= check)."""
-        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80, memory_critical=0.95)
-        with patch("psutil.virtual_memory", return_value=_mock_vm(95.0)):
-            assert not rm.can_dispatch(ResourceRequest(), active_count=0)
+    def test_active_count_zero_bypasses_extreme_memory(self):
+        """#2187: even extreme memory pressure must not hard-block a system
+        with nothing running — modern OSes fill RAM with reclaimable cache,
+        and a hard refusal here stalls the workflow forever.
+        """
+        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80)
+        with patch("psutil.virtual_memory", return_value=_mock_vm(97.0)):
+            assert rm.can_dispatch(ResourceRequest(), active_count=0)
 
     def test_active_count_nonzero_watermark_enforced(self):
         """Memory above watermark with tasks running: still blocked."""
-        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80, memory_critical=0.95)
+        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80)
         with patch("psutil.virtual_memory", return_value=_mock_vm(85.0)):
             assert not rm.can_dispatch(ResourceRequest(), active_count=1)
 
     def test_default_active_count_is_zero(self):
         """Default active_count=0 bypasses watermark (backward compat)."""
-        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80, memory_critical=0.95)
+        rm = ResourceManager(gpu_slots=0, memory_high_watermark=0.80)
         with patch("psutil.virtual_memory", return_value=_mock_vm(85.0)):
             assert rm.can_dispatch(ResourceRequest())

--- a/tests/engine/test_scheduler.py
+++ b/tests/engine/test_scheduler.py
@@ -1197,3 +1197,83 @@ class TestSchedulerConfigPreCheck:
 
         assert scheduler._block_states["A"] == BlockState.DONE
         runner.run.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Resource-refusal polling retry (#2187)
+# ---------------------------------------------------------------------------
+
+
+class TestResourceRetryPolling:
+    """#2187: a block refused by ``can_dispatch`` stays READY and is retried
+    by a 1s polling timer, so a resource refusal can never stall a run
+    silently when no resource-freeing terminal events fire.
+    """
+
+    def test_refused_block_is_retried_until_dispatch_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """can_dispatch refuses twice, then allows: the polling retry must
+        re-attempt dispatch without any terminal event and the run completes.
+        """
+        from scistudio.engine.scheduler import _dispatch as _dispatch_mod
+
+        monkeypatch.setattr(_dispatch_mod, "_RESOURCE_RETRY_INTERVAL_S", 0.01)
+
+        wf = _wf(nodes=[("A", "proc")])
+        scheduler, _event_bus, _runner = _make_scheduler(wf)
+
+        calls = {"n": 0}
+
+        def _gate(_request: object, active_count: int = 0) -> bool:
+            calls["n"] += 1
+            return calls["n"] > 2
+
+        scheduler._resource_manager.can_dispatch.side_effect = _gate
+
+        asyncio.run(asyncio.wait_for(scheduler.execute(), timeout=5.0))
+
+        assert scheduler._block_states["A"] == BlockState.DONE
+        assert calls["n"] >= 3
+
+    def test_retry_timer_dedupes_pending_handles(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Multiple refused dispatches share a single pending timer."""
+        from scistudio.engine.scheduler import _dispatch as _dispatch_mod
+
+        monkeypatch.setattr(_dispatch_mod, "_RESOURCE_RETRY_INTERVAL_S", 60.0)
+
+        wf = _wf(nodes=[("A", "proc"), ("B", "proc")])
+        scheduler, _event_bus, _runner = _make_scheduler(wf)
+        scheduler._resource_manager.can_dispatch.return_value = False
+
+        async def run() -> asyncio.TimerHandle | None:
+            await scheduler._dispatch("A")
+            first = scheduler._resource_retry_handle
+            await scheduler._dispatch("B")
+            assert scheduler._resource_retry_handle is first
+            return first
+
+        handle = asyncio.run(run())
+        assert handle is not None
+        handle.cancel()
+
+    def test_dispose_cancels_pending_retry_timer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """dispose() cancels the pending retry so a torn-down scheduler
+        never fires a polling pass into a later run's event bus.
+        """
+        from scistudio.engine.scheduler import _dispatch as _dispatch_mod
+
+        monkeypatch.setattr(_dispatch_mod, "_RESOURCE_RETRY_INTERVAL_S", 60.0)
+
+        wf = _wf(nodes=[("A", "proc")])
+        scheduler, _event_bus, _runner = _make_scheduler(wf)
+        scheduler._resource_manager.can_dispatch.return_value = False
+
+        async def run() -> asyncio.TimerHandle | None:
+            await scheduler._dispatch("A")
+            handle = scheduler._resource_retry_handle
+            scheduler.dispose()
+            return handle
+
+        handle = asyncio.run(run())
+        assert handle is not None
+        assert handle.cancelled()
+        assert scheduler._resource_retry_handle is None


### PR DESCRIPTION
## Summary

Fix the silent workflow stall when OS memory pressure is high (#2187).

- `ResourceManager.can_dispatch` no longer has a hard memory cap: the
  `memory_critical` constructor parameter and its `>= 0.95` refusal are
  removed. Memory gating is now a single soft high-watermark pause, default
  raised 0.90 → 0.95, throttling new dispatch only while other blocks run
  (the #495 `active_count == 0` bypass is kept).
- The scheduler gains a deduplicated 1-second polling retry
  (`_schedule_resource_retry` / `_on_resource_retry_timer`): any
  resource-refused READY block is re-attempted even when no terminal events
  fire, which previously stalled the run forever. `dispose()` cancels the
  pending timer.
- OOM is surfaced via the existing Layer 3 path (OS kills the worker
  subprocess → block ERROR in the UI) instead of an invisible permanent
  READY stall.

Decision record: `docs/adr/ADR-022-addendum1.md`.

Closes #2187

## Test plan

- `tests/engine/test_resources.py`: watermark defaults/behavior updated;
  new `test_no_hard_memory_cap` and `test_active_count_zero_bypasses_extreme_memory`.
- `tests/engine/test_scheduler.py`: new `TestResourceRetryPolling` —
  refused block retried to DONE without terminal events, timer dedup,
  dispose cancels the pending timer.
- `gate_record check --mode pre-pr` tier-selected checks.

Gate-Record: .workflow/records/2187-guided-2187-memory-dispatch-gate.json
Task-Kind: guided
Issue: #2187
Assisted-by: kimi-cli
