### PR TITLE
fix(#2195): give every interactive panel a host-owned way out

### DIFF
--- a/.workflow/records/2195-fix-2195-panel-escape-hatch.json
+++ b/.workflow/records/2195-fix-2195-panel-escape-hatch.json
@@ -1,9 +1,116 @@
 {
   "base_ref": "origin/main",
   "branch": "fix/2195-panel-escape-hatch",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-26T20:58:07.375008Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f758b128a156a5cae07d13248d2c2af1e66530353ec499d0b3c1f253cf095526",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T20:58:07.519647Z",
+      "command": "ruff format --check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:bee0017f30f552d2df2de1173f9ac14b9aee5192ca5e5c1de574bb119512b275",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T20:58:20.596135Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d2016153ffe72f6d9588cf72b647d8f545261ca64eb63f312f104e3c66e7d074",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T20:58:20.679258Z",
+      "command": "ruff check .",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e31351abfc33f0b3c0f28bc9f2f3d59ae3bc5d4925dc1159a7f931aa932441ed",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T20:58:42.399187Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e5de214e9b250fb7ed6b56b7b267c248aa397ad85304d1270ddd32919946712a",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:01:10.037072Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:7be98e0908398fcc58976bcbeb274a50ade28103756fde842dc9d2e3e02d9402",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "d21692a477c9a14f90683a58b7f36e704bd4e7b6",
+    "shas": [
+      "d21692a477c9a14f90683a58b7f36e704bd4e7b6"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -23,7 +130,338 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-26T20:58:20.739630Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.755308Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.772751Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.788681Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.804694Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.821251Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.836657Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.851359Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.866456Z",
+      "findings": [],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.881935Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T20:58:20.897827Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.099409Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.114928Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.130930Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.147341Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.163241Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.179110Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.195019Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.271952Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.287523Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.303966Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:10.320996Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.433719Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.452653Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.472609Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.491200Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.507861Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.526013Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.542870Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.559192Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.575072Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.591615Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:01:23.610238Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.505631Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.523966Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.541090Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.557893Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.574206Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.589287Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.604331Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.619132Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.634918Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.650172Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:17.670369Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -33,25 +471,122 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "main",
+    "base_sha": "2543d2e90",
+    "changed_files": [
+      ".workflow/records/2195-fix-2195-panel-escape-hatch.json",
+      "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx",
+      "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx",
+      "frontend/src/App.parts/InteractiveModals.test.tsx",
+      "frontend/src/App.parts/InteractiveModals.tsx"
+    ],
+    "diff_fingerprint": "sha256:d167c4539ccceb62a05fb9f828268edb1db278630a0262ee17b6df8d98bcb5ac",
+    "head": "HEAD",
+    "head_sha": "d21692a47",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 4,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 4,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 4,
+      "test": 2,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "A user was locked inside an AI-written interactive block's panel that drew neither a continue nor a cancel control; the host must always offer a way out.",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2195
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T20:58:20.897877Z",
+      "diff_fingerprint": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:01:10.321028Z",
+      "diff_fingerprint": "sha256:b4e38870b109cc285babcea97273c4ef03485effbc9e3fa39b380582fa9ca079",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 2,
+      "unsatisfied": [
+        "scope.out-of-scope"
+      ]
+    },
+    {
+      "at": "2026-08-26T21:01:23.610277Z",
+      "diff_fingerprint": "sha256:b4e38870b109cc285babcea97273c4ef03485effbc9e3fa39b380582fa9ca079",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:02:17.670406Z",
+      "diff_fingerprint": "sha256:d167c4539ccceb62a05fb9f828268edb1db278630a0262ee17b6df8d98bcb5ac",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2195-fix-2195-panel-escape-hatch",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "commit_hygiene",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "lint_format"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code:claude-opus-5",
   "schema_version": 2,
-  "scope_events": [],
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-26T21:01:17.643954Z",
+      "pattern": "frontend/src/App.parts/InteractiveModals.test.tsx",
+      "reason": "Colocated test for InteractiveModals.tsx. The dispatch scope grants 'Tests for the above'; there was no existing InteractiveModals test file, so the manifest-resolution coverage for the no-module_url path lands in a new sibling."
+    }
+  ],
   "session_id": "d176b4b6-540f-4e37-8401-513d91a35f68",
-  "strictness_tier": null,
+  "strictness_tier": 2,
   "task_kind": "bugfix",
   "test_events": [
     {

--- a/.workflow/records/2195-fix-2195-panel-escape-hatch.json
+++ b/.workflow/records/2195-fix-2195-panel-escape-hatch.json
@@ -101,6 +101,38 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-27T21:37:41.003787Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aabcc09170ff97e9237d3381c1d3108e69d7effd809e9578a3e10d097a03289c",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-27T21:40:15.081317Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:96f2e507eff833ba8076bb24b09eacb2fcf691d36cd14ddf1ce8a35a3f0e7b72",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -636,6 +668,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.144558Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.159370Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.174420Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.189426Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.203484Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.218131Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.232041Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.245689Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.258847Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.271925Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:15.288308Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -648,29 +768,31 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
+    "base": "main",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2195-fix-2195-panel-escape-hatch.json",
       "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx",
       "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx",
+      "frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.test.ts",
+      "frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts",
       "frontend/src/App.parts/InteractiveModals.test.tsx",
       "frontend/src/App.parts/InteractiveModals.tsx"
     ],
-    "diff_fingerprint": "sha256:5d25abf9c84c54f1b8e8d493786b8ea2b8aa991c7a611d3f766f7f460803f1e7",
+    "diff_fingerprint": "sha256:163c3b3b62402436a3261a6c46e98ea4a3431f22a56f2769e11231a26921599e",
     "head": "HEAD",
-    "head_sha": "6541e032a",
+    "head_sha": "dbf9c5687",
     "surfaces": {
       "docs": 0,
-      "frontend": 4,
+      "frontend": 6,
       "governance": 0,
       "governed_docs": 0,
-      "implementation": 4,
+      "implementation": 6,
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 0,
-      "sentrux": 4,
-      "test": 2,
+      "sentrux": 6,
+      "test": 3,
       "workflow_ci": 0
     }
   },
@@ -730,6 +852,14 @@
     {
       "at": "2026-08-26T21:02:52.114931Z",
       "diff_fingerprint": "sha256:5d25abf9c84c54f1b8e8d493786b8ea2b8aa991c7a611d3f766f7f460803f1e7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-27T21:40:15.288340Z",
+      "diff_fingerprint": "sha256:163c3b3b62402436a3261a6c46e98ea4a3431f22a56f2769e11231a26921599e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2195-fix-2195-panel-escape-hatch.json
+++ b/.workflow/records/2195-fix-2195-panel-escape-hatch.json
@@ -137,9 +137,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "6541e032a66b13735cd572e7cc644db2851b2995",
+    "sha": "d3c1f1c93d7b69a5685c5a129f13ad1e70d67431",
     "shas": [
-      "6541e032a66b13735cd572e7cc644db2851b2995"
+      "d3c1f1c93d7b69a5685c5a129f13ad1e70d67431"
     ],
     "trailers": []
   },
@@ -756,6 +756,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.744695Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.759090Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.774089Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.789967Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.805468Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.820013Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.834265Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.850050Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.864012Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.877441Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-27T21:40:40.893955Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -768,7 +856,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2195-fix-2195-panel-escape-hatch.json",
@@ -779,9 +867,9 @@
       "frontend/src/App.parts/InteractiveModals.test.tsx",
       "frontend/src/App.parts/InteractiveModals.tsx"
     ],
