### PR TITLE
feat(#2190): show elapsed-time pill on plot card while running

### DIFF
--- a/.workflow/records/2190-feat-2190-plot-run-elapsed.json
+++ b/.workflow/records/2190-feat-2190-plot-run-elapsed.json
@@ -168,7 +168,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "8f278ab567162321c0f1ef33f11127246658f29d",
+    "shas": [
+      "8f278ab567162321c0f1ef33f11127246658f29d"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -311,6 +317,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.528820Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.544001Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.559792Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.576231Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.591039Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.608459Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.673214Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.687876Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.702798Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.718270Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:06.734804Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -335,9 +429,9 @@
       "frontend/src/hooks/useElapsedMs.ts",
       "src/scistudio/_user_guide/how-scistudio-works.md"
     ],
-    "diff_fingerprint": "sha256:1118d31ba04d3f4a869f1985d8b735a7ed9fac258e26f65fe03cbec5bf10f4c2",
+    "diff_fingerprint": "sha256:aa057193b3d26bdafb13d1c082f50194584296dda6844dd63f28542bca71cfba",
     "head": "HEAD",
-    "head_sha": "cb5d04952",
+    "head_sha": "8f278ab56",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -354,11 +448,26 @@
   },
   "owner_directive": "Plot card running UX: show a small elapsed-time timer next to the plot card buttons while a run is in flight (like the block node timer from #1974); hide it when the run completes or fails.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2190
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-26T05:43:21.938777Z",
       "diff_fingerprint": "sha256:1118d31ba04d3f4a869f1985d8b735a7ed9fac258e26f65fe03cbec5bf10f4c2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T05:44:06.734835Z",
+      "diff_fingerprint": "sha256:aa057193b3d26bdafb13d1c082f50194584296dda6844dd63f28542bca71cfba",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2190-feat-2190-plot-run-elapsed.json
+++ b/.workflow/records/2190-feat-2190-plot-run-elapsed.json
@@ -169,9 +169,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "8f278ab567162321c0f1ef33f11127246658f29d",
+    "sha": "9b223cb58267d7901175fa570967cbbbd51112ac",
     "shas": [
-      "8f278ab567162321c0f1ef33f11127246658f29d"
+      "9b223cb58267d7901175fa570967cbbbd51112ac"
     ],
     "trailers": []
   },
@@ -405,6 +405,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.338283Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.354523Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.369699Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.384436Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.403627Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.418591Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.436291Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.490998Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.505985Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.520793Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:45.537688Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.885656Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.900919Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.915514Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.929904Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.944282Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.958732Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.973469Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:58.987764Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:59.004093Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:59.019966Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:44:59.037827Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -417,7 +593,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "89619c7857a393efe5dda09778b61ed106daced0",
     "base_sha": "89619c785",
     "changed_files": [
       ".workflow/records/2190-feat-2190-plot-run-elapsed.json",
@@ -429,9 +605,9 @@
       "frontend/src/hooks/useElapsedMs.ts",
       "src/scistudio/_user_guide/how-scistudio-works.md"
     ],
-    "diff_fingerprint": "sha256:aa057193b3d26bdafb13d1c082f50194584296dda6844dd63f28542bca71cfba",
+    "diff_fingerprint": "sha256:6d7e4a0d9e5861ffb00aa69f37032aafadfe315972d0dce97e775fbb08daf4a1",
     "head": "HEAD",
