### PR TITLE
feat(#2197): teach interactive panels and scaffold both halves

### DIFF
--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -782,6 +782,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.655048Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.670438Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.685678Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.700225Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.715059Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.729730Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.744785Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.760529Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.776180Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.790869Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:35.809609Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -808,9 +896,9 @@
       "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
       "tests/ai/test_panel_scaffold.py"
     ],
-    "diff_fingerprint": "sha256:1eae97c5a5d476f5a166ddd96e97f823a90b4bc3e49836bd46a744b7e1d99d03",
+    "diff_fingerprint": "sha256:2d466564e879f0c5e7129110e73e3e68c8ee33e5f3dbf3a4cead5783efaa3b0a",
     "head": "HEAD",
-    "head_sha": "76d2193b1",
+    "head_sha": "36dd5a428",
     "surfaces": {
       "docs": 0,
       "frontend": 1,
@@ -878,6 +966,14 @@
     {
       "at": "2026-08-26T21:06:27.806590Z",
       "diff_fingerprint": "sha256:1eae97c5a5d476f5a166ddd96e97f823a90b4bc3e49836bd46a744b7e1d99d03",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:06:35.809641Z",
+      "diff_fingerprint": "sha256:2d466564e879f0c5e7129110e73e3e68c8ee33e5f3dbf3a4cead5783efaa3b0a",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -265,13 +265,161 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:00.406327Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:8a4b7b2900860decc8b4d1686b4d1ea583ddcccff46c8db14ceb6c3ca3cc130a",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:03.727583Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d8593ad8fed9ba189f85f3acf647848ec059725f048106944e9516dc9567dd50",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:05.151949Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6e9fc0dcf62f652dfb414417481fc8c33f669c485934cc285579cae28b1c5afd",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:05.176465Z",
+      "command": "ruff format src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a4689d9193cf6d2880830098d9ac524c962402961bf5925a58273b60e4d96465",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:10:17.168167Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:12ffa65899156939f4fda55cee76834ce3a90655e88dfc81b33415d7764ec83f",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:17.431340Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e1ee2dfd1be11779b937e6c341475e46dae6290070d6e40c1bbd4f355d770cf8",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:17.454857Z",
+      "command": "ruff check src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b71f140bc47040de45bdf6e7a50da4ca98dd46dbf3e1331d0e3551017c57783a",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:10:25.546812Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/ai/agent/mcp tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f7bba3bc67981733f8f22e9219d315a07b7185da10f95d320a48ac982bfbd086",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:10:26.256759Z",
+      "command": "mypy src/scistudio/ai/agent/mcp/panel_scaffold.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4f4697f8ff622d4a959db2ed9f87077cc58f7fecce80c9ffef57427758a9b590",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
   "commit": {
-    "sha": "deed318f201a2ea04c2ca77d42f69855303f8798",
+    "sha": "cd40006684d35275785662088fa93a6bf78d642e",
     "shas": [
-      "deed318f201a2ea04c2ca77d42f69855303f8798"
+      "cd40006684d35275785662088fa93a6bf78d642e"
     ],
     "trailers": []
   },
@@ -1046,6 +1194,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.874665Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.890152Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.904701Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.919335Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.934232Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.949274Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.964297Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.979396Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:41.994545Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:42.009832Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:09:42.029102Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.320386Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.335228Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.351315Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.367760Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.384525Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.401930Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.418788Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.435449Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.450655Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.465490Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:26.486905Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1058,7 +1382,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
+    "base": "origin/main",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2197-docs-2197-panel-authoring-skill.json",
@@ -1072,9 +1396,9 @@
       "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
       "tests/ai/test_panel_scaffold.py"
     ],
-    "diff_fingerprint": "sha256:5630a7a70424d448c61f6957e6454cd97a18ecfcd56271fa15c364f7df6fc577",
+    "diff_fingerprint": "sha256:7cd3e7219b027431d2b46dd695519f60db97a04511d545123d98fc3c9bac8d51",
     "head": "HEAD",
-    "head_sha": "deed318f2",
+    "head_sha": "cd4000668",
     "surfaces": {
       "docs": 0,
       "frontend": 1,
@@ -1166,6 +1490,32 @@
     {
       "at": "2026-08-26T21:06:58.311105Z",
       "diff_fingerprint": "sha256:5630a7a70424d448c61f6957e6454cd97a18ecfcd56271fa15c364f7df6fc577",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:09:42.029127Z",
+      "diff_fingerprint": "sha256:7cd3e7219b027431d2b46dd695519f60db97a04511d545123d98fc3c9bac8d51",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.architecture_tests",
+        "checks.commit_hygiene",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.import_contracts",
+        "checks.lint_format",
+        "checks.python_tests",
+        "checks.type_check"
+      ]
+    },
+    {
+      "at": "2026-08-26T21:10:26.486938Z",
+      "diff_fingerprint": "sha256:7cd3e7219b027431d2b46dd695519f60db97a04511d545123d98fc3c9bac8d51",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -269,9 +269,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "383844750c91c26142e1f225a293a84988ad5d02",
+    "sha": "deed318f201a2ea04c2ca77d42f69855303f8798",
     "shas": [
-      "383844750c91c26142e1f225a293a84988ad5d02"
+      "deed318f201a2ea04c2ca77d42f69855303f8798"
     ],
     "trailers": []
   },
@@ -870,6 +870,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.413955Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.428320Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.441974Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.455729Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.470218Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.484691Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.499185Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.512962Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.527177Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.541385Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:50.559648Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.146506Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.161626Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.177424Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.194059Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.211051Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.226586Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.246140Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.261052Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.276117Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.290292Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:58.311068Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -882,7 +1058,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2197-docs-2197-panel-authoring-skill.json",
@@ -896,9 +1072,9 @@
       "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
       "tests/ai/test_panel_scaffold.py"
     ],
-    "diff_fingerprint": "sha256:2d466564e879f0c5e7129110e73e3e68c8ee33e5f3dbf3a4cead5783efaa3b0a",
+    "diff_fingerprint": "sha256:5630a7a70424d448c61f6957e6454cd97a18ecfcd56271fa15c364f7df6fc577",
     "head": "HEAD",