-    "diff_fingerprint": "sha256:163c3b3b62402436a3261a6c46e98ea4a3431f22a56f2769e11231a26921599e",
+    "diff_fingerprint": "sha256:734fd0c4c7ad125cf0b606a25e74b771ad2560762df94c9975284f486bb2342e",
     "head": "HEAD",
-    "head_sha": "dbf9c5687",
+    "head_sha": "d3c1f1c93",
     "surfaces": {
       "docs": 0,
       "frontend": 6,
@@ -860,6 +948,14 @@
     {
       "at": "2026-08-27T21:40:15.288340Z",
       "diff_fingerprint": "sha256:163c3b3b62402436a3261a6c46e98ea4a3431f22a56f2769e11231a26921599e",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-27T21:40:40.893983Z",
+      "diff_fingerprint": "sha256:734fd0c4c7ad125cf0b606a25e74b771ad2560762df94c9975284f486bb2342e",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/.workflow/records/2195-fix-2195-panel-escape-hatch.json
+++ b/.workflow/records/2195-fix-2195-panel-escape-hatch.json
@@ -1,0 +1,74 @@
+{
+  "base_ref": "origin/main",
+  "branch": "fix/2195-panel-escape-hatch",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "frontend/src/App.parts/InteractiveModals.tsx",
+      "frontend/src/App.parts/InteractiveModals.parts/**"
+    ]
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-26T20:57:04.313541Z",
+      "class": "no-doc-describes-surface",
+      "kind": "na",
+      "path": null,
+      "rationale": "no ADR, spec, or guide documents the interactive modal's chrome. ADR-051 US3/FR-012 already promise that closing the window cancels the block; this restores the missing affordance for that promise rather than changing it. The panel host API version, PanelHostApi, and PanelModule contracts are unchanged, so src/scistudio/_agent_reference/block-contract.md stays accurate.",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2195,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "A user was locked inside an AI-written interactive block's panel that drew neither a continue nor a cancel control; the host must always offer a way out.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2195-fix-2195-panel-escape-hatch",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code:claude-opus-5",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "d176b4b6-540f-4e37-8401-513d91a35f68",
+  "strictness_tier": null,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-26T20:57:04.313564Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/InteractiveModals.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:57:04.313570Z",
+      "class": null,
+      "kind": "path",
+      "path": "frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2195-fix-2195-panel-escape-hatch.json
+++ b/.workflow/records/2195-fix-2195-panel-escape-hatch.json
@@ -105,9 +105,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "d21692a477c9a14f90683a58b7f36e704bd4e7b6",
+    "sha": "6541e032a66b13735cd572e7cc644db2851b2995",
     "shas": [
-      "d21692a477c9a14f90683a58b7f36e704bd4e7b6"
+      "6541e032a66b13735cd572e7cc644db2851b2995"
     ],
     "trailers": []
   },
@@ -460,6 +460,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.262971Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.279265Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.295486Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.312015Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.330068Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.347690Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.363050Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.379337Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.395550Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.413359Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:43.432295Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.895814Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.910463Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.926401Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.942730Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.959074Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.974617Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:51.990232Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:52.005070Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:52.082829Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:52.098108Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:02:52.114898Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -472,7 +648,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2195-fix-2195-panel-escape-hatch.json",
@@ -481,9 +657,9 @@
       "frontend/src/App.parts/InteractiveModals.test.tsx",
       "frontend/src/App.parts/InteractiveModals.tsx"
     ],