-    "head_sha": "8f278ab56",
+    "head_sha": "9b223cb58",
     "surfaces": {
       "docs": 0,
       "frontend": 5,
@@ -453,7 +629,7 @@
     "closes": [
       2190
     ],
-    "number": null,
+    "number": 2191,
     "url": null
   },
   "reconcile_events": [
@@ -468,6 +644,22 @@
     {
       "at": "2026-08-26T05:44:06.734835Z",
       "diff_fingerprint": "sha256:aa057193b3d26bdafb13d1c082f50194584296dda6844dd63f28542bca71cfba",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T05:44:45.537723Z",
+      "diff_fingerprint": "sha256:6d7e4a0d9e5861ffb00aa69f37032aafadfe315972d0dce97e775fbb08daf4a1",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T05:44:59.037862Z",
+      "diff_fingerprint": "sha256:6d7e4a0d9e5861ffb00aa69f37032aafadfe315972d0dce97e775fbb08daf4a1",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2190-feat-2190-plot-run-elapsed.json
+++ b/.workflow/records/2190-feat-2190-plot-run-elapsed.json
@@ -1,0 +1,428 @@
+{
+  "base_ref": null,
+  "branch": "feat/2190-plot-run-elapsed",
+  "check_events": [
+    {
+      "at": "2026-08-26T05:35:45.192511Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2747b16b5a4ccf7b70a037758edb531d5bb14f64f768e708af5f305c9e0856fe",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:35:48.120175Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:cda0ecc055f9365b17693c4071267d415832763bd9611151d7d8bdbe8ce5e046",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:35:49.479663Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:102f4fec721ebfc465e7a0ebf36ba896c75f73ca64a3d872407303e84c235e40",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:35:49.528416Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:58d0aa713e6dc15832d117174dc6ea571bb7570cf756bc6ec035cd97f781efef",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T05:37:59.643307Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fa4a5097ffc938f42aef694dc2cb78a233e1e33bf877f0cc6610488d842656d1",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:38:12.699462Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:56345981b1aa70f71808421fedaa1d8b6b57109bd39e2f0ae09b9dba016076f7",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:38:12.979357Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:38:13.018540Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8c1aaed298619dc001e06292fa5789fce1cdecd1891eb16aed2276211cbd057c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T05:43:21.009945Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:de82190e3af14d0378f79f6f881761e18bfc4d2a67a6bac402346fa75e2c7573",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T05:43:21.720814Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/hooks/useElapsedMs.ts",
+      "frontend/src/hooks/__tests__/useElapsedMs.test.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.tsx",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "CHANGELOG.md",
+      "src/scistudio/_user_guide/how-scistudio-works.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-26T05:35:01.681427Z",
+      "owner_directive": "Extract the #1974 elapsed-timer helpers (formatElapsed, useElapsedMs) from NodeStatusSurface into shared frontend/src/hooks/useElapsedMs.ts; PlotsTab tracks running plot id + client-side startedAt and renders a compact elapsed pill next to the Run button; pill unmounts on success/failure. Tests: hook unit tests + PlotsTab timer tests. Docs: user-guide plot-card row + CHANGELOG entry. SpecKit/spec/ADR: N/A \u2014 presentational UX addition, no contract/schema/runtime change (mirrors existing #1974 pattern).",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-26T05:35:01.681449Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T05:35:01.681456Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_user_guide/how-scistudio-works.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T05:35:01.681464Z",
+      "class": "spec",
+      "kind": "na",
+      "path": null,
+      "rationale": "No contract/schema/runtime change; presentational UX only",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T05:35:01.681469Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "No architectural or hard-to-reverse decision; reuses #1974 pattern",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [
+    {
+      "at": "2026-08-26T05:43:21.785514Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.800055Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.815119Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.829393Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.843335Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.857098Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.872871Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.888061Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.904236Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.920839Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T05:43:21.938740Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2190,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "89619c785",
+    "changed_files": [
+      ".workflow/records/2190-feat-2190-plot-run-elapsed.json",
+      "CHANGELOG.md",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "frontend/src/components/BottomPanel.parts/PlotsTab.tsx",
+      "frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx",
+      "frontend/src/hooks/__tests__/useElapsedMs.test.tsx",
+      "frontend/src/hooks/useElapsedMs.ts",
+      "src/scistudio/_user_guide/how-scistudio-works.md"
+    ],
+    "diff_fingerprint": "sha256:1118d31ba04d3f4a869f1985d8b735a7ed9fac258e26f65fe03cbec5bf10f4c2",
+    "head": "HEAD",
+    "head_sha": "cb5d04952",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 5,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 6,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 6,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Plot card running UX: show a small elapsed-time timer next to the plot card buttons while a run is in flight (like the block node timer from #1974); hide it when the run completes or fails.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T05:43:21.938777Z",
+      "diff_fingerprint": "sha256:1118d31ba04d3f4a869f1985d8b735a7ed9fac258e26f65fe03cbec5bf10f4c2",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2190-feat-2190-plot-run-elapsed",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
+  },
+  "runtime": "agents:kimi-code",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "0843eabe-69ad-45a4-9e49-e88743e4630b",
+  "strictness_tier": 1,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-26T05:35:01.681472Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/hooks/__tests__/useElapsedMs.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T05:35:01.681476Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2190] **Plot cards show how long a run has been going.** While a plot run
+  is in flight, the card shows a small elapsed-time pill next to the Run
+  button — the same `7s` / `2:05` / `1:04:09` counter a running canvas block
+  already had — and it disappears the moment the run finishes or fails,
+  leaving no final duration on the card. The timer's formatting and ticking
+  now live in one shared helper, so both surfaces always read identically.
+
 - [#2090] **The left sidebar is a VS Code-style icon rail, and it gained two
   sections.** The Blocks / Data types / Project text tabs are replaced by a 48px
   vertical rail of icons that sits outside the resizable area, so it stays put

--- a/frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx
+++ b/frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor, screen, fireEvent, cleanup } from "@testing-library/react";
+import { render, waitFor, screen, fireEvent, cleanup, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { PlotListItem, PlotRunResponse } from "../../types/api";
@@ -297,5 +297,73 @@ describe("PlotsTab", () => {
 
     await waitFor(() => expect(runPlotJob).toHaveBeenCalled());
     expect(reportTutorialUiEvent).not.toHaveBeenCalled();
+  });
+});
+
+// #2190 — transient elapsed-time pill next to the Run button, mirroring the
+// block node timer (#1974): visible only while the run is in flight, no final
+// duration left on the card. Format/tick rules live in the shared hook tests
+// (`hooks/__tests__/useElapsedMs.test.tsx`); these tests pin the card wiring.
+describe("PlotsTab — running elapsed timer (#2190)", () => {
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+    return { promise, resolve, reject };
+  }
+
+  it("shows the elapsed pill next to the Run button while the run is in flight", async () => {
+    const run = deferred<PlotRunResponse>();
+    listPlots.mockResolvedValue({ plots: [makePlot()], count: 1, warnings: [] });
+    runPlotJob.mockReturnValue(run.promise);
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run plot My Plot" }));
+
+    const pill = await screen.findByTestId("plot-run-elapsed");
+    expect(pill.textContent).toMatch(/^\d+s$/);
+    expect(pill).toHaveAccessibleName(/^Running for /);
+    expect(screen.getByRole("button", { name: "Run plot My Plot" })).toHaveTextContent("Running");
+
+    run.resolve(plotRunResponse());
+    await waitFor(() => expect(screen.queryByTestId("plot-run-elapsed")).toBeNull());
+    expect(screen.getByRole("button", { name: "Run plot My Plot" })).toHaveTextContent("Run");
+  });
+
+  it("shows the pill only on the card whose run is in flight", async () => {
+    const run = deferred<PlotRunResponse>();
+    listPlots.mockResolvedValue({
+      plots: [makePlot(), makePlot({ plot_id: "p2", title: "Other Plot" })],
+      count: 2,
+      warnings: [],
+    });
+    runPlotJob.mockReturnValue(run.promise);
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run plot My Plot" }));
+
+    await screen.findByTestId("plot-run-elapsed");
+    expect(screen.getAllByTestId("plot-run-elapsed")).toHaveLength(1);
+    expect(within(screen.getByTestId("plot-card-p2")).queryByTestId("plot-run-elapsed")).toBeNull();
+
+    run.resolve(plotRunResponse());
+    await waitFor(() => expect(screen.queryByTestId("plot-run-elapsed")).toBeNull());
+  });
+
+  it("drops the pill when the run fails, leaving no final duration", async () => {
+    const run = deferred<PlotRunResponse>();
+    listPlots.mockResolvedValue({ plots: [makePlot()], count: 1, warnings: [] });
+    runPlotJob.mockReturnValue(run.promise);
+    render(<PlotsTab />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Run plot My Plot" }));
+    await screen.findByTestId("plot-run-elapsed");
+
+    run.reject(new Error("boom"));
+    expect(await screen.findByText("boom")).toBeInTheDocument();
+    expect(screen.queryByTestId("plot-run-elapsed")).toBeNull();
   });
 });

--- a/frontend/src/components/BottomPanel.parts/PlotsTab.tsx
+++ b/frontend/src/components/BottomPanel.parts/PlotsTab.tsx
@@ -3,9 +3,34 @@ import { useEffect, useState } from "react";
 
 import { api } from "../../lib/api";
 import { plotTargetFromRunResponse } from "../../lib/api/data";
+import { formatElapsed, useElapsedMs } from "../../hooks/useElapsedMs";
 import { useAppStore } from "../../store";
 import type { PlotListItem } from "../../types/api";
 import { PlotTargetPicker } from "./PlotTargetPicker";
+
+/**
+ * #2190 — compact elapsed counter rendered next to the Run button while this
+ * card's plot run is in flight, mirroring the block node timer (#1974): same
+ * `formatElapsed`/`useElapsedMs` contract, same transient lifetime — it
+ * unmounts the moment the run settles (success or failure), leaving no final
+ * duration or history on the card. A plot run is a direct API call, not an
+ * engine block run, so the anchor is the client-side `Date.now()` captured
+ * when the run starts.
+ */
+function PlotRunElapsed({ startedAt }: { startedAt: number }) {
+  const elapsedMs = useElapsedMs(startedAt);
+  const label = formatElapsed(elapsedMs);
+  return (
+    <span
+      aria-label={`Running for ${label}`}
+      className="rounded-full border border-stone-200 bg-stone-50 px-1.5 py-0.5 font-mono text-[10px] font-semibold tabular-nums text-blue-600"
+      data-testid="plot-run-elapsed"
+      title={`Running for ${label}`}
+    >
+      {label}
+    </span>
+  );
+}
 
 /**
  * #1713 — dedicated Plots panel.
@@ -25,6 +50,10 @@ import { PlotTargetPicker } from "./PlotTargetPicker";
  * the canvas stays visible above it and hovering a target highlights/centers
  * the matching block on the canvas. Cards bound to the selected/highlighted
  * node are ringed, completing the canvas ↔ card mapping.
+ *
+ * #2190 — while a card's run is in flight, a small elapsed-time pill sits next
+ * to its Run button (same contract as the block node timer, #1974) and
+ * disappears when the run completes or fails.
  */
 export function PlotsTab() {
   const workflowId = useAppStore((s) => s.workflowId);
@@ -47,6 +76,9 @@ export function PlotsTab() {
   // Run, relink, and delete failures stay on the plot card that produced them.
   const [cardError, setCardError] = useState<{ plotId: string; message: string } | null>(null);
   const [runningId, setRunningId] = useState<string | null>(null);
+  // #2190 — client-side anchor for the elapsed pill; set with `runningId`,
+  // cleared with it, so the timer lives exactly as long as the run.
+  const [runStartedAt, setRunStartedAt] = useState<number | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   // Bumped after relink / create so the list re-fetches. Also re-runs whenever
   // the tab is (re)mounted — BottomPanel unmounts inactive tabs, so switching
@@ -75,6 +107,7 @@ export function PlotsTab() {
 
   async function handleRun(plot: PlotListItem) {
     setRunningId(plot.plot_id);
+    setRunStartedAt(Date.now());
     setCardError(null);
     try {
       const result = await api.runPlotJob({ plot_id: plot.plot_id });
@@ -109,6 +142,7 @@ export function PlotsTab() {
       });
     } finally {
       setRunningId(null);
+      setRunStartedAt(null);
     }
   }
 
@@ -300,6 +334,11 @@ export function PlotsTab() {
                   {plot.language}
                 </span>
                 <div className="flex items-center justify-end gap-1.5">
+                  {/* #2190 — elapsed pill sits immediately left of the Run
+                      button, only while this card's run is in flight. */}
+                  {runningId === plot.plot_id && runStartedAt !== null ? (
+                    <PlotRunElapsed startedAt={runStartedAt} />
+                  ) : null}
                   <button
                     aria-label={`Run plot ${name}`}
                     className="shrink-0 rounded-full bg-ink px-2.5 py-1 text-xs text-white disabled:opacity-50"

--- a/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
+++ b/frontend/src/components/nodes/BlockNode.parts/NodeStatusSurface.tsx
@@ -35,7 +35,10 @@ import {
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+
+// #1974/#2190 — the elapsed counter contract (format + 1 Hz tick) is shared
+// with the plot card via this hook; this file only places the pill.
+import { formatElapsed, useElapsedMs } from "../../../hooks/useElapsedMs";
 
 interface SurfaceStyle {
   /** Icon rendered inside the corner badge. */
@@ -53,8 +56,6 @@ interface SurfaceStyle {
 const STATUS_BADGE_BACKGROUND = "rgba(255, 255, 255, 0.86)";
 const STATUS_BADGE_BORDER = "rgba(15, 23, 42, 0.14)";
 const ERROR_STATUSES = new Set(["error", "fail", "failed", "failure"]);
-/** #1974 — the counter ticks once a second; sub-second precision is noise here. */
-const ELAPSED_TICK_MS = 1000;
 
 const RUNTIME_STYLES: Record<string, SurfaceStyle> = {
   idle: { Icon: Circle, iconName: "circle", color: "#8A94A6", label: "Idle" },
@@ -94,38 +95,6 @@ const WARNING_STYLE: SurfaceStyle = {
 };
 
 export type ProblemSeverity = "none" | "warning" | "error";
-
-/**
- * #1974 — render the elapsed run time compactly: `7s` under a minute, `2:05`
- * under an hour, `1:04:09` beyond it. Seconds are floored so the counter reads
- * `0s` the instant the block starts rather than skipping ahead.
- */
-function formatElapsed(elapsedMs: number): string {
-  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const seconds = totalSeconds % 60;
-  const paddedSeconds = String(seconds).padStart(2, "0");
-  if (hours > 0) return `${hours}:${String(minutes).padStart(2, "0")}:${paddedSeconds}`;
-  if (minutes > 0) return `${minutes}:${paddedSeconds}`;
-  return `${seconds}s`;
-}
-
-/**
- * #1974 — tick once a second while `startedAt` is set. Passing `null` (any
- * non-running state) tears the interval down, so a finished node holds no
- * timer, no duration, and no pending work.
- */
-function useElapsedMs(startedAt: number | null): number {
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (startedAt === null) return undefined;
-    setNow(Date.now());
-    const timer = setInterval(() => setNow(Date.now()), ELAPSED_TICK_MS);
-    return () => clearInterval(timer);
-  }, [startedAt]);
-  return startedAt === null ? 0 : Math.max(0, now - startedAt);
-}
 
 export interface NodeStatusSurfaceProps {
   /** Runtime state — defaults to "idle" when unset. */

--- a/frontend/src/hooks/__tests__/useElapsedMs.test.tsx
+++ b/frontend/src/hooks/__tests__/useElapsedMs.test.tsx
@@ -1,0 +1,72 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { formatElapsed, useElapsedMs } from "../useElapsedMs";
+
+// #1974/#2190 — the elapsed-timer contract is shared by the block node status
+// surface and the plot card pill, so the format + tick rules are pinned here
+// once rather than per consumer.
+describe("formatElapsed (#1974)", () => {
+  it("renders seconds under a minute, m:ss under an hour, h:mm:ss beyond", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(7_000)).toBe("7s");
+    expect(formatElapsed(59_999)).toBe("59s");
+    expect(formatElapsed(60_000)).toBe("1:00");
+    expect(formatElapsed(65_000)).toBe("1:05");
+    expect(formatElapsed(3_600_000)).toBe("1:00:00");
+    expect(formatElapsed(3_849_000)).toBe("1:04:09");
+  });
+
+  it("floors sub-second precision and clamps negative drift to 0s", () => {
+    expect(formatElapsed(999)).toBe("0s");
+    expect(formatElapsed(-5_000)).toBe("0s");
+  });
+});
+
+describe("useElapsedMs (#1974)", () => {
+  const START = Date.parse("2026-05-22T00:00:00Z");
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("ticks once a second while startedAt is set", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+    const { result } = renderHook(() => useElapsedMs(START));
+    expect(result.current).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(3_000);
+    });
+    expect(result.current).toBe(3_000);
+  });
+
+  it("returns 0 and holds no timer when startedAt is null", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+    const { result } = renderHook(() => useElapsedMs(null));
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current).toBe(0);
+  });
+
+  it("stops ticking when startedAt clears, leaving no final duration", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(START);
+    const { result, rerender } = renderHook(
+      ({ startedAt }: { startedAt: number | null }) => useElapsedMs(startedAt),
+      { initialProps: { startedAt: START as number | null } },
+    );
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current).toBe(2_000);
+    rerender({ startedAt: null });
+    expect(result.current).toBe(0);
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    expect(result.current).toBe(0);
+  });
+});

--- a/frontend/src/hooks/useElapsedMs.ts
+++ b/frontend/src/hooks/useElapsedMs.ts
@@ -1,0 +1,43 @@
+// #1974 — elapsed-run timer shared by every "running" surface.
+//
+// Extracted from `BlockNode.parts/NodeStatusSurface.tsx` in #2190 so the plot
+// card can show the same compact counter while a plot run is in flight. The
+// formatting rules and the 1 Hz tick are a single contract: block nodes and
+// plot cards must read identically.
+
+import { useEffect, useState } from "react";
+
+/** #1974 — the counter ticks once a second; sub-second precision is noise here. */
+const ELAPSED_TICK_MS = 1000;
+
+/**
+ * #1974 — render the elapsed run time compactly: `7s` under a minute, `2:05`
+ * under an hour, `1:04:09` beyond it. Seconds are floored so the counter reads
+ * `0s` the instant the run starts rather than skipping ahead.
+ */
+export function formatElapsed(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  const paddedSeconds = String(seconds).padStart(2, "0");
+  if (hours > 0) return `${hours}:${String(minutes).padStart(2, "0")}:${paddedSeconds}`;
+  if (minutes > 0) return `${minutes}:${paddedSeconds}`;
+  return `${seconds}s`;
+}
+
+/**
+ * #1974 — tick once a second while `startedAt` is set. Passing `null` (any
+ * non-running state) tears the interval down, so a finished run holds no
+ * timer, no duration, and no pending work.
+ */
+export function useElapsedMs(startedAt: number | null): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === null) return undefined;
+    setNow(Date.now());
+    const timer = setInterval(() => setNow(Date.now()), ELAPSED_TICK_MS);
+    return () => clearInterval(timer);
+  }, [startedAt]);
+  return startedAt === null ? 0 : Math.max(0, now - startedAt);
+}