-    "head_sha": "36dd5a428",
+    "head_sha": "deed318f2",
     "surfaces": {
       "docs": 0,
       "frontend": 1,
@@ -920,7 +1096,7 @@
     "closes": [
       2197
     ],
-    "number": null,
+    "number": 2200,
     "url": null
   },
   "reconcile_events": [
@@ -974,6 +1150,22 @@
     {
       "at": "2026-08-26T21:06:35.809641Z",
       "diff_fingerprint": "sha256:2d466564e879f0c5e7129110e73e3e68c8ee33e5f3dbf3a4cead5783efaa3b0a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:06:50.559679Z",
+      "diff_fingerprint": "sha256:5630a7a70424d448c61f6957e6454cd97a18ecfcd56271fa15c364f7df6fc577",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:06:58.311105Z",
+      "diff_fingerprint": "sha256:5630a7a70424d448c61f6957e6454cd97a18ecfcd56271fa15c364f7df6fc577",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -165,6 +165,106 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:06:06.701254Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:27ebbdc8930f25f5b2f79e1c792a509bf188703c7ec8a88a9bd3a1a3909eebe9",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:06:08.102918Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0093ebe153f6f669613b0e0b316eda6b2cdc35080b123262380c5e7f091587e3",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:06:08.128984Z",
+      "command": "ruff format src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a17be96830d9fbb574bc6efcba4a0895a4a4c1a1a7a6b72908eb66756efcfea2",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:06:19.572587Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:6d7234cda8937d6aabeedda73240cf676181833422c37be4117cbbd74bea45fd",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:06:19.594396Z",
+      "command": "ruff check src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:5d4b724ce83e98804395b1f98a00933d6960861d5ef3466d00042f70226fe3eb",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:06:27.580118Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/ai/agent/mcp tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0a2ca32a03d18a1d730289bdb7773e4543d506ac1ddb27139889783e1e7689e6",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -506,6 +606,182 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.292104Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.305552Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.319888Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.334413Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.349508Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.363528Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.377651Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.394525Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.410550Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.430328Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:57.449218Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.643727Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.658569Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.673903Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.692413Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.708781Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.725564Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.741677Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.756482Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.772152Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.786997Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:06:27.806554Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -532,9 +808,9 @@
       "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
       "tests/ai/test_panel_scaffold.py"
     ],
-    "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+    "diff_fingerprint": "sha256:1eae97c5a5d476f5a166ddd96e97f823a90b4bc3e49836bd46a744b7e1d99d03",
     "head": "HEAD",
-    "head_sha": "383844750",
+    "head_sha": "76d2193b1",
     "surfaces": {
       "docs": 0,
       "frontend": 1,
@@ -579,6 +855,29 @@
     {
       "at": "2026-08-26T21:05:41.988696Z",
       "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:05:57.449243Z",
+      "diff_fingerprint": "sha256:1eae97c5a5d476f5a166ddd96e97f823a90b4bc3e49836bd46a744b7e1d99d03",
+      "mode": "pre-pr",
+      "result": "fail",
+      "tier": 1,
+      "unsatisfied": [
+        "checks.commit_hygiene",
+        "checks.deferral_discipline",
+        "checks.format_check",
+        "checks.full_audit",
+        "checks.lint_format",
+        "checks.python_tests"
+      ]
+    },
+    {
+      "at": "2026-08-26T21:06:27.806590Z",
+      "diff_fingerprint": "sha256:1eae97c5a5d476f5a166ddd96e97f823a90b4bc3e49836bd46a744b7e1d99d03",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -1,0 +1,114 @@
+{
+  "base_ref": null,
+  "branch": "docs/2197-panel-authoring-skill",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/_skills/**",
+      "src/scistudio/_agent_reference/block-contract.md",
+      "src/scistudio/cli/templates/**",
+      "src/scistudio/ai/agent/mcp/panel_scaffold.py",
+      "frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts",
+      "tests/**",
+      ".workflow/records/**"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-26T20:50:58.333506Z",
+      "owner_directive": "Deliver: (1) new skill src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md; (2) routing update in scistudio-write-block/SKILL.md and the base scistudio/SKILL.md index; (3) self-contained scaffold helper src/scistudio/ai/agent/mcp/panel_scaffold.py emitting blocks/<name>.py plus the panel module skeleton; (4) block-contract.md default-export and module_url corrections; (5) panelModuleLoader.ts header comment route fix; (6) tests for scaffold output shape.",
+      "reason": "plan"
+    },
+    {
+      "at": "2026-08-26T21:00:48.270081Z",
+      "owner_directive": "BLOCKER for the manager: provisioning the new scistudio-write-panel skill into projects requires src/scistudio/agent_provisioning/skills.py (_SKILL_NAMES), _orchestrate.py (_expected_skill_paths, 14 -> 16) and templates/claude_agents_md.md, all of which are agent A2's exclusive write set for this dispatch (#2196). Those edits plus the paired test-count updates in tests/agent_provisioning/test_skills.py and tests/packaging/test_wheel_skills.py must land together; this branch deliberately leaves all of them untouched.",
+      "reason": "Record the sequencing blocker found during implementation and the docs check the dispatch asked for."
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-26T20:50:58.333531Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_agent_reference/block-contract.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:50:58.333539Z",
+      "class": null,
+      "kind": "path",
+      "path": "src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:50:58.333547Z",
+      "class": "changelog",
+      "kind": "na",
+      "path": null,
+      "rationale": "agent-facing skill and reference text plus an internal scaffold helper; no user-visible release-note behavior change",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:50:58.333552Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "ADR-051 already defines the interactive panel contract; this work corrects reference docs to match it and adds no new contract",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:00:48.270103Z",
+      "class": "package-development",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/package-development/blocks.md does not document the interactive panel contract at all (no interactive/module_url/apiVersion text), so the default-export and module_url corrections have no counterpart there",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2197,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Manager dispatch A3 (#2197): dedicated interactive-panel authoring skill, a self-contained interactive scaffold helper, and the block-contract / loader-comment documentation corrections. tools_authoring.py and agent_provisioning/** are sequenced to other agents.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2197-docs-2197-panel-authoring-skill",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code:claude-opus-5",
+  "schema_version": 2,
+  "scope_events": [],
+  "session_id": "deb032ec-f24f-4feb-adbe-27b01e1e2cee",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-26T20:50:58.333556Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_panel_scaffold.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -417,9 +417,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "cd40006684d35275785662088fa93a6bf78d642e",
+    "sha": "49bb974351f4d1b861c36c3d9a20bd8727182656",
     "shas": [
-      "cd40006684d35275785662088fa93a6bf78d642e"
+      "49bb974351f4d1b861c36c3d9a20bd8727182656"
     ],
     "trailers": []
   },
@@ -1370,6 +1370,94 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.141451Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.156316Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.170728Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.186682Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.202121Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.221701Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.238357Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.254241Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.270461Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.285094Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:10:34.307208Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1382,7 +1470,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2197-docs-2197-panel-authoring-skill.json",
@@ -1396,9 +1484,9 @@
       "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
       "tests/ai/test_panel_scaffold.py"
     ],
-    "diff_fingerprint": "sha256:7cd3e7219b027431d2b46dd695519f60db97a04511d545123d98fc3c9bac8d51",
+    "diff_fingerprint": "sha256:44a775fa853833c5a74b5f7701855d1a61c9ffacdc5fcf61bf04961e3a2c97cc",
     "head": "HEAD",
-    "head_sha": "cd4000668",
+    "head_sha": "49bb97435",
     "surfaces": {
       "docs": 0,
       "frontend": 1,
@@ -1516,6 +1604,14 @@
     {
       "at": "2026-08-26T21:10:26.486938Z",
       "diff_fingerprint": "sha256:7cd3e7219b027431d2b46dd695519f60db97a04511d545123d98fc3c9bac8d51",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:10:34.307240Z",
+      "diff_fingerprint": "sha256:44a775fa853833c5a74b5f7701855d1a61c9ffacdc5fcf61bf04961e3a2c97cc",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2197-docs-2197-panel-authoring-skill.json
+++ b/.workflow/records/2197-docs-2197-panel-authoring-skill.json
@@ -1,9 +1,180 @@
 {
   "base_ref": null,
   "branch": "docs/2197-panel-authoring-skill",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-26T21:01:58.838813Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f6bfa4e61f6a38261d4c0aa4c7921f3f035719df6d19a80a9d1c76c5d0152df6",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:02:02.132039Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2639a528c707f25992852b069125f0003c80b18eaea8afe36d51af33700c679b",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:02:03.544016Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:04fd02e75123ab45f93e040142165177d34bf2fb3b3e3aeefc12fe57b40fb6c6",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:02:03.574050Z",
+      "command": "ruff format src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e45897080e38a6fc13b83a316e630df0c49ded13c775186a792bb7929c2eec70",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:04:31.703141Z",
+      "command": "(cd frontend && npm run check:ci)",
+      "covered_surface": "frontend",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:abd425ac5240e2a36af87f8a226dd4b1c1e0567b13a9f079cb1f1ec3b196b322",
+      "name": "frontend",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/frontend.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:04:42.782488Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f1da63f6522e2789a11783a8cb3d8435a85ab82c01f7f72678fcaaf47163415c",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:04:43.982609Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b7719b6b2b0ae2cdc107d75d98f3bf1cfb45ea99c8da108ae5688d41a1da961e",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:04:44.012987Z",
+      "command": "ruff check src/scistudio/ai/agent/mcp/panel_scaffold.py tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d3447cd066c837da5b95f7466f87f1cf41c47571f6ad6665942338dc76a5fd55",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:05:01.140211Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/ai/agent/mcp tests/ai/test_panel_scaffold.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a9b4606abece3bd9a857eee5c79290524e32a9c2d3e79b1025a72dcb167b1d3b",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:05:12.998417Z",
+      "command": "mypy src/scistudio/ai/agent/mcp/panel_scaffold.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0d6081ac6308a82c31d09c423eae8ef526474383619f9ea18b85e574b9ac3df5",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "383844750c91c26142e1f225a293a84988ad5d02",
+    "shas": [
+      "383844750c91c26142e1f225a293a84988ad5d02"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -71,7 +242,272 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-26T21:05:13.041026Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.056531Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.072099Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.087957Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.102584Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.118584Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.196572Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.212076Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.227369Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.242639Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:13.260788Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.222730Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.236989Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.251561Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.265818Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.280134Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.294499Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.310378Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.325766Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.340186Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.353800Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:35.370746Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.833395Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.847867Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.862131Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.877506Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.892785Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.907691Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.922606Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.938345Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.954011Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.969318Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:05:41.988660Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -81,25 +517,115 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "2543d2e90",
+    "changed_files": [
+      ".workflow/records/2197-docs-2197-panel-authoring-skill.json",
+      "frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts",
+      "src/scistudio/_agent_reference/block-contract.md",
+      "src/scistudio/_skills/scistudio/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md",
+      "src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md",
+      "src/scistudio/ai/agent/mcp/panel_scaffold.py",
+      "src/scistudio/cli/templates/interactive_block/block.py.tpl",
+      "src/scistudio/cli/templates/interactive_block/panel.mjs.tpl",
+      "tests/ai/test_panel_scaffold.py"
+    ],
+    "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+    "head": "HEAD",
+    "head_sha": "383844750",
+    "surfaces": {
+      "docs": 0,
+      "frontend": 1,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 8,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 9,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Manager dispatch A3 (#2197): dedicated interactive-panel authoring skill, a self-contained interactive scaffold helper, and the block-contract / loader-comment documentation corrections. tools_authoring.py and agent_provisioning/** are sequenced to other agents.",
   "persona": "implementer",
-  "pull_request": null,
-  "reconcile_events": [],
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2197
+    ],
+    "number": null,
+    "url": null
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T21:05:13.260823Z",
+      "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:05:35.370781Z",
+      "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:05:41.988696Z",
+      "diff_fingerprint": "sha256:62202cc5f2b1a4151e9458d9628142eab62849f4adc810f028dbd9a02d299330",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2197-docs-2197-panel-authoring-skill",
   "requested_admin_labels": [],
   "required_obligations": {
     "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "frontend",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code:claude-opus-5",
   "schema_version": 2,
   "scope_events": [],
   "session_id": "deb032ec-f24f-4feb-adbe-27b01e1e2cee",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts
+++ b/frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts
@@ -5,7 +5,10 @@
  * ({@link ../../components/DataPreview.parts/dynamicPreviewer.ts}) but for the
  * interactive-block panel host. A package-provided interactive block ships its
  * window as an ESM module served by the backend under a same-origin, backend-
- * relative `module_url` (e.g. `/api/interactive/panels/<panel_id>/<file>.js`).
+ * relative `module_url`. That route is `/api/blocks/panels/<panel_id>/<file>`
+ * (`serve_panel_asset` in `src/scistudio/api/routes/blocks.py`, router prefix
+ * `/api/blocks`) — a `module_url` of any other shape resolves to nothing and
+ * fails here as `import_failed`.
  *
  * {@link mountDynamicPanel} validates the manifest, dynamically `import()`s the
  * module from a *same-origin* URL only, reads the named export, checks it is a

--- a/src/scistudio/_agent_reference/block-contract.md
+++ b/src/scistudio/_agent_reference/block-contract.md
@@ -51,22 +51,45 @@ Two panel options:
   from pathlib import Path
   interactive_panel = PanelManifest(
       panel_id="myproj.pick_baseline",
-      module_url="/api/blocks/panels/myproj.pick_baseline/index.js",
-      asset_root=str(Path(__file__).parent / "pick_baseline"),  # dir holding index.js
+      module_url="/api/blocks/panels/myproj.pick_baseline/panel.mjs",
+      asset_root=str(Path(__file__).parent / "pick_baseline"),  # dir holding panel.mjs
       version="1",
   )
   ```
 
   `asset_root` is the on-disk directory (next to the block `.py`) holding the
   panel files; it is served path-confined and never sent to the browser.
-  `module_url` is always `/api/blocks/panels/<panel_id>/<file>`. The module
-  exports `{ apiVersion: "1", mount(container, host) }`; `host.panelPayload` is
-  what `prepare_prompt` returned, `host.confirm(decision)` sends the JSON that
-  becomes `config["interactive_response"]`, and `host.cancel()` cancels the
-  block. `mount` returns `{ unmount() {...} }`.
+  `module_url` is **always** `/api/blocks/panels/<panel_id>/<file>` — that is the
+  route the backend serves panel assets on, and it must name the file that
+  actually exists under `asset_root` (`.mjs` and `.js` are both served). A URL of
+  any other shape fails to load as `import_failed`.
+
+  The module's **default export** is the panel — `export_name` defaults to
+  `"default"`, so a module that exports only a named binding fails to load as
+  `export_missing`. The exported object is
+  `{ apiVersion: "1", mount(container, host) }` and `mount` returns
+  `{ unmount() {...} }`:
+
+  ```js
+  export default {
+    apiVersion: "1",
+    mount(container, host) { /* ... */ return { unmount() { /* ... */ } }; },
+  };
+  ```
+
+  `host.panelPayload` is what `prepare_prompt` returned, `host.confirm(decision)`
+  sends the JSON that becomes `config["interactive_response"]`, and
+  `host.cancel()` cancels the block.
+
+**The panel MUST give the user a reachable way to both confirm and cancel.** The
+run is paused on this window; a panel that renders neither leaves the user with
+no way forward and no way out. This is not enforced by the registry — it is on
+you, on every panel, whatever else the window does.
 
 The registry rejects an interactive block that declares the mixin without the
 mode (or vice versa), omits `prepare_prompt`, or has no valid `interactive_panel`.
+Write a panel with the `scistudio-write-panel` skill; it carries a minimal
+working module and the failure codes the panel host reports.
 
 ## Hand off to an app (AppBlock) or a script (CodeBlock)
 

--- a/src/scistudio/_skills/scistudio/SKILL.md
+++ b/src/scistudio/_skills/scistudio/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: scistudio
 description: |
-  Base identity for Mio, the SciStudio embedded agent. Lists the 6 task skills
+  Base identity for Mio, the SciStudio embedded agent. Lists the 7 task skills
   available and when to invoke each. Loaded once at session start; task
   skills load on demand when the user turn matches their trigger
   description.
@@ -18,7 +18,7 @@ access goes through the `mcp__scistudio__*` tool surface — your only
 interface to SciStudio. There is no command-line tool, and you do not edit
 `workflows/*.yaml` by hand.
 
-The six task skills below are the canonical teaching surfaces. This
+The seven task skills below are the canonical teaching surfaces. This
 base file is the identity + index; the per-task bodies hold the actual
 schemas, contracts, and worked examples. Load the relevant skill before
 deep work in that area.
@@ -42,6 +42,11 @@ deep work in that area.
 - **`scistudio-project-qa`** — answer the user's questions about SciStudio or
   this project (how a feature works, what a contract is, what's installed,
   where docs/data live), grounded in the provisioned docs + MCP tools.
+- **`scistudio-write-panel`** — author an INTERACTIVE block and the window
+  (panel) it opens: the block pauses mid-run and the user decides from the
+  data. Use when the decision can only be made by looking at the specific
+  data. An interactive block is two files; load this before writing either,
+  because the panel — not the Python — is where they break.
 - **`scistudio-write-plot`** — author a PREVIEW-ONLY plot (matplotlib /
   seaborn / ggplot2) from a block output port. Use when the user wants a
   quick figure in the preview panel. A plot job is NOT a workflow block
@@ -112,8 +117,9 @@ static list names every tool but omits descriptions / parameter
 shapes — call `mcp__scistudio__<tool>` and read FastMCP's error
 envelope if you need the exact signature, or load the relevant task
 skill (`scistudio-build-workflow`, `scistudio-write-block`,
-`scistudio-debug-run`, `scistudio-inspect-data`, `scistudio-project-qa`,
-`scistudio-write-plot`) for the documented call sequence.
+`scistudio-write-panel`, `scistudio-debug-run`, `scistudio-inspect-data`,
+`scistudio-project-qa`, `scistudio-write-plot`) for the documented call
+sequence.
 
 <!-- tool_catalog:begin -->
 **Static fallback (35 tools — shown when the live catalog was not

--- a/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-write-block/SKILL.md
@@ -65,7 +65,11 @@ genuinely helps the user. See `block-contract.md` for how to author each.
 - **interactive (optional)** — a block can pause and let the user make a
   data-dependent decision in the GUI (route items, mark a region). Reuse a
   built-in panel (`core.interactive.data_router`, `core.interactive.pair_editor`)
-  or ship a small custom panel.
+  or ship a small custom panel. **Load `scistudio-write-panel` before writing
+  one**: an interactive block is two files, and both of the ways they reach users
+  broken — a panel the host cannot load, and a panel with no way out of the
+  paused run — live in the second one. That skill carries the working module and
+  the failure codes.
 - **AppBlock / CodeBlock** — hand the step to an external GUI/CLI tool, or to a
   project-local script.
 
@@ -123,3 +127,6 @@ a convenient default.
 - An interactive block declaring `InteractiveMixin` without
   `execution_mode=INTERACTIVE` (or vice versa), or missing `prepare_prompt` /
   `interactive_panel` — the registry rejects it at scan time.
+- Writing an interactive block's panel from this skill instead of loading
+  `scistudio-write-panel`. The registry checks the Python half only; the panel
+  is where interactive blocks actually break.

--- a/src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md
+++ b/src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: scistudio-write-panel
+description: |
+  Use when a block needs to PAUSE THE RUN AND ASK THE USER — an interactive
+  block and the small window (panel) it opens: an ES module in
+  ``<project>/blocks/<name>_panel/panel.mjs`` plus the block's
+  InteractiveMixin / execution_mode / PanelManifest / prepare_prompt
+  declaration. Covers picking a region on a trace, clicking a peak, routing
+  items, confirming a segmentation — anything only a person looking at the
+  specific data can decide.
+
+  NOT for an ordinary block that computes without asking (scistudio-write-block).
+  NOT for a preview figure (scistudio-write-plot). NOT for a config parameter
+  the user sets before the run — that is ``config_schema``, not a panel.
+---
+
+# scistudio-write-panel
+
+Author an interactive block: a block that pauses mid-run, opens a window onto
+its own input data, takes the user's decision, and computes from it. This skill
+is the **task flow**; the contract lives in
+**`.scistudio/agent-reference/block-contract.md`** ("Interactive blocks") —
+read it, do not guess.
+
+An interactive block is **two files**, and both must be right:
+
+| File | What it is |
+|---|---|
+| `blocks/<name>.py` | the block: `InteractiveMixin`, `execution_mode = INTERACTIVE`, a `PanelManifest`, `prepare_prompt`, and a `run` that reads the decision |
+| `blocks/<name>_panel/panel.mjs` | the window: one plain ES module, no framework, no build step |
+
+## Non-negotiable
+
+1. **The panel MUST give the user a reachable way to BOTH confirm and cancel.**
+   The run is paused on this window. A panel that renders neither leaves the
+   person with no way forward and no way out of their own workflow. Two visible
+   controls wired to `host.confirm(decision)` and `host.cancel()` — always,
+   whatever else the window does. Nothing in the registry enforces this. You do.
+2. **The module's `default` export is the panel.** `export_name` defaults to
+   `"default"`; a named-only export fails to load as `export_missing`.
+3. **`module_url` is always `/api/blocks/panels/<panel_id>/<file>`**, and
+   `<file>` must be the file that really exists under `asset_root`. Any other
+   shape fails as `import_failed`.
+4. **`prepare_prompt` returns plain JSON, not the data.** Reduce the real inputs
+   to a window-sized view (a downsampled trace, a summary table, a list of
+   choices). The runtime rejects a payload that is not JSON-safe.
+5. **One pause for the whole batch.** `prepare_prompt` receives the full input
+   collections and the run pauses once. Do not ask the same question per item.
+
+## Reuse first
+
+Two built-in panels need no frontend code at all. Use one if it fits:
+
+- `PanelManifest(panel_id="core.interactive.data_router")` — drag items from N
+  inputs to M outputs.
+- `PanelManifest(panel_id="core.interactive.pair_editor")` — reorder items to
+  fix pairing across collections.
+
+They ship with the app: leave `module_url` and `asset_root` unset. Write your
+own panel only for something data-specific those two cannot express.
+
+## Tool-call sequence
+
+```
+mcp__scistudio__list_blocks                  # reuse check — STOP if a match exists
+mcp__scistudio__list_types                   # concrete port types
+mcp__scistudio__scaffold_block(name="pick_baseline", category="interactive",
+    input_ports={...}, output_ports={...})   # writes BOTH files; READ every warnings[]
+# fill the three TODO(scaffold) markers: the payload reduction, the panel's
+# content area, the compute body
+mcp__scistudio__reload_blocks                # re-scan; READ its diagnostics
+mcp__scistudio__validate_workflow            # once the block is a node
+mcp__scistudio__open_gui                     # open the panel and click both controls
+```
+
+If your build's `scaffold_block` does not accept `category="interactive"`,
+scaffold `category="process"` and add the interactive declaration plus the panel
+module below by hand — the contract is the same either way.
+
+## The minimal working panel
+
+Copy this, then replace only the content area. Everything else is the contract.
+
+```js
+const API_VERSION = "1";
+
+export default {
+  apiVersion: API_VERSION,
+
+  mount(container, host) {
+    const payload = host.panelPayload || {};   // what prepare_prompt returned
+
+    const root = document.createElement("div");
+    root.style.cssText = "padding:16px;font-family:system-ui,sans-serif;";
+
+    // --- your content: draw `payload`, collect the decision ---------------
+    const content = document.createElement("pre");
+    content.textContent = JSON.stringify(payload, null, 2);
+    root.appendChild(content);
+
+    // --- the exit: BOTH controls, always ---------------------------------
+    const confirm = document.createElement("button");
+    confirm.textContent = "Continue";
+    confirm.addEventListener("click", () => host.confirm({ /* your JSON */ }));
+
+    const cancel = document.createElement("button");
+    cancel.textContent = "Cancel";
+    cancel.addEventListener("click", () => host.cancel());
+
+    root.append(confirm, cancel);
+    container.appendChild(root);
+
+    return { unmount() { root.remove(); } };
+  },
+};
+```
+
+Whatever `host.confirm(...)` sends arrives in the compute phase as
+`config["interactive_response"]`; `run` reads it with
+`config.get("interactive_response", {})`.
+
+A full, real example ships in the core tutorial *What is a type* — a batch
+review panel with a canvas, a label list, and a Continue that refuses to finish
+while a slide is unseen. Read it with `search_docs` / `get_doc` when you want a
+worked one rather than a skeleton.
+
+## Debug it yourself — do not hand the user a broken window
+
+`reload_blocks` is the first stop: it reports why a block did not register and
+whether its panel resolves. `validate_workflow` reports the same class of
+problem once the block is wired into a graph. Read what they say before
+changing anything.
+
+The panel host reports one of these codes when a panel fails to open. Each maps
+to one mistake:
+
+| Code | What you did |
+|---|---|
+| `export_missing` | the module has no `default` export (or none matching `export_name`) |
+| `not_a_panel_module` | the export has no callable `mount` or no string `apiVersion` |
+| `api_version_mismatch` | the module's `apiVersion` major differs from the host's (`"1"`) |
+| `import_failed` | `module_url` names a file the route does not serve — wrong shape, wrong filename, or the file is not under `asset_root` |
+| `mount_failed` | `mount` threw; it must not throw for routine failures |
+
+`remote_url_rejected` / `invalid_module_url` mean `module_url` was not a
+site-relative `/api/...` path. Remote and inline URLs are never imported.
+
+Then open the GUI (`open_gui`) and actually click both controls once. A panel
+that mounts is not a panel that works.
+
+## Mandatory rules
+
+- `list_blocks` FIRST; reuse a built-in panel when routing or pairing fits.
+- Both halves of the interactive declaration: `InteractiveMixin` **and**
+  `execution_mode = ExecutionMode.INTERACTIVE`. The registry rejects one without
+  the other, and also rejects a missing `prepare_prompt` or `interactive_panel`.
+- `default` export, string `apiVersion`, `mount` returning `{ unmount }`.
+- Confirm and cancel both reachable, on every panel.
+- `prepare_prompt` returns plain JSON, sized for a window.
+- After writing: `reload_blocks`, read the diagnostics, then open the GUI and
+  click through the panel.
+
+## Anti-patterns
+
+- A panel with only a Confirm, or with its Cancel behind a state the user cannot
+  reach — the run is paused and they are stuck.
+- `export const panel = {...}` with no default export (`export_missing`).
+- `module_url` pointing at `/api/interactive/panels/...`, at a bare filename, or
+  at a file that is not the one on disk (`import_failed`).
+- `asset_root` pointing anywhere but the directory beside the block `.py` that
+  holds the panel file.
+- Sending the raw arrays from `prepare_prompt` instead of a reduced view.
+- Pausing per item instead of once for the batch.
+- Declaring `InteractiveMixin` without `execution_mode=INTERACTIVE` (or vice
+  versa) — the registry drops the block at scan time.
+- Calling it done because the block registered. Registration says nothing about
+  whether the window opens or whether the user can leave it.

--- a/src/scistudio/ai/agent/mcp/panel_scaffold.py
+++ b/src/scistudio/ai/agent/mcp/panel_scaffold.py
@@ -1,0 +1,292 @@
+"""Scaffold an interactive block together with the panel module it opens (#2197).
+
+An interactive block is two files, not one: the Python block and the ES module
+that draws its window. Scaffolding only the Python half is what produced the two
+failures this module exists to prevent — a panel that never loads (the module
+did not use a **default** export, or its ``module_url`` did not match the route
+the backend serves), and a panel that loads but strands the user on a paused run
+because it renders no way to confirm or cancel.
+
+So this scaffold emits both halves, already wired to each other:
+
+- ``blocks/<name>.py`` — ``InteractiveMixin`` + ``execution_mode = INTERACTIVE``,
+  a ``PanelManifest`` whose ``panel_id``, ``module_url`` and ``asset_root``
+  agree with where the panel is actually written, and a ``prepare_prompt`` stub.
+- ``blocks/<name>_panel/panel.mjs`` — a default-exported module carrying
+  ``apiVersion`` and a ``mount`` that returns ``{ unmount }``, with confirm and
+  cancel already bound to ``host.confirm`` / ``host.cancel``.
+
+The generated pair is correct as generated: it registers, and it mounts with
+working controls, with no further edits. What the author fills in afterwards is
+the payload reduction, the panel's content area, and the compute body.
+
+This module is deliberately self-contained — one public entry point,
+:func:`scaffold_interactive_block`, with no dependency on the MCP tool surface —
+so the ``scaffold_block`` tool can delegate to it in one call.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+__all__ = [
+    "DEFAULT_PANEL_NAMESPACE",
+    "PANEL_ASSET_ROUTE",
+    "PANEL_MODULE_FILENAME",
+    "InteractiveScaffold",
+    "scaffold_interactive_block",
+]
+
+_TEMPLATE_DIR = Path(__file__).resolve().parents[3] / "cli" / "templates" / "interactive_block"
+
+PANEL_MODULE_FILENAME = "panel.mjs"
+"""Filename the panel module is written under, and the one ``module_url`` names.
+
+``.mjs`` rather than ``.js`` because it is unambiguously an ES module and it is
+what the only shipped panel example uses; the asset route's suffix allowlist
+serves both.
+"""
+
+PANEL_ASSET_ROUTE = "/api/blocks/panels/{panel_id}/{asset_path}"
+"""The one route shape a package panel's ``module_url`` may take.
+
+The backend serves panel assets from ``GET /api/blocks/panels/{panel_id}/{path}``
+(router prefix ``/api/blocks``). A ``module_url`` of any other shape resolves to
+nothing and the panel host reports ``import_failed``.
+"""
+
+DEFAULT_PANEL_NAMESPACE = "project"
+"""Namespace prefix for a scaffolded ``panel_id`` (``project.<name>``).
+
+``core.*`` is reserved for the built-in panels that ship with the frontend and
+are resolved from its registry rather than from an ``asset_root``.
+"""
+
+# Types a scaffolded port may name without the generated file needing an import
+# the author has to add by hand. Anything else is scaffolded as ``DataObject``
+# with a warning naming what was asked for, so the pair still registers.
+_CORE_TYPE_NAMES = frozenset(
+    {
+        "Array",
+        "Artifact",
+        "CompositeData",
+        "DataFrame",
+        "DataObject",
+        "Series",
+        "Text",
+    }
+)
+
+_IDENTIFIER_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class InteractiveScaffold:
+    """What :func:`scaffold_interactive_block` wrote, and what to tell the author."""
+
+    block_path: Path
+    """The generated ``blocks/<name>.py``."""
+
+    panel_path: Path
+    """The generated panel module (``blocks/<name>_panel/panel.mjs``)."""
+
+    panel_id: str
+    """The manifest's ``panel_id``, e.g. ``project.pick_baseline``."""
+
+    module_url: str
+    """The manifest's ``module_url`` — the route the panel is served on."""
+
+    asset_root: Path
+    """The directory the panel module lives in (the manifest's ``asset_root``)."""
+
+    class_name: str
+    """The generated block class name."""
+
+    warnings: list[str] = field(default_factory=list)
+    """Author-facing warnings. Every entry must be read before proceeding."""
+
+
+def _to_class_name(name: str) -> str:
+    """``pick_baseline`` -> ``PickBaseline``."""
+    return "".join(part.title() for part in name.split("_") if part)
+
+
+def _to_label(name: str) -> str:
+    """``pick_baseline`` -> ``Pick Baseline`` (the palette text, pre-filled)."""
+    return " ".join(part.capitalize() for part in name.split("_") if part)
+
+
+def _render_ports(
+    spec_map: Mapping[str, Mapping[str, Any]] | None,
+    port_class: str,
+    fallback_name: str,
+    warnings: list[str],
+) -> tuple[str, str, set[str]]:
+    """Render one port list body.
+
+    Returns the rendered lines, the first port's name (the one the stub body
+    wires through), and the set of core type names the file must import.
+    """
+    entries = list((spec_map or {}).items())
+    if not entries:
+        entries = [(fallback_name, {})]
+
+    used: set[str] = set()
+    lines: list[str] = []
+    for port_name, spec in entries:
+        requested = str((spec or {}).get("type") or "DataObject")
+        if requested in _CORE_TYPE_NAMES:
+            type_name = requested
+            if type_name == "DataObject":
+                warnings.append(
+                    f"port {port_name!r} accepts DataObject, which means 'anything'. Call list_types "
+                    f"and narrow it to the most specific applicable type before you ship the block."
+                )
+        else:
+            # Package types (Image, Spectrum, ...) are not importable from a
+            # canonical root, and an unresolvable import would stop the block
+            # registering at all. Scaffold something that works and say so.
+            type_name = "DataObject"
+            warnings.append(
+                f"port {port_name!r}: type {requested!r} is not exported by scistudio.core.types, so the "
+                f"port was scaffolded as DataObject (accepts anything). Import {requested} from the "
+                f"package that defines it and replace the accepted_types entry."
+            )
+        used.add(type_name)
+        description = str((spec or {}).get("description") or "").strip()
+        described = f', description="{description}"' if description else ""
+        lines.append(f'        {port_class}(name="{port_name}", accepted_types=[{type_name}]{described}),')
+    return "\n".join(lines), str(entries[0][0]), used
+
+
+def _render(template_name: str, tokens: Mapping[str, str]) -> str:
+    """Read a template and substitute its ``@@TOKEN@@`` markers.
+
+    ``@@TOKEN@@`` rather than ``{token}`` because one of the two templates is
+    JavaScript, where braces are on nearly every line.
+    """
+    text = (_TEMPLATE_DIR / template_name).read_text(encoding="utf-8")
+    for token, value in tokens.items():
+        text = text.replace(f"@@{token}@@", value)
+    return text
+
+
+def scaffold_interactive_block(
+    project_dir: Path | str,
+    name: str,
+    *,
+    input_ports: Mapping[str, Mapping[str, Any]] | None = None,
+    output_ports: Mapping[str, Mapping[str, Any]] | None = None,
+    panel_namespace: str = DEFAULT_PANEL_NAMESPACE,
+) -> InteractiveScaffold:
+    """Write an interactive block and the panel module it opens.
+
+    Args:
+        project_dir: The SciStudio project root. The block lands under its
+            ``blocks/`` directory, which is created when absent.
+        name: Snake-case block name (``pick_baseline``). Becomes the file name,
+            the ``type_name``, the class name, and the panel id suffix.
+        input_ports: Optional ``{port_name: {"type": ..., "description": ...}}``.
+            Defaults to a single ``input`` port accepting ``DataObject``.
+        output_ports: Same shape for outputs. Defaults to a single ``output``.
+        panel_namespace: Prefix for the generated ``panel_id``. ``core`` is
+            refused — it is reserved for the frontend's built-in panels.
+
+    Returns:
+        An :class:`InteractiveScaffold` naming both written files, the manifest
+        values they agree on, and the warnings the author must read.
+
+    Raises:
+        ValueError: *name* is not a snake-case identifier, or *panel_namespace*
+            is empty or the reserved ``core`` namespace.
+        FileExistsError: the block file or the panel directory already exists.
+            Nothing is written in that case.
+    """
+    if not _IDENTIFIER_RE.match(name):
+        raise ValueError(f"block name must be snake_case starting with a letter, got {name!r}")
+    namespace = panel_namespace.strip()
+    if not namespace:
+        raise ValueError("panel_namespace must not be empty")
+    if namespace == "core" or namespace.startswith("core."):
+        raise ValueError("the 'core' panel namespace is reserved for the frontend's built-in panels")
+
+    root = Path(project_dir)
+    blocks_dir = root / "blocks"
+    block_path = blocks_dir / f"{name}.py"
+    panel_dirname = f"{name}_panel"
+    asset_root = blocks_dir / panel_dirname
+    panel_path = asset_root / PANEL_MODULE_FILENAME
+
+    # Check both halves before writing either: a half-written pair is a block
+    # that registers and then fails to open.
+    if block_path.exists():
+        raise FileExistsError(f"block already exists: {block_path}")
+    if asset_root.exists():
+        raise FileExistsError(f"panel directory already exists: {asset_root}")
+
+    panel_id = f"{namespace}.{name}"
+    module_url = PANEL_ASSET_ROUTE.format(panel_id=panel_id, asset_path=PANEL_MODULE_FILENAME)
+    class_name = _to_class_name(name)
+    label = _to_label(name)
+
+    warnings: list[str] = []
+    inputs_rendered, primary_input, input_types = _render_ports(input_ports, "InputPort", "input", warnings)
+    outputs_rendered, primary_output, output_types = _render_ports(output_ports, "OutputPort", "output", warnings)
+
+    imported = sorted({"Collection", *input_types, *output_types})
+    type_import_line = f"from scistudio.core.types import {', '.join(imported)}"
+
+    block_text = _render(
+        "block.py.tpl",
+        {
+            "BLOCK_LABEL": label,
+            "CLASS_NAME": class_name,
+            "TYPE_NAME": name,
+            "PANEL_ID": panel_id,
+            "MODULE_URL": module_url,
+            "PANEL_DIRNAME": panel_dirname,
+            "PANEL_FILENAME": PANEL_MODULE_FILENAME,
+            "TYPE_IMPORT_LINE": type_import_line,
+            "INPUT_PORTS": inputs_rendered,
+            "OUTPUT_PORTS": outputs_rendered,
+            "PRIMARY_INPUT": primary_input,
+            "PRIMARY_OUTPUT": primary_output,
+        },
+    )
+    panel_text = _render(
+        "panel.mjs.tpl",
+        {"BLOCK_LABEL": label, "PANEL_HEADING": label},
+    )
+
+    blocks_dir.mkdir(parents=True, exist_ok=True)
+    asset_root.mkdir(parents=True, exist_ok=False)
+    panel_path.write_text(panel_text, encoding="utf-8", newline="\n")
+    block_path.write_text(block_text, encoding="utf-8", newline="\n")
+
+    warnings.append(
+        "The panel already renders working controls bound to host.confirm and host.cancel. "
+        "Whatever you put in its content area, both must stay on screen and reachable — a "
+        "panel with no exit strands the user on a paused run."
+    )
+    warnings.append(
+        f"Fill the three TODO(scaffold) markers: the payload reduction in prepare_prompt, "
+        f"the content area of {panel_dirname}/{PANEL_MODULE_FILENAME}, and the compute body of run()."
+    )
+    warnings.append(
+        "Then call reload_blocks and read its diagnostics: it is what tells you whether the "
+        "block registered and the panel resolves."
+    )
+
+    return InteractiveScaffold(
+        block_path=block_path,
+        panel_path=panel_path,
+        panel_id=panel_id,
+        module_url=module_url,
+        asset_root=asset_root,
+        class_name=class_name,
+        warnings=warnings,
+    )

--- a/src/scistudio/ai/agent/mcp/panel_scaffold.py
+++ b/src/scistudio/ai/agent/mcp/panel_scaffold.py
@@ -273,8 +273,9 @@ def scaffold_interactive_block(
         "panel with no exit strands the user on a paused run."
     )
     warnings.append(
-        f"Fill the three TODO(scaffold) markers: the payload reduction in prepare_prompt, "
-        f"the content area of {panel_dirname}/{PANEL_MODULE_FILENAME}, and the compute body of run()."
+        f"Three things are left for you, each marked in the generated files: the payload "
+        f"reduction in prepare_prompt, the content area of "
+        f"{panel_dirname}/{PANEL_MODULE_FILENAME}, and the compute body of run()."
     )
     warnings.append(
         "Then call reload_blocks and read its diagnostics: it is what tells you whether the "

--- a/src/scistudio/cli/templates/interactive_block/block.py.tpl
+++ b/src/scistudio/cli/templates/interactive_block/block.py.tpl
@@ -1,0 +1,109 @@
+"""@@BLOCK_LABEL@@ — an interactive block: it pauses the run and asks the user.
+
+Interaction is a capability, not a base class: this is an ordinary block that
+mixes in ``InteractiveMixin`` and declares ``execution_mode = INTERACTIVE``. The
+run reaches it, ``prepare_prompt`` reduces the real inputs to a small JSON view,
+the window beside this file (``@@PANEL_DIRNAME@@/@@PANEL_FILENAME@@``) shows that
+view and takes the user's decision, and then ``run`` computes the outputs from
+it.
+
+Everything the registry and the panel host check is already filled in and
+correct: both halves of the interactive declaration, a panel manifest whose
+``module_url`` matches the route the backend actually serves, and a panel with
+working confirm and cancel controls. Three things are yours, each marked TODO:
+
+  1. ``prepare_prompt`` — reduce the inputs to the plain-JSON view the panel
+     renders. Never send the raw data.
+  2. the panel's content area — draw that view and collect the decision.
+  3. ``run`` — read the decision and produce the outputs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+from scistudio.blocks.base import (
+    Block,
+    BlockConfig,
+    ExecutionMode,
+    InputPort,
+    InteractiveMixin,
+    InteractivePrompt,
+    OutputPort,
+    PanelManifest,
+)
+@@TYPE_IMPORT_LINE@@
+
+
+class @@CLASS_NAME@@(InteractiveMixin, Block):
+    """@@BLOCK_LABEL@@: pause the run, show the data, and act on the answer."""
+
+    name: ClassVar[str] = "@@BLOCK_LABEL@@"
+    type_name: ClassVar[str] = "@@TYPE_NAME@@"
+    # TODO(scaffold): one line, in the user's language — this is the palette text.
+    description: ClassVar[str] = "Pause and let the user decide from the data."
+    version: ClassVar[str] = "0.1.0"
+
+    # Both halves, always. The registry rejects the block when only one of the
+    # mixin and the mode is present (ADR-051 FR-002).
+    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+
+    # The window this block opens.
+    #
+    # ``asset_root`` is the on-disk directory beside this file that holds the
+    # panel; it is a backend-only path and never reaches the browser.
+    # ``module_url`` is always ``/api/blocks/panels/<panel_id>/<file>`` — that is
+    # the route the backend serves panel assets on, and a URL of any other shape
+    # fails to load with ``import_failed``.
+    interactive_panel: ClassVar[PanelManifest] = PanelManifest(
+        panel_id="@@PANEL_ID@@",
+        module_url="@@MODULE_URL@@",
+        version="1",
+        asset_root=str(Path(__file__).resolve().parent / "@@PANEL_DIRNAME@@"),
+    )
+
+    input_ports: ClassVar[list[InputPort]] = [
+@@INPUT_PORTS@@
+    ]
+    output_ports: ClassVar[list[OutputPort]] = [
+@@OUTPUT_PORTS@@
+    ]
+
+    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:
+        """Reduce the real inputs to the window-sized JSON view the panel renders.
+
+        Runs first, in its own worker, with the block's full input collections.
+        One prompt covers the whole batch: the run pauses once, not once per item.
+
+        Args:
+            inputs: The block's input collections, keyed by input-port name.
+            config: The resolved block configuration.
+
+        Returns:
+            An :class:`InteractivePrompt` whose ``panel_payload`` is plain JSON.
+            The runtime rejects a payload that is not JSON-safe.
+        """
+        items = self.unpack(inputs["@@PRIMARY_INPUT@@"])
+        # TODO(scaffold): reduce the real data to something a person can look at
+        # — a downsampled trace, a summary table, a list of choices — and send
+        # that instead of this placeholder count. Never send the raw arrays.
+        return InteractivePrompt(panel_payload={"item_count": len(items)})
+
+    def run(self, inputs: dict[str, Collection], config: BlockConfig) -> dict[str, Collection]:
+        """Compute the outputs from the decision the user made in the panel.
+
+        Args:
+            inputs: The block's input collections, keyed by input-port name.
+            config: Carries ``interactive_response`` — the JSON the panel sent
+                through ``host.confirm(...)`` — injected by the engine after the
+                user confirms.
+
+        Returns:
+            One :class:`Collection` per output port name.
+        """
+        response = config.get("interactive_response", {}) or {}
+        # TODO(scaffold): compute the real outputs from ``response``. This
+        # passes the input through so the block runs end to end as scaffolded.
+        _ = response
+        return {"@@PRIMARY_OUTPUT@@": inputs["@@PRIMARY_INPUT@@"]}

--- a/src/scistudio/cli/templates/interactive_block/panel.mjs.tpl
+++ b/src/scistudio/cli/templates/interactive_block/panel.mjs.tpl
@@ -1,0 +1,102 @@
+// The window @@BLOCK_LABEL@@ opens.
+//
+// One hand-written ES module: no framework, no build step, no bundler. The host
+// imports this file from the block's `module_url`, calls `mount(container, host)`
+// once, and tears the panel down through the `{ unmount }` handle `mount` returns.
+//
+// Four things below are already correct. Keep them that way — each one has a
+// named failure code the panel host reports when it is broken:
+//
+//   1. This object is the module's **default** export. The manifest's
+//      `export_name` defaults to `"default"`; exporting only a named binding
+//      fails to load with `export_missing`.
+//   2. `apiVersion` is a string and its major must match the host's, or the
+//      panel is refused with `api_version_mismatch`.
+//   3. `mount` returns `{ unmount() {...} }`. A module without a callable
+//      `mount` is rejected as `not_a_panel_module`.
+//   4. Confirm and cancel are BOTH on screen and both reachable.
+//      `host.confirm(decision)` resumes the run with the panel's JSON answer;
+//      `host.cancel()` cancels the block. A panel that renders neither leaves
+//      the user staring at a paused run with no way out. Never ship one.
+//
+// What is left for you is the content area between the heading and the buttons:
+// draw `host.panelPayload` (exactly what the block's `prepare_prompt` returned)
+// and collect the decision, then return it from `readDecision()`.
+
+const API_VERSION = "1";
+
+/** Small DOM helper so the body below stays about the panel, not about tags. */
+function el(tag, style, text) {
+  const node = document.createElement(tag);
+  if (style) node.style.cssText = style;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+export default {
+  apiVersion: API_VERSION,
+
+  mount(container, host) {
+    // What `prepare_prompt` built. Plain JSON — never the real data.
+    const payload = host.panelPayload || {};
+
+    const root = el(
+      "div",
+      "display:flex;flex-direction:column;gap:12px;padding:16px;" +
+        "font-family:system-ui,sans-serif;color:#1c1917;",
+    );
+    root.appendChild(el("div", "font-weight:600;", "@@PANEL_HEADING@@"));
+
+    // ---- content area ------------------------------------------------------
+    // TODO(scaffold): replace this dump with the real view — a canvas, a table,
+    // a list of choices — and with the controls the user decides through. Until
+    // you do, the panel shows the payload so you can see what arrived.
+    const content = el(
+      "pre",
+      "margin:0;padding:12px;border-radius:8px;background:#f5f5f4;" +
+        "max-height:360px;overflow:auto;font-size:12px;white-space:pre-wrap;",
+      JSON.stringify(payload, null, 2),
+    );
+    root.appendChild(content);
+
+    /**
+     * The JSON the block reads back.
+     *
+     * Whatever this returns arrives in the compute phase as
+     * `config["interactive_response"]`. It must be plain JSON.
+     */
+    function readDecision() {
+      // TODO(scaffold): return the user's actual decision.
+      return { confirmed: true };
+    }
+
+    // ---- confirm / cancel --------------------------------------------------
+    // Both, always. This pair is the block's only exit.
+    const buttons = el("div", "display:flex;gap:8px;margin-top:4px;");
+    const confirm = el(
+      "button",
+      "padding:6px 16px;border-radius:8px;border:1px solid #1c1917;" +
+        "background:#1c1917;color:#fff;cursor:pointer;",
+      "Continue",
+    );
+    const cancel = el(
+      "button",
+      "padding:6px 16px;border-radius:8px;border:1px solid #d6d3d1;" +
+        "background:#fff;cursor:pointer;",
+      "Cancel",
+    );
+    confirm.addEventListener("click", () => host.confirm(readDecision()));
+    cancel.addEventListener("click", () => host.cancel());
+    buttons.appendChild(confirm);
+    buttons.appendChild(cancel);
+    root.appendChild(buttons);
+
+    container.appendChild(root);
+
+    return {
+      unmount() {
+        root.remove();
+      },
+    };
+  },
+};

--- a/tests/ai/test_panel_scaffold.py
+++ b/tests/ai/test_panel_scaffold.py
@@ -123,7 +123,7 @@ def test_package_port_type_falls_back_and_says_so(tmp_path: Path) -> None:
     a warning the authoring agent is required to read.
     """
     result = scaffold_interactive_block(tmp_path, "review", input_ports={"labels": {"type": "Image"}})
-    assert 'accepted_types=[DataObject]' in result.block_path.read_text(encoding="utf-8")
+    assert "accepted_types=[DataObject]" in result.block_path.read_text(encoding="utf-8")
     assert any("Image" in warning and "DataObject" in warning for warning in result.warnings)
 
 

--- a/tests/ai/test_panel_scaffold.py
+++ b/tests/ai/test_panel_scaffold.py
@@ -1,0 +1,194 @@
+"""The interactive scaffold emits a pair that works as generated (#2197).
+
+An interactive block is two files, and the two ways an AI-authored one reached
+users broken were both in the second file: a panel module the host could not
+load, and a panel with no way out of the paused run. These tests hold the
+generated pair to the parts of the contract those failures violated —
+
+- the block registers (so ``prepare_prompt``, ``execution_mode``, and the
+  ``PanelManifest`` really do satisfy ADR-051 FR-002, not just look like it);
+- the manifest's ``module_url`` is the route the backend actually serves, and it
+  points at where the panel was actually written;
+- the panel module is a **default** export carrying ``apiVersion`` and a
+  ``mount`` that returns ``{ unmount }`` — the three shapes whose absence the
+  panel host reports as ``export_missing`` / ``api_version_mismatch`` /
+  ``not_a_panel_module``;
+- confirm and cancel are both wired.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from scistudio.ai.agent.mcp.panel_scaffold import (
+    PANEL_MODULE_FILENAME,
+    InteractiveScaffold,
+    scaffold_interactive_block,
+)
+from scistudio.blocks.base.state import ExecutionMode
+from scistudio.blocks.registry import BlockRegistry
+
+
+@pytest.fixture
+def scaffold(tmp_path: Path) -> InteractiveScaffold:
+    """One scaffolded pair with default ports, in an empty project."""
+    return scaffold_interactive_block(tmp_path, "pick_baseline")
+
+
+# --- what gets written -----------------------------------------------------
+
+
+def test_scaffold_writes_both_halves(tmp_path: Path, scaffold: InteractiveScaffold) -> None:
+    assert scaffold.block_path == tmp_path / "blocks" / "pick_baseline.py"
+    assert scaffold.panel_path == tmp_path / "blocks" / "pick_baseline_panel" / PANEL_MODULE_FILENAME
+    assert scaffold.block_path.is_file()
+    assert scaffold.panel_path.is_file()
+    assert scaffold.class_name == "PickBaseline"
+
+
+def test_manifest_points_at_where_the_panel_was_written(scaffold: InteractiveScaffold) -> None:
+    """``asset_root`` and ``module_url`` must agree with the file on disk."""
+    assert scaffold.asset_root == scaffold.panel_path.parent
+    assert scaffold.panel_id == "project.pick_baseline"
+    assert scaffold.module_url == f"/api/blocks/panels/{scaffold.panel_id}/{PANEL_MODULE_FILENAME}"
+    block_text = scaffold.block_path.read_text(encoding="utf-8")
+    assert f'module_url="{scaffold.module_url}"' in block_text
+    assert f'panel_id="{scaffold.panel_id}"' in block_text
+    assert f'/ "{scaffold.asset_root.name}"' in block_text
+
+
+def test_module_url_is_the_route_the_backend_serves(scaffold: InteractiveScaffold) -> None:
+    """Guard against the ``import_failed`` class: a URL no route answers.
+
+    Compared against the live route table rather than a copied string, so the
+    scaffold breaks loudly if the panel asset route ever moves.
+    """
+    from scistudio.api.routes.blocks import router
+
+    served = {route.path for route in router.routes if "panels" in getattr(route, "path", "")}
+    assert "/api/blocks/panels/{panel_id}/{asset_path:path}" in served
+    prefix = f"/api/blocks/panels/{scaffold.panel_id}/"
+    assert scaffold.module_url.startswith(prefix)
+    assert scaffold.module_url[len(prefix) :] == PANEL_MODULE_FILENAME
+
+
+# --- the block half --------------------------------------------------------
+
+
+def test_generated_block_registers(tmp_path: Path, scaffold: InteractiveScaffold) -> None:
+    """The registry accepts it with no edits — the real ADR-051 FR-002 check."""
+    logging.disable(logging.CRITICAL)  # the drop-in scanner warns per file by design
+    try:
+        registry = BlockRegistry()
+        registry.add_scan_dir(scaffold.block_path.parent)
+        registry.scan()
+    finally:
+        logging.disable(logging.NOTSET)
+
+    assert registry.dropin_failures() == []
+    spec = registry.all_specs()["Pick Baseline"]
+    assert spec.execution_mode == ExecutionMode.INTERACTIVE.value
+    manifest = spec.panel_manifest
+    assert manifest is not None
+    assert manifest["panel_id"] == scaffold.panel_id
+    assert manifest["module_url"] == scaffold.module_url
+    # ``export_name`` defaults to "default"; the panel module must match it.
+    assert manifest["export_name"] == "default"
+    assert Path(spec.panel_asset_root) == scaffold.asset_root
+
+
+def test_generated_block_declares_the_ports_it_was_asked_for(tmp_path: Path) -> None:
+    result = scaffold_interactive_block(
+        tmp_path,
+        "sort_traces",
+        input_ports={"traces": {"type": "Array", "description": "the raw traces"}},
+        output_ports={"kept": {"type": "Array"}},
+    )
+    text = result.block_path.read_text(encoding="utf-8")
+    assert 'InputPort(name="traces", accepted_types=[Array], description="the raw traces")' in text
+    assert 'OutputPort(name="kept", accepted_types=[Array])' in text
+    assert "from scistudio.core.types import Array, Collection" in text
+    # The stub body wires the first input through to the first output, so the
+    # block runs end to end before the author has touched it.
+    assert 'return {"kept": inputs["traces"]}' in text
+
+
+def test_package_port_type_falls_back_and_says_so(tmp_path: Path) -> None:
+    """A type no canonical root exports would break the import, so it degrades.
+
+    Degrading silently would be worse than the bug, so the fallback is named in
+    a warning the authoring agent is required to read.
+    """
+    result = scaffold_interactive_block(tmp_path, "review", input_ports={"labels": {"type": "Image"}})
+    assert 'accepted_types=[DataObject]' in result.block_path.read_text(encoding="utf-8")
+    assert any("Image" in warning and "DataObject" in warning for warning in result.warnings)
+
+
+# --- the panel half --------------------------------------------------------
+
+
+def test_panel_module_is_a_default_export(scaffold: InteractiveScaffold) -> None:
+    """``export_name`` defaults to "default"; a named-only export is export_missing."""
+    text = scaffold.panel_path.read_text(encoding="utf-8")
+    assert "export default {" in text
+    assert "export const" not in text
+
+
+def test_panel_module_declares_api_version_and_mount(scaffold: InteractiveScaffold) -> None:
+    text = scaffold.panel_path.read_text(encoding="utf-8")
+    assert 'const API_VERSION = "1";' in text
+    assert "apiVersion: API_VERSION," in text
+    assert "mount(container, host) {" in text
+    # mount must hand back an unmount handle or the host cannot tear it down.
+    assert "unmount() {" in text
+    assert "return {" in text
+
+
+def test_panel_module_wires_confirm_and_cancel(scaffold: InteractiveScaffold) -> None:
+    """The defect that reached users: a panel with no reachable way out."""
+    text = scaffold.panel_path.read_text(encoding="utf-8")
+    assert "host.confirm(" in text
+    assert "host.cancel()" in text
+    assert '"Continue",' in text
+    assert '"Cancel",' in text
+
+
+def test_scaffold_warns_that_both_controls_must_stay(scaffold: InteractiveScaffold) -> None:
+    joined = " ".join(scaffold.warnings).lower()
+    assert "confirm" in joined and "cancel" in joined
+
+
+# --- refusals --------------------------------------------------------------
+
+
+def test_refuses_to_overwrite_an_existing_block(tmp_path: Path) -> None:
+    blocks = tmp_path / "blocks"
+    blocks.mkdir()
+    (blocks / "dup.py").write_text("# already here\n", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        scaffold_interactive_block(tmp_path, "dup")
+    # Nothing half-written: a block that registers and then fails to open is
+    # exactly the state this scaffold exists to prevent.
+    assert not (blocks / "dup_panel").exists()
+
+
+def test_refuses_to_overwrite_an_existing_panel_directory(tmp_path: Path) -> None:
+    (tmp_path / "blocks" / "dup_panel").mkdir(parents=True)
+    with pytest.raises(FileExistsError):
+        scaffold_interactive_block(tmp_path, "dup")
+    assert not (tmp_path / "blocks" / "dup.py").exists()
+
+
+@pytest.mark.parametrize("name", ["Pick", "1pick", "pick-baseline", ""])
+def test_rejects_a_name_that_is_not_snake_case(tmp_path: Path, name: str) -> None:
+    with pytest.raises(ValueError):
+        scaffold_interactive_block(tmp_path, name)
+
+
+def test_rejects_the_reserved_core_panel_namespace(tmp_path: Path) -> None:
+    """``core.*`` resolves from the frontend's built-in registry, not an asset_root."""
+    with pytest.raises(ValueError):
+        scaffold_interactive_block(tmp_path, "pick", panel_namespace="core")


### PR DESCRIPTION
## What

Interactive blocks were the worst-taught authoring surface in the repository,
and AI-authored ones were reaching users broken. Both failure modes live in the
second file an interactive block needs — the panel module — and nothing taught
that file.

### 1. A dedicated authoring skill

`src/scistudio/_skills/scistudio/scistudio-write-panel/SKILL.md`, alongside
`scistudio-write-block`. It states as non-negotiable that the panel gives the
user a reachable way to **both** confirm and cancel (the defect that reached
users), carries a minimal working panel module, and routes to the validation
surfaces — `reload_blocks` diagnostics and `validate_workflow` — plus the panel
host's failure codes (`export_missing`, `not_a_panel_module`,
`api_version_mismatch`, `import_failed`, `mount_failed`) so the agent
self-debugs. `scistudio-write-block` (three lines of interactive coverage
before) and the base skill index now route to it.

### 2. An interactive scaffold

`scistudio.ai.agent.mcp.panel_scaffold.scaffold_interactive_block` emits both
halves already wired to each other:

- `blocks/<name>.py` — `InteractiveMixin`, `execution_mode = INTERACTIVE`, a
  `PanelManifest` whose `module_url` is a real
  `/api/blocks/panels/<panel_id>/panel.mjs` and whose `asset_root` points at
  where the panel was actually written, and a `prepare_prompt` stub.
- `blocks/<name>_panel/panel.mjs` — a **default** export carrying `apiVersion`
  and a `mount` returning `{ unmount }`, with confirm and cancel already bound
  to `host.confirm` / `host.cancel`.

The pair is correct as generated: it registers and it mounts with working
controls with no further edits. The author fills the payload reduction, the
content area, and the compute body.

### 3. Documentation corrections

- `block-contract.md` now states that the module must be the **default** export
  (`export_name` defaults to `"default"`, so the old text produced
  `export_missing`), names `panel.mjs` — the file that actually ships — instead
  of `index.js`, states the exact `module_url` shape, and states the
  confirm-and-cancel rule.
- `panelModuleLoader.ts`'s header comment documented the route as
  `/api/interactive/panels/...`, which does not exist. Comment text only.
- `docs/package-development/blocks.md` does not document the interactive panel
  contract at all, so it needed no counterpart correction (recorded as a docs
  N/A in the ledger).

## Tests

`tests/ai/test_panel_scaffold.py` (17 tests): the generated block registers
through a real `BlockRegistry` scan with no drop-in failures; the manifest's
`module_url` is checked against the live FastAPI route table rather than a
copied string; the generated panel module is asserted to be a default export
with `apiVersion`, a `mount` returning `{ unmount }`, and both `host.confirm`
and `host.cancel` wired; plus the refusal paths.

## Follow-up sequenced to the manager

Provisioning the new skill into projects needs `_SKILL_NAMES` in
`src/scistudio/agent_provisioning/skills.py`, `_expected_skill_paths()` in
`_orchestrate.py`, and `templates/claude_agents_md.md` — all of which are agent
A2's exclusive write set for this dispatch — together with the paired count
updates in `tests/agent_provisioning/test_skills.py` and
`tests/packaging/test_wheel_skills.py`. This branch deliberately leaves all of
them untouched.

Gate record: .workflow/records/2197-docs-2197-panel-authoring-skill.json

Closes #2197