-    "diff_fingerprint": "sha256:d167c4539ccceb62a05fb9f828268edb1db278630a0262ee17b6df8d98bcb5ac",
+    "diff_fingerprint": "sha256:5d25abf9c84c54f1b8e8d493786b8ea2b8aa991c7a611d3f766f7f460803f1e7",
     "head": "HEAD",
-    "head_sha": "d21692a47",
+    "head_sha": "6541e032a",
     "surfaces": {
       "docs": 0,
       "frontend": 4,
@@ -505,8 +681,8 @@
     "closes": [
       2195
     ],
-    "number": null,
-    "url": null
+    "number": 2199,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2199"
   },
   "reconcile_events": [
     {
@@ -538,6 +714,22 @@
     {
       "at": "2026-08-26T21:02:17.670406Z",
       "diff_fingerprint": "sha256:d167c4539ccceb62a05fb9f828268edb1db278630a0262ee17b6df8d98bcb5ac",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:02:43.432329Z",
+      "diff_fingerprint": "sha256:5d25abf9c84c54f1b8e8d493786b8ea2b8aa991c7a611d3f766f7f460803f1e7",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 2,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:02:52.114931Z",
+      "diff_fingerprint": "sha256:5d25abf9c84c54f1b8e8d493786b8ea2b8aa991c7a611d3f766f7f460803f1e7",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 2,

--- a/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx
+++ b/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx
@@ -107,4 +107,188 @@ describe("<DynamicPanel>", () => {
     await waitFor(() => expect(mount).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(unmount).toHaveBeenCalledTimes(1));
   });
+
+  // #2195 — the panel that locks the user out: it mounts fine, so there is no
+  // error surface, and it wires neither Continue nor Cancel. The overlay covers
+  // the Toolbar's Stop button, so without host-owned chrome the app is gone.
+  describe("host-owned escape hatch (#2195)", () => {
+    /** A module that mounts successfully and offers the user no way out. */
+    function exitlessImporter() {
+      const mount = vi.fn((container: HTMLElement) => {
+        container.textContent = "NO WAY OUT";
+        return { unmount: vi.fn() };
+      });
+      return { mount, importer: vi.fn(async () => ({ default: { apiVersion: "1", mount } })) };
+    }
+
+    it("cancels an exit-less mounted panel on ESC", async () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+      const { mount, importer } = exitlessImporter();
+
+      render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          importer={importer}
+        />,
+      );
+
+      await waitFor(() => expect(mount).toHaveBeenCalled());
+      expect(screen.queryByTestId("dynamic-panel-error")).not.toBeInTheDocument();
+
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("cancels an exit-less mounted panel from the title-bar close control", async () => {
+      const onConfirm = vi.fn();
+      const onCancel = vi.fn();
+      const { mount, importer } = exitlessImporter();
+
+      render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={onConfirm}
+          onCancel={onCancel}
+          importer={importer}
+        />,
+      );
+
+      await waitFor(() => expect(mount).toHaveBeenCalled());
+      fireEvent.click(screen.getByTestId("dynamic-panel-close"));
+      expect(onCancel).toHaveBeenCalledTimes(1);
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it("leaves the panel's own content area alone, so a panel with its own Cancel keeps it", async () => {
+      const onCancel = vi.fn();
+      // The tutorial panel's shape: it draws its own Cancel in the content area.
+      const mount = vi.fn((container: HTMLElement, host: PanelHostApi) => {
+        const own = document.createElement("button");
+        own.textContent = "Cancel";
+        own.dataset.testid = "panel-own-cancel";
+        own.addEventListener("click", () => host.cancel());
+        container.appendChild(own);
+        return { unmount: vi.fn() };
+      });
+      const importer = vi.fn(async () => ({ default: { apiVersion: "1", mount } }));
+
+      render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={onCancel}
+          importer={importer}
+        />,
+      );
+
+      await waitFor(() => expect(mount).toHaveBeenCalled());
+      // Two distinct controls: one host-drawn in the title bar, one the panel's
+      // own inside the mount container. Neither is inside the other.
+      const mountPoint = screen.getByTestId("dynamic-panel-mount");
+      const own = screen.getByTestId("panel-own-cancel");
+      const hostClose = screen.getByTestId("dynamic-panel-close");
+      expect(mountPoint).toContainElement(own);
+      expect(mountPoint).not.toContainElement(hostClose);
+
+      fireEvent.click(own);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("names the block in the title bar, falling back to the block id", async () => {
+      const { importer } = exitlessImporter();
+      const { rerender } = render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          blockName="review_labels"
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+          importer={importer}
+        />,
+      );
+      expect(screen.getByTestId("dynamic-panel-titlebar")).toHaveTextContent("review_labels");
+
+      rerender(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          blockName="   "
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={vi.fn()}
+          importer={importer}
+        />,
+      );
+      expect(screen.getByTestId("dynamic-panel-titlebar")).toHaveTextContent("block-1");
+    });
+
+    it("still exits on ESC when the module never loaded at all", async () => {
+      const onCancel = vi.fn();
+      render(
+        <DynamicPanel
+          manifest={{ ...MANIFEST, module_url: "" }}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={onCancel}
+          importer={vi.fn(async () => ({}))}
+        />,
+      );
+
+      await screen.findByTestId("dynamic-panel-error");
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores keys that are not ESC", async () => {
+      const onCancel = vi.fn();
+      const { mount, importer } = exitlessImporter();
+      render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={onCancel}
+          importer={importer}
+        />,
+      );
+      await waitFor(() => expect(mount).toHaveBeenCalled());
+
+      fireEvent.keyDown(document, { key: "Enter" });
+      fireEvent.keyDown(document, { key: "a" });
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    it("unbinds ESC once the panel is gone", async () => {
+      const onCancel = vi.fn();
+      const { mount, importer } = exitlessImporter();
+      const { unmount } = render(
+        <DynamicPanel
+          manifest={MANIFEST}
+          blockId="block-1"
+          panelPayload={{}}
+          onConfirm={vi.fn()}
+          onCancel={onCancel}
+          importer={importer}
+        />,
+      );
+      await waitFor(() => expect(mount).toHaveBeenCalled());
+
+      unmount();
+      fireEvent.keyDown(document, { key: "Escape" });
+      expect(onCancel).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx
+++ b/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.test.tsx
@@ -9,7 +9,7 @@ afterEach(cleanup);
 
 const MANIFEST: PanelManifestDescriptor = {
   panel_id: "pkg.panel",
-  module_url: "/api/interactive/panels/pkg.panel/index.js",
+  module_url: "/api/blocks/panels/pkg.panel/index.js",
   export_name: "default",
   api_version: "1",
 };

--- a/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx
+++ b/frontend/src/App.parts/InteractiveModals.parts/DynamicPanel.tsx
@@ -15,9 +15,17 @@
  *      button wired to `onCancel`. The user is NEVER left on a paused block with
  *      no window and no exit (the P1 this change closes). It never renders a
  *      silent `null` on failure.
+ *   4. Draws a host-owned title bar above the panel's mount container carrying
+ *      the block's name and a close (X) control, and listens for ESC (#2195).
+ *      Both drive the SAME `onCancel`, so the escape hatch exists even when the
+ *      module mounts fine and wires no exit of its own — the overlay covers the
+ *      Toolbar's Stop button, so without this the app is unreachable. The
+ *      panel's own content area is untouched: a module that draws its own
+ *      Cancel keeps it, one control in the title bar and one in the content.
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "../../components/ui/button";
 import type { PanelManifestDescriptor } from "../../store/types";
@@ -41,6 +49,12 @@ export interface DynamicPanelProps {
   onConfirm: (responseData: Record<string, unknown>) => void;
   /** Cancel the interactive block (run-scoped). */
   onCancel: () => void;
+  /**
+   * #2195 — what the host-drawn title bar calls this window. The block's type
+   * name when the prompt carries one; falls back to {@link blockId} so the bar
+   * always names something the reader can match to a node on the canvas.
+   */
+  blockName?: string;
   /** Test seam: inject a fake dynamic-module importer. */
   importer?: ModuleImporter;
 }
@@ -62,6 +76,7 @@ export function DynamicPanel({
   panelPayload,
   onConfirm,
   onCancel,
+  blockName,
   importer,
 }: DynamicPanelProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -131,18 +146,72 @@ export function DynamicPanel({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key, host, importer]);
 
+  // #2195 — ESC is the host's second escape hatch. It is bound while ANY
+  // dynamic panel is open, whether the module mounted or the error surface is
+  // showing, because the overlay covers the Toolbar's Stop button and a module
+  // that wires no exit would otherwise leave the whole app unreachable.
+  //
+  // Bubble phase on `window`, deliberately: a capture listener would swallow
+  // ESC before the package module's own DOM ever saw it. A panel that handles
+  // ESC itself (and stops propagation) keeps winning; one that does not gets
+  // the host's cancel. `useAppKeyboardShortcuts` also listens on this target
+  // and only clears the canvas selection, which is harmless while a panel is
+  // open — note it calls `preventDefault()`, so `defaultPrevented` cannot be
+  // used here to tell "someone handled it" apart from "nobody did".
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") return;
+      onCancelRef.current();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  const handleClose = useCallback(() => onCancelRef.current(), []);
+
+  // The block's own name when the prompt carried one, else its id — the title
+  // bar always names the node the reader is being asked about.
+  const title = blockName?.trim() ? blockName.trim() : blockId;
+
   return (
     <div
       className="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
       data-testid="dynamic-panel"
       data-block-id={blockId}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${title} — interactive block`}
     >
       <div className="flex max-h-[85vh] w-[900px] flex-col overflow-hidden rounded-xl border border-ink/10 bg-white shadow-panel">
+        {/* #2195 — host-drawn title bar. This is chrome the host owns, never the
+            package module's DOM, so the exit exists no matter what the module
+            renders below it. */}
+        <div
+          className="flex shrink-0 items-center justify-between gap-3 border-b border-ink/10 bg-ink/[0.03] px-4 py-2"
+          data-testid="dynamic-panel-titlebar"
+        >
+          <div className="truncate text-sm font-medium text-ink/80" title={title}>
+            {title}
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="-mr-1 rounded p-1 text-ink/50 transition-colors hover:bg-ink/5 hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ink/30"
+            aria-label="Close panel and cancel this block"
+            title="Close and cancel (Esc)"
+            data-testid="dynamic-panel-close"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
         {/* Mount point for the package panel module. Always present in the DOM so
             the mount effect has a stable container; hidden when we show the
-            error surface instead. */}
+            error surface instead. Scrolls on its own so the title bar above it
+            stays reachable for a panel taller than the modal. */}
         <div
           ref={containerRef}
+          className="min-h-0 overflow-auto"
           data-testid="dynamic-panel-mount"
           style={{ display: failure ? "none" : "block" }}
         />

--- a/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.test.ts
+++ b/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.test.ts
@@ -9,7 +9,7 @@ import {
   mountDynamicPanel,
 } from "./panelModuleLoader";
 
-const GOOD_URL = "/api/interactive/panels/pkg.panel/index.js";
+const GOOD_URL = "/api/blocks/panels/pkg.panel/index.js";
 
 function makeHost(overrides: Partial<PanelHostApi> = {}): PanelHostApi {
   return {

--- a/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts
+++ b/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts
@@ -108,7 +108,7 @@ const defaultImporter: ModuleImporter = (moduleUrl) =>
 
 /**
  * Reject any module URL that is not same-origin. The backend serves validated
- * panel assets under `/api/interactive/panels/...`, so a legitimate
+ * panel assets under `/api/blocks/panels/...`, so a legitimate
  * `module_url` is a site-relative path. Absolute http(s)/protocol-relative/
  * data/blob URLs are rejected — no remote or inline code is ever imported.
  *
@@ -123,7 +123,7 @@ export function isSameOriginModuleUrl(moduleUrl: string): boolean {
   if (url.startsWith("//")) return false;
   if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return false;
   // Require a site-relative absolute path so it always resolves against the
-  // app origin (the backend always emits `/api/interactive/panels/...`).
+  // app origin (the backend always emits `/api/blocks/panels/...`).
   if (!url.startsWith("/")) return false;
   // Defensive: confirm it resolves to the current origin.
   try {

--- a/frontend/src/App.parts/InteractiveModals.test.tsx
+++ b/frontend/src/App.parts/InteractiveModals.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * #2195 — the host must always offer a way out of an interactive block.
+ *
+ * These cover the manifest-resolution fork in `<InteractiveModals>`: a core
+ * panel still resolves from `PANEL_REGISTRY`, a package panel still goes to
+ * `<DynamicPanel>`, and — the bug — a manifest that carries a `panel_id` but no
+ * `module_url` no longer resolves to a silent `null`. `PanelManifest.module_url`
+ * defaults to `""` and the registry only requires a non-empty `panel_id`, so
+ * that block registers, runs, and pauses; before this fix the run sat in PAUSED
+ * with no window at all and only a `console.warn` to show for it.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useAppStore } from "../store";
+import type { InteractivePrompt, PanelManifestDescriptor } from "../store/types";
+import { resetAppStore } from "../testUtils";
+import { InteractiveModals } from "./InteractiveModals";
+
+vi.mock("../hooks/useWebSocket", () => ({
+  sendWebSocketMessage: vi.fn(),
+}));
+
+import { sendWebSocketMessage } from "../hooks/useWebSocket";
+
+function seedPrompt(
+  manifest: PanelManifestDescriptor | null,
+  overrides: Partial<InteractivePrompt> = {},
+) {
+  const prompt: InteractivePrompt = {
+    blockId: "block-1",
+    blockType: "myproj.foo",
+    workflowId: "wf-1",
+    panelManifest: manifest,
+    panelPayload: {},
+    inputSignature: {},
+    data: {},
+    ...overrides,
+  };
+  useAppStore.setState({ interactivePrompt: prompt });
+  return prompt;
+}
+
+beforeEach(() => {
+  resetAppStore();
+  // `resetAppStore` does not own the execution slice's prompt; clear it here so
+  // a prompt seeded by one test cannot leak into the next.
+  useAppStore.setState({ interactivePrompt: null });
+  vi.mocked(sendWebSocketMessage).mockClear();
+});
+
+afterEach(cleanup);
+
+describe("<InteractiveModals> panel resolution", () => {
+  it("renders a visible error surface with a working Cancel for a manifest with no module_url", async () => {
+    // The exact shape the issue describes: a block author wrote
+    // `PanelManifest(panel_id="myproj.foo")` and forgot `module_url`.
+    seedPrompt({ panel_id: "myproj.foo", api_version: "1" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<InteractiveModals />);
+
+    // A window exists at all — this is what used to be `null`.
+    expect(screen.getByTestId("dynamic-panel")).toBeInTheDocument();
+    const error = await screen.findByTestId("dynamic-panel-error");
+    expect(error).toBeInTheDocument();
+    // And it names the block, so the reader knows what is being waited on.
+    expect(screen.getByTestId("dynamic-panel-titlebar")).toHaveTextContent("myproj.foo");
+
+    fireEvent.click(screen.getByTestId("dynamic-panel-cancel"));
+    expect(sendWebSocketMessage).toHaveBeenCalledWith({
+      type: "cancel_block",
+      block_id: "block-1",
+      workflow_id: "wf-1",
+    });
+    expect(useAppStore.getState().interactivePrompt).toBeNull();
+    warn.mockRestore();
+  });
+
+  it("cancels that misconfigured-manifest window on ESC too", async () => {
+    seedPrompt({ panel_id: "myproj.foo", api_version: "1" });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    render(<InteractiveModals />);
+    await screen.findByTestId("dynamic-panel-error");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(useAppStore.getState().interactivePrompt).toBeNull());
+    expect(sendWebSocketMessage).toHaveBeenCalledWith({
+      type: "cancel_block",
+      block_id: "block-1",
+      workflow_id: "wf-1",
+    });
+    warn.mockRestore();
+  });
+
+  it("still resolves a core panel from the registry, untouched by the host chrome", () => {
+    seedPrompt(
+      { panel_id: "core.interactive.data_router" },
+      {
+        blockType: "data_router",
+        panelPayload: { input_ports: ["in"], output_ports: ["out"], items_per_port: { in: [] } },
+      },
+    );
+
+    render(<InteractiveModals />);
+
+    // The core modal renders itself; no dynamic-panel host chrome is involved.
+    expect(screen.queryByTestId("dynamic-panel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("dynamic-panel-titlebar")).not.toBeInTheDocument();
+  });
+
+  it("routes a package manifest with a module_url to the dynamic panel host", () => {
+    seedPrompt({
+      panel_id: "myproj.foo",
+      module_url: "/api/interactive/panels/myproj.foo/index.js",
+      api_version: "1",
+    });
+
+    render(<InteractiveModals />);
+
+    expect(screen.getByTestId("dynamic-panel")).toBeInTheDocument();
+    expect(screen.getByTestId("dynamic-panel-titlebar")).toHaveTextContent("myproj.foo");
+  });
+
+  it("renders nothing when the prompt carries no panel manifest", () => {
+    seedPrompt(null);
+    const { container } = render(<InteractiveModals />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is no interactive prompt", () => {
+    const { container } = render(<InteractiveModals />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/App.parts/InteractiveModals.test.tsx
+++ b/frontend/src/App.parts/InteractiveModals.test.tsx
@@ -114,7 +114,7 @@ describe("<InteractiveModals> panel resolution", () => {
   it("routes a package manifest with a module_url to the dynamic panel host", () => {
     seedPrompt({
       panel_id: "myproj.foo",
-      module_url: "/api/interactive/panels/myproj.foo/index.js",
+      module_url: "/api/blocks/panels/myproj.foo/index.js",
       api_version: "1",
     });
 

--- a/frontend/src/App.parts/InteractiveModals.tsx
+++ b/frontend/src/App.parts/InteractiveModals.tsx
@@ -133,12 +133,25 @@ export function InteractiveModals() {
   // window via the ADR-048 same-origin dynamic-import path. `onConfirm`/`onCancel`
   // are passed exactly as the registry entries receive them, so the run-scoped
   // `interactive_complete` / `cancel_block` frames are sent unchanged.
-  const moduleUrl = manifest?.module_url;
-  if (manifest && typeof moduleUrl === "string" && moduleUrl !== "") {
+  //
+  // #2195 — a manifest that resolves to NEITHER a core panel nor a usable
+  // `module_url` still routes here. `PanelManifest.module_url` defaults to `""`
+  // and the registry only requires a non-empty `panel_id`, so a block that
+  // forgets `module_url` registers, runs, and pauses; the old code returned
+  // `null` and left the run sitting in PAUSED with no window and only a
+  // `console.warn`. `mountDynamicPanel` rejects an empty url as a typed
+  // `invalid_module_url` failure, so handing the manifest to <DynamicPanel>
+  // gives the misconfiguration the same visible error surface + Cancel every
+  // other load failure already gets.
+  if (manifest) {
+    if (!manifest.module_url) {
+      console.warn(`[InteractiveModals] no registered panel for manifest panel_id "${panelId}"`);
+    }
     return (
       <DynamicPanel
         manifest={manifest}
         blockId={interactivePrompt.blockId}
+        blockName={interactivePrompt.blockType}
         panelPayload={interactivePrompt.panelPayload}
         onConfirm={onConfirm}
         onCancel={onCancel}
@@ -146,10 +159,8 @@ export function InteractiveModals() {
     );
   }
 
-  // Neither a registered core panel nor a package `module_url`: nothing to
-  // render. Warn so a misconfigured manifest is visible in the console.
-  if (panelId) {
-    console.warn(`[InteractiveModals] no registered panel for manifest panel_id "${panelId}"`);
-  }
+  // No panel manifest at all: this prompt does not describe a window, so there
+  // is nothing for the host to draw and no overlay to trap the user behind —
+  // the Toolbar's Stop control stays reachable.
   return null;
 }


### PR DESCRIPTION
## What

A user was locked inside an AI-authored interactive block's panel: it drew
neither a Continue nor a Cancel control, and the app had to be killed. The host
chrome offered no exit of its own. This gives the host an escape hatch that
exists no matter what the package module renders, and closes the second stuck
path where a misconfigured manifest produced no window at all.

Frontend only. `PANEL_HOST_API_VERSION`, `PanelHostApi`, and `PanelModule` are
untouched, so existing panel modules keep working with no edits.

## Why

ADR-051 US3 / FR-012 promise that a scientist who closes the window cancels the
block. For a dynamic panel there was no window-closing affordance for that
promise to attach to, and `DynamicPanel`'s `fixed inset-0 z-[9999]` overlay
covers the Toolbar's Stop button (`frontend/src/App.tsx:490`) — so a panel that
never calls `host.cancel()` took the whole app with it.

## How

**1. Host-owned escape hatch.** `DynamicPanel` draws a thin title bar above the
package module's mount container carrying the block's name and a close (X)
control, and binds ESC while any dynamic panel is open. Both drive the same
`onCancel` the core panels already receive, so the run-scoped `cancel_block`
frame is unchanged.

The panel's content area is untouched. A module that draws its own Cancel (the
tutorial's `review_labels` panel) keeps it — one control in the title bar, one
in the content, which is the placement the owner chose so the two do not
collide.

ESC binds on `window` in the **bubble** phase, not capture: a capture listener
would swallow ESC before the package module's DOM ever saw it, so a module that
handles ESC itself and stops propagation still wins. `defaultPrevented` is
deliberately not consulted — `useAppKeyboardShortcuts` already calls
`preventDefault()` on Escape to clear the canvas selection, so the flag cannot
distinguish "someone handled it" from "nobody did".

The mount container gained `min-h-0 overflow-auto` so a panel taller than the
modal scrolls under the title bar instead of pushing it out of reach.

**2. No silent `null`.** `InteractiveModals` no longer returns `null` for a
manifest that carries a `panel_id` but resolves to neither a registered core
panel nor a `module_url`. That branch was reachable: `PanelManifest.module_url`
defaults to `""` and `_validate_interactive_capability` only requires a
non-empty `panel_id`, so a block that forgets `module_url` registers, scans,
runs, and pauses — and the run then sat in `PAUSED` with no window and only a
`console.warn`. The manifest now goes to `<DynamicPanel>`, where
`mountDynamicPanel` already rejects an empty url as a typed
`invalid_module_url` failure, so the misconfiguration gets the same visible
error surface + Cancel every other load failure gets.

A prompt with **no** panel manifest at all still renders nothing: it describes
no window, so there is no overlay to trap the user behind and the Toolbar's Stop
control stays reachable.

## Tests

New coverage in `DynamicPanel.test.tsx` and a new colocated
`InteractiveModals.test.tsx`:

- ESC cancels a mounted, exit-less panel; the title-bar X cancels it.
- ESC still exits when the module never loaded, is ignored for non-ESC keys, and
  unbinds once the panel is gone.
- A panel that draws its own Cancel keeps it — the test asserts the panel's
  control is inside the mount container and the host's is not.
- The title bar names the block, falling back to the block id.
- A `panel_id`-only manifest renders the error surface, and both its Cancel and
  ESC send the run-scoped `cancel_block` frame.
- Core panels (`core.interactive.data_router`) still resolve from the registry
  with no host chrome involved; a manifest with a `module_url` still routes to
  the dynamic host; a manifest-less prompt still renders nothing.

Full frontend suite: 189 files / 2170 tests passing. Gate `check --mode pre-pr`
ran `commit_hygiene`, `format_check`, `frontend` (`npm run check:ci` — lint,
format, typecheck, test, build), `full_audit`, and `lint_format`, all green.

## Docs

N/A, recorded in the gate ledger. No ADR, spec, or guide documents the
interactive modal's chrome. ADR-051 US3 / FR-012 already promise that closing
the window cancels the block; this restores the missing affordance for that
promise rather than changing it. The panel host API version, `PanelHostApi`, and
`PanelModule` are unchanged, so `src/scistudio/_agent_reference/block-contract.md`
stays accurate. No wrapper, hook, gate-record, CI, or AI-runtime behavior
changes, so the AI-docs impact check is N/A too.

Closes #2195

🤖 Generated with [Claude Code](https://claude.com/claude-code)