--- a/src/scistudio/_user_guide/how-scistudio-works.md
+++ b/src/scistudio/_user_guide/how-scistudio-works.md
@@ -82,7 +82,7 @@ Plot cards turn workflow results into figures for exploration and communication.
 
 | Surface | Role |
 |---|---|
-| Plot card | Saves a visualization connected to one workflow output |
+| Plot card | Saves a visualization connected to one workflow output; shows an elapsed-time indicator next to Run while a run is in progress |
 | Authoring | Uses Python or R and supports several views of one result |
 | Preview and export | Displays figures in the preview panel and exports SVG, PNG, PDF, or JPEG |
 | Relinking | Connects a card to a new output after workflow changes |


### PR DESCRIPTION
## Summary

Plot cards gave no sense of progress while a run was in flight — only the Run
button label switching to "Running". This adds a small elapsed-time pill next
to the Run button for the card whose run is active, using the exact same
format and tick contract as the block node timer (#1974): `7s` under a minute,
`2:05` under an hour, `1:04:09` beyond. The pill unmounts the moment the run
succeeds or fails, leaving no final duration or history on the card.

The timer helpers (`formatElapsed`, `useElapsedMs`) are extracted from
`NodeStatusSurface` into a shared `frontend/src/hooks/useElapsedMs.ts` so both
surfaces read identically and cannot drift. A plot run is a direct API call,
not an engine block run, so the anchor is a client-side `Date.now()` captured
when the run starts.

Gate record: .workflow/records/2190-feat-2190-plot-run-elapsed.json

## Tests

- `frontend/src/hooks/__tests__/useElapsedMs.test.tsx` — format boundaries
  (`0s`/`59s`/`1:00`/`1:04:09`), sub-second flooring, negative clamping,
  1 Hz ticking, teardown when the anchor clears.
- `frontend/src/components/BottomPanel.parts/PlotsTab.test.tsx` — pill appears
  next to Run only on the running card, and disappears on success and on
  failure.
- Existing `statusSurface.test.tsx` (#1974) passes unchanged against the
  extracted hook.

Closes #2190
