### PR TITLE
feat(#2196): validate the interactive block and panel contract at reload, workflow-validate, and write time

### DIFF
--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -1,0 +1,227 @@
+{
+  "base_ref": null,
+  "branch": "feat/2196-interactive-contract-validation",
+  "check_events": [],
+  "check_na": [],
+  "commit": null,
+  "declared_scope": {
+    "exclude": [],
+    "include": [
+      "src/scistudio/blocks/base/panel_contract.py",
+      "src/scistudio/blocks/registry/**",
+      "src/scistudio/ai/agent/mcp/tools_authoring.py",
+      "src/scistudio/ai/agent/mcp/_reload.py",
+      "src/scistudio/workflow/validator.py",
+      "src/scistudio/agent_provisioning/**",
+      "tests/**",
+      "docs/package-development/blocks.md",
+      "docs/specs/adr-051-interactive-blocks.md"
+    ]
+  },
+  "directive_events": [
+    {
+      "at": "2026-08-26T20:53:58.955954Z",
+      "owner_directive": "Shared static panel-contract validator in src/scistudio/blocks/base/panel_contract.py (next to interactive.py, which owns PanelManifest/PANEL_API_VERSION; no cycle). Surfaced at three agent-unavoidable points: registry scan rejection reasons returned by reload_blocks, workflow validator Check 11, and a new provisioned PostToolUse hook covering panel .js/.mjs writes.",
+      "reason": "plan"
+    }
+  ],
+  "docs_events": [
+    {
+      "at": "2026-08-26T20:53:58.955978Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/package-development/blocks.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:53:58.955985Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-051-interactive-blocks.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417422Z",
+      "class": null,
+      "kind": "path",
+      "path": "CHANGELOG.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417427Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/package-development/blocks.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417429Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/specs/adr-051-interactive-blocks.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:14:12.216351Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/agent-provisioning.md",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:14:12.216362Z",
+      "class": "adr",
+      "kind": "na",
+      "path": null,
+      "rationale": "no new architectural decision \u2014 the panel contract and its scan-time enforcement are ADR-051; this lands FR-016/017/018 in the ADR-051 implementation spec",
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:14:12.216367Z",
+      "class": "ai-developer-docs",
+      "kind": "na",
+      "path": null,
+      "rationale": "docs/ai-developer/** describes the SciStudio-repo gate workflow and the worktree write guard, neither of which changes here; the new hook is provisioned into end-user projects under ADR-040 and is documented in docs/agent-provisioning.md",
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": false,
+  "guard_events": [],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2196,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": null,
+  "owner_directive": "Manager dispatch A2 (#2196): validate the interactive block + panel contract statically at three agent-unavoidable surfaces (registry scan/reload_blocks, workflow validator, PostToolUse hook), emitting the same failure codes the frontend panel host shows. No JS runtime, no CLI entry point, no new MCP tool.",
+  "persona": "implementer",
+  "pull_request": null,
+  "reconcile_events": [],
+  "record_id": "2196-feat-2196-interactive-contract-validation",
+  "requested_admin_labels": [
+    {
+      "actor_permission": null,
+      "applied_at": null,
+      "applied_by": null,
+      "name": "admin-approved:core-change"
+    }
+  ],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [],
+    "docs": [],
+    "guards": [],
+    "tests": []
+  },
+  "runtime": "claude-code:claude-opus-5",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-26T21:13:33.417399Z",
+      "pattern": "CHANGELOG.md",
+      "reason": "CHANGELOG entry for the user-visible change; also naming the ADR-051 spec FR-016/017/018 addition and the new test paths"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-26T21:14:12.216329Z",
+      "pattern": "docs/agent-provisioning.md",
+      "reason": "docs/agent-provisioning.md lists the provisioned hook set and gains the new PostToolUse entry"
+    }
+  ],
+  "session_id": "7278a440-0cc5-4a88-b463-7c0f00c01733",
+  "strictness_tier": null,
+  "task_kind": "feature",
+  "test_events": [
+    {
+      "at": "2026-08-26T20:53:58.955990Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_panel_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:53:58.955995Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_registry_rejections.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:53:58.955996Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/workflow/test_validator_panel_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:53:58.955998Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_hooks.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T20:53:58.956000Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/agent/mcp/test_tools_authoring_reload.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417432Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_panel_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417435Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/blocks/test_registry_rejections.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417437Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/workflow/test_validator_panel_contract.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417438Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/agent_provisioning/test_hook_panel_contract_parity.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:13:33.417439Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/ai/test_mcp_tools_authoring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -1,7 +1,156 @@
 {
   "base_ref": null,
   "branch": "feat/2196-interactive-contract-validation",
-  "check_events": [],
+  "check_events": [
+    {
+      "at": "2026-08-26T21:24:01.540395Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fecf6ca3563a231a4e10ca8805bf05530612333efc3e9801ad14996e0dde7117",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:24:06.383607Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:2f18447b755472ca845e12c13c006d9ba7a7b34d20ababd99925c12727499aa8",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:24:07.830682Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:f01df772b6e45c9006cf616c3729feb7af6898686afdf50c0326d7c25203ca48",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:24:07.862354Z",
+      "command": "ruff format src/scistudio/agent_provisioning/_orchestrate.py src/scistudio/agent_provisioning/codex_config.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py src/scistudio/ai/agent/mcp/tools_authoring.py src/scistudio/blocks/base/panel_contract.py src/scistudio/blocks/registry/__init__.py src/scistudio/blocks/registry/_capability.py src/scistudio/blocks/registry/_scan.py src/scistudio/workflow/validator.py tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/test_mcp_tools_authoring.py tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:b00911be6b4fdea6764a8483247f73c151edb2c62e70531a71666e73d9657dc6",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:24:19.883031Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:292738fe707ad7db74b9a25a971291c071d78ac5b4edd28fc8a407a27fadf531",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:24:20.413634Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:4cc424c26fbc8ca9cc1cac01a1e14f51d3356cc7089d57f91360d8793b70d96c",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:24:20.441874Z",
+      "command": "ruff check src/scistudio/agent_provisioning/_orchestrate.py src/scistudio/agent_provisioning/codex_config.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py src/scistudio/ai/agent/mcp/tools_authoring.py src/scistudio/blocks/base/panel_contract.py src/scistudio/blocks/registry/__init__.py src/scistudio/blocks/registry/_capability.py src/scistudio/blocks/registry/_scan.py src/scistudio/workflow/validator.py tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/test_mcp_tools_authoring.py tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d4ea7b932f5c607dfac22fcb3e6087736568330a4567f6ae88779d5f9f041f3c",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:24:59.459380Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/agent_provisioning tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/agent/mcp tests/ai/test_mcp_tools_authoring.py tests/blocks tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/workflow tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:d0b1e1cfeeddf3eae6b61c1a41d67474c6776af59571047acc49604bc8d9732f",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:25:07.594069Z",
+      "command": "mypy src/scistudio/agent_provisioning/_orchestrate.py src/scistudio/agent_provisioning/codex_config.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py src/scistudio/ai/agent/mcp/tools_authoring.py src/scistudio/blocks/base/panel_contract.py src/scistudio/blocks/registry/__init__.py src/scistudio/blocks/registry/_capability.py src/scistudio/blocks/registry/_scan.py src/scistudio/workflow/validator.py --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:87fc2d885c5ea4b2d23f9b6a6fa354ecdfc41dfb9f3461bcc66d571616351d33",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
   "check_na": [],
   "commit": null,
   "declared_scope": {
@@ -92,7 +241,202 @@
     }
   ],
   "governance_touch": false,
-  "guard_events": [],
+  "guard_events": [
+    {
+      "at": "2026-08-26T21:25:07.667382Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.682726Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.697044Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.711509Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.726647Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.743010Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.759676Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.776007Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.791856Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.806859Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:07.829478Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
   "issues": [
     {
       "close_in_pr": true,
@@ -102,11 +446,66 @@
     }
   ],
   "observed_admin_labels": [],
-  "observed_diff": null,
+  "observed_diff": {
+    "base": "origin/main",
+    "base_sha": "2543d2e90",
+    "changed_files": [
+      ".workflow/records/2196-feat-2196-interactive-contract-validation.json",
+      "CHANGELOG.md",
+      "docs/agent-provisioning.md",
+      "docs/package-development/blocks.md",
+      "docs/specs/adr-051-interactive-blocks.md",
+      "src/scistudio/agent_provisioning/_orchestrate.py",
+      "src/scistudio/agent_provisioning/codex_config.py",
+      "src/scistudio/agent_provisioning/hooks.py",
+      "src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py",
+      "src/scistudio/ai/agent/mcp/tools_authoring.py",
+      "src/scistudio/blocks/base/panel_contract.py",
+      "src/scistudio/blocks/registry/__init__.py",
+      "src/scistudio/blocks/registry/_capability.py",
+      "src/scistudio/blocks/registry/_scan.py",
+      "src/scistudio/workflow/validator.py",
+      "tests/agent_provisioning/test_codex_config.py",
+      "tests/agent_provisioning/test_hook_panel_contract_parity.py",
+      "tests/agent_provisioning/test_hooks.py",
+      "tests/agent_provisioning/test_orchestrate.py",
+      "tests/ai/test_mcp_tools_authoring.py",
+      "tests/blocks/test_interactive_adversarial_registry.py",
+      "tests/blocks/test_panel_contract.py",
+      "tests/blocks/test_registry_package_layout.py",
+      "tests/blocks/test_registry_rejections.py",
+      "tests/workflow/test_validator_panel_contract.py"
+    ],
+    "diff_fingerprint": "sha256:c6eed6efc3d0073c74630f07da7b47c23cbdd46632220aad8694c4fb1044bc2a",
+    "head": "HEAD",
+    "head_sha": "0480b3cc5",
+    "surfaces": {
+      "docs": 3,
+      "frontend": 0,
+      "governance": 0,
+      "governed_docs": 0,
+      "implementation": 10,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 5,
+      "sentrux": 21,
+      "test": 10,
+      "workflow_ci": 0
+    }
+  },
   "owner_directive": "Manager dispatch A2 (#2196): validate the interactive block + panel contract statically at three agent-unavoidable surfaces (registry scan/reload_blocks, workflow validator, PostToolUse hook), emitting the same failure codes the frontend panel host shows. No JS runtime, no CLI entry point, no new MCP tool.",
   "persona": "implementer",
   "pull_request": null,
-  "reconcile_events": [],
+  "reconcile_events": [
+    {
+      "at": "2026-08-26T21:25:07.829522Z",
+      "diff_fingerprint": "sha256:c6eed6efc3d0073c74630f07da7b47c23cbdd46632220aad8694c4fb1044bc2a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
   "record_id": "2196-feat-2196-interactive-contract-validation",
   "requested_admin_labels": [
     {
@@ -117,11 +516,39 @@
     }
   ],
   "required_obligations": {
-    "admin_labels": [],
-    "checks": [],
-    "docs": [],
-    "guards": [],
-    "tests": []
+    "admin_labels": [
+      "admin-approved:core-change"
+    ],
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": [
+      "changed_test_required"
+    ]
   },
   "runtime": "claude-code:claude-opus-5",
   "schema_version": 2,
@@ -140,7 +567,7 @@
     }
   ],
   "session_id": "7278a440-0cc5-4a88-b463-7c0f00c01733",
-  "strictness_tier": null,
+  "strictness_tier": 1,
   "task_kind": "feature",
   "test_events": [
     {

--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -149,6 +149,106 @@
       "status": "pass",
       "summary": "clean",
       "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:39:19.263760Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:83e3b61a67ef1910c4b0f3751fc0b13acc6859fa457c413289f304068feca29d",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:39:20.706268Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:dcb4520c288249d744f0dbaf087cb00a63ae26f1d4e9f39f9d1e35bacf75e3b8",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:39:20.735125Z",
+      "command": "ruff format src/scistudio/agent_provisioning/_orchestrate.py src/scistudio/agent_provisioning/codex_config.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py src/scistudio/ai/agent/mcp/tools_authoring.py src/scistudio/blocks/base/panel_contract.py src/scistudio/blocks/registry/__init__.py src/scistudio/blocks/registry/_capability.py src/scistudio/blocks/registry/_scan.py src/scistudio/workflow/validator.py tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/test_mcp_tools_authoring.py tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/tutorials/test_core_tutorial_what_is_a_type.py tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:3c60217d4bab42019251bd38a2ef2be73344cb856e4fd3b8ecba137471316d12",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:39:32.814471Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:a80c7e44a1a4d4fde682a4fc3a70c0ebde4f4d5dec8902d0ae040b648f5717d5",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-26T21:39:32.842641Z",
+      "command": "ruff check src/scistudio/agent_provisioning/_orchestrate.py src/scistudio/agent_provisioning/codex_config.py src/scistudio/agent_provisioning/hooks.py src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py src/scistudio/ai/agent/mcp/tools_authoring.py src/scistudio/blocks/base/panel_contract.py src/scistudio/blocks/registry/__init__.py src/scistudio/blocks/registry/_capability.py src/scistudio/blocks/registry/_scan.py src/scistudio/workflow/validator.py tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/test_mcp_tools_authoring.py tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/tutorials/test_core_tutorial_what_is_a_type.py tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:42badd763485022044c96f342553c83c9e9ee78b1ccee09d5f8d576971888ecf",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-26T21:40:04.652874Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread --no-cov tests/agent_provisioning tests/agent_provisioning/test_codex_config.py tests/agent_provisioning/test_hook_panel_contract_parity.py tests/agent_provisioning/test_hooks.py tests/agent_provisioning/test_orchestrate.py tests/ai/agent/mcp tests/ai/test_mcp_tools_authoring.py tests/blocks tests/blocks/test_interactive_adversarial_registry.py tests/blocks/test_panel_contract.py tests/blocks/test_registry_package_layout.py tests/blocks/test_registry_rejections.py tests/tutorials/test_core_tutorial_what_is_a_type.py tests/workflow tests/workflow/test_validator_panel_contract.py",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1dc0c14e983fbd7a582d084f9643c77612eef8622a16711487cf76da03718fcc",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
     }
   ],
   "check_na": [],
@@ -1023,6 +1123,200 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.735888Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.751691Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.767466Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.784211Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.806020Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.822507Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.838817Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.856137Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.872329Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.888675Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:04.915532Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1035,7 +1329,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
+    "base": "origin/main",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2196-feat-2196-interactive-contract-validation.json",
@@ -1062,11 +1356,12 @@
       "tests/blocks/test_panel_contract.py",
       "tests/blocks/test_registry_package_layout.py",
       "tests/blocks/test_registry_rejections.py",
+      "tests/tutorials/test_core_tutorial_what_is_a_type.py",
       "tests/workflow/test_validator_panel_contract.py"
     ],
-    "diff_fingerprint": "sha256:551765daec76c16d52e6dd0685a030a60e7c30173954ee8d491aaf322974dd60",
+    "diff_fingerprint": "sha256:77405819cf36bb79f4cc6530086c834d9e163315a071d7fe8c6576914b381785",
     "head": "HEAD",
-    "head_sha": "34236de9a",
+    "head_sha": "3ddecd87c",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -1076,8 +1371,8 @@
       "packaging": 0,
       "protected_architecture": 0,
       "protected_core": 5,
-      "sentrux": 21,
-      "test": 10,
+      "sentrux": 22,
+      "test": 11,
       "workflow_ci": 0
     }
   },
@@ -1119,6 +1414,14 @@
     {
       "at": "2026-08-26T21:25:45.551692Z",
       "diff_fingerprint": "sha256:551765daec76c16d52e6dd0685a030a60e7c30173954ee8d491aaf322974dd60",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:40:04.915576Z",
+      "diff_fingerprint": "sha256:77405819cf36bb79f4cc6530086c834d9e163315a071d7fe8c6576914b381785",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,
@@ -1266,6 +1569,14 @@
       "class": null,
       "kind": "path",
       "path": "tests/ai/test_mcp_tools_authoring.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-26T21:39:07.912986Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/tutorials/test_core_tutorial_what_is_a_type.py",
       "rationale": null,
       "verified_in_diff": null
     }

--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -153,9 +153,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "368f6b6092f532b76d3bb93357473199d8eee201",
+    "sha": "34236de9a22c35ce4d83ee755b8c58c5c6728802",
     "shas": [
-      "368f6b6092f532b76d3bb93357473199d8eee201"
+      "34236de9a22c35ce4d83ee755b8c58c5c6728802"
     ],
     "trailers": []
   },
@@ -635,6 +635,394 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.463055Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.477560Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.493230Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.507064Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.521164Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.536865Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.552188Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.566738Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.581677Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.599941Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:36.624024Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.390605Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.404892Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.419802Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.434827Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.450377Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.465091Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.480192Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.495555Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.511916Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.527300Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:45.551649Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -647,7 +1035,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2196-feat-2196-interactive-contract-validation.json",
@@ -676,9 +1064,9 @@
       "tests/blocks/test_registry_rejections.py",
       "tests/workflow/test_validator_panel_contract.py"
     ],
-    "diff_fingerprint": "sha256:d1225386fab2d73c8032b10cdad7a65e7a618730c999ac820780058ae2266c22",
+    "diff_fingerprint": "sha256:551765daec76c16d52e6dd0685a030a60e7c30173954ee8d491aaf322974dd60",
     "head": "HEAD",
-    "head_sha": "368f6b609",
+    "head_sha": "34236de9a",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -700,8 +1088,8 @@
     "closes": [
       2196
     ],
-    "number": null,
-    "url": null
+    "number": 2201,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2201"
   },
   "reconcile_events": [
     {
@@ -715,6 +1103,22 @@
     {
       "at": "2026-08-26T21:25:22.441638Z",
       "diff_fingerprint": "sha256:d1225386fab2d73c8032b10cdad7a65e7a618730c999ac820780058ae2266c22",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:25:36.624064Z",
+      "diff_fingerprint": "sha256:551765daec76c16d52e6dd0685a030a60e7c30173954ee8d491aaf322974dd60",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:25:45.551692Z",
+      "diff_fingerprint": "sha256:551765daec76c16d52e6dd0685a030a60e7c30173954ee8d491aaf322974dd60",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -152,7 +152,13 @@
     }
   ],
   "check_na": [],
-  "commit": null,
+  "commit": {
+    "sha": "368f6b6092f532b76d3bb93357473199d8eee201",
+    "shas": [
+      "368f6b6092f532b76d3bb93357473199d8eee201"
+    ],
+    "trailers": []
+  },
   "declared_scope": {
     "exclude": [],
     "include": [
@@ -435,6 +441,200 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.219843Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.235272Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.251884Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.266980Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.339162Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.355016Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.370618Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.386329Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.402364Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.417380Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:25:22.441596Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -476,9 +676,9 @@
       "tests/blocks/test_registry_rejections.py",
       "tests/workflow/test_validator_panel_contract.py"
     ],
-    "diff_fingerprint": "sha256:c6eed6efc3d0073c74630f07da7b47c23cbdd46632220aad8694c4fb1044bc2a",
+    "diff_fingerprint": "sha256:d1225386fab2d73c8032b10cdad7a65e7a618730c999ac820780058ae2266c22",
     "head": "HEAD",
-    "head_sha": "0480b3cc5",
+    "head_sha": "368f6b609",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -495,11 +695,26 @@
   },
   "owner_directive": "Manager dispatch A2 (#2196): validate the interactive block + panel contract statically at three agent-unavoidable surfaces (registry scan/reload_blocks, workflow validator, PostToolUse hook), emitting the same failure codes the frontend panel host shows. No JS runtime, no CLI entry point, no new MCP tool.",
   "persona": "implementer",
-  "pull_request": null,
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [
+      2196
+    ],
+    "number": null,
+    "url": null
+  },
   "reconcile_events": [
     {
       "at": "2026-08-26T21:25:07.829522Z",
       "diff_fingerprint": "sha256:c6eed6efc3d0073c74630f07da7b47c23cbdd46632220aad8694c4fb1044bc2a",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:25:22.441638Z",
+      "diff_fingerprint": "sha256:d1225386fab2d73c8032b10cdad7a65e7a618730c999ac820780058ae2266c22",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/.workflow/records/2196-feat-2196-interactive-contract-validation.json
+++ b/.workflow/records/2196-feat-2196-interactive-contract-validation.json
@@ -253,9 +253,9 @@
   ],
   "check_na": [],
   "commit": {
-    "sha": "34236de9a22c35ce4d83ee755b8c58c5c6728802",
+    "sha": "05e629767927219b686e164e85fd698a21bd59e0",
     "shas": [
-      "34236de9a22c35ce4d83ee755b8c58c5c6728802"
+      "05e629767927219b686e164e85fd698a21bd59e0"
     ],
     "trailers": []
   },
@@ -1317,6 +1317,200 @@
       "findings": [],
       "guard": "weakened_ci_check",
       "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.840600Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.856967Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/base/panel_contract.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/base/panel_contract.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/__init__.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/__init__.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_capability.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_capability.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/blocks/registry/_scan.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/blocks/registry/_scan.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        },
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "src/scistudio/workflow/validator.py",
+          "finding_class": "core_change_guard",
+          "git_evidence": null,
+          "id": "core_change_guard.missing-admin-approval",
+          "line": null,
+          "message": "protected core/runtime change requires admin-approved:core-change applied by an authorized maintainer or administrator approval",
+          "path": "src/scistudio/workflow/validator.py",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "core_change_guard.missing-admin-approval",
+          "severity": "warning",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.874080Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.890998Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.907651Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.921742Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.936572Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.952222Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.970943Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:19.987448Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-26T21:40:20.013948Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
     }
   ],
   "issues": [
@@ -1329,7 +1523,7 @@
   ],
   "observed_admin_labels": [],
   "observed_diff": {
-    "base": "origin/main",
+    "base": "2543d2e901261d43774f83cfbcaaa4cd4151ce2c",
     "base_sha": "2543d2e90",
     "changed_files": [
       ".workflow/records/2196-feat-2196-interactive-contract-validation.json",
@@ -1359,9 +1553,9 @@
       "tests/tutorials/test_core_tutorial_what_is_a_type.py",
       "tests/workflow/test_validator_panel_contract.py"
     ],
-    "diff_fingerprint": "sha256:77405819cf36bb79f4cc6530086c834d9e163315a071d7fe8c6576914b381785",
+    "diff_fingerprint": "sha256:6b99eeca4c6424dd6fd821c33bd7bd19db247d286fd2465d2951a1e19cd28b80",
     "head": "HEAD",
-    "head_sha": "3ddecd87c",
+    "head_sha": "05e629767",
     "surfaces": {
       "docs": 3,
       "frontend": 0,
@@ -1422,6 +1616,14 @@
     {
       "at": "2026-08-26T21:40:04.915576Z",
       "diff_fingerprint": "sha256:77405819cf36bb79f4cc6530086c834d9e163315a071d7fe8c6576914b381785",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-26T21:40:20.013992Z",
+      "diff_fingerprint": "sha256:6b99eeca4c6424dd6fd821c33bd7bd19db247d286fd2465d2951a1e19cd28b80",
       "mode": "pre-pr",
       "result": "pass",
       "tier": 1,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- [#2196] **An interactive block's panel is checked before it can break for
+  you.** An interactive block opens a window built from a small JavaScript
+  module the package ships beside it. Nothing checked that module, or the
+  manifest pointing at it, so a wrong URL, a missing file, or the wrong kind of
+  export all arrived the same way: the panel opened and immediately errored,
+  mid-run, with the reason nowhere you could see it.
+
+  All of those are now decided ahead of time — without running any JavaScript —
+  and reported using the same words the error would have used. A block whose
+  panel cannot mount is refused when the block library is scanned, and a
+  workflow containing one refuses to start rather than pausing on a broken
+  window. Editing a panel after the fact is caught too, which the scan alone
+  could not see. Checks that a text search cannot prove — that the panel's
+  confirm and cancel buttons are really wired — are reported as advice and never
+  block anything.
+
+  For anyone writing blocks with the in-app assistant, the same information now
+  comes back from reloading the block library: a block that was refused is
+  listed with the reason and the fix, instead of quietly not appearing. That
+  also covers every other reason a block can be refused, which used to be
+  equally silent. A new project hook warns right after a panel file is written.
+
 - [#2112] **Previews open as canvas tabs, and the Data tree opens files for
   preview.** The DataPreview panel's maximize button used to float the preview
   over the workspace as an overlay; it now opens the preview as a tab in the

--- a/docs/agent-provisioning.md
+++ b/docs/agent-provisioning.md
@@ -25,6 +25,7 @@ the first time it is created or opened:
       remind_poll_status.py                # PostToolUse / run_workflow — stderr reminder to poll
       mark_list_blocks_called.py           # PostToolUse / list_blocks — writes session marker
       enforce_concrete_port_types.py       # PostToolUse — stderr-warns on DataObject ports
+      check_panel_contract.py              # PostToolUse — stderr-warns on a broken interactive panel .js/.mjs
     skills/                                  # 6 task-scoped Claude Code skills (flat — one level only)
       scistudio/SKILL.md                     # base index
       scistudio-build-workflow/SKILL.md

--- a/docs/package-development/blocks.md
+++ b/docs/package-development/blocks.md
@@ -141,6 +141,52 @@ def get_block_package() -> tuple[PackageInfo, list[type]]:
 `PackageInfo` (from `scistudio.blocks.base`) carries your package name, version,
 and update channel. See [publishing.md](publishing.md) for wiring it up.
 
+## Interactive blocks ship a panel, and the panel is checked
+
+A block becomes interactive by mixing in `InteractiveMixin`, declaring
+`execution_mode = ExecutionMode.INTERACTIVE`, and naming the window it opens in
+a `PanelManifest`. A package-provided panel is a plain ES module you ship beside
+the block:
+
+```python
+interactive_panel: ClassVar[PanelManifest] = PanelManifest(
+    panel_id="myplugin.review_labels",
+    module_url="/api/blocks/panels/myplugin.review_labels/panel.mjs",
+    asset_root=str(Path(__file__).resolve().parent / "review_labels_panel"),
+)
+```
+
+Both halves are validated, statically, before your block ever runs — at registry
+scan, at workflow validation, and by a write-time hook in the AI project. What
+each of them requires:
+
+| The manifest | Why |
+|---|---|
+| `module_url` is site-relative and spelled `/api/blocks/panels/<panel_id>/<file>` | It is the panel asset route; any other shape 404s. `panel_id` must be the manifest's own |
+| `asset_root` is a directory that ships with the package | The route serves the module path-confined under it and nowhere else |
+| the file `module_url` names exists under `asset_root` | A URL naming nothing is the `import_failed` the user sees as a modal that opens and errors |
+| its suffix is one the route serves (`.js`, `.mjs`, `.css`, `.map`, `.json`, `.svg`, `.woff`, `.woff2`) | Anything else is refused before it is read |
+| `api_version` majors match the host's | The host refuses the manifest before importing |
+
+| The module | Why |
+|---|---|
+| it exports the name `export_name` names (`default` unless you say otherwise) | The host imports exactly that name — named exports against the default is the most common mistake |
+| that export carries `apiVersion` and `mount` | The host's `PanelModule` guard refuses anything else |
+| `apiVersion`'s major matches the host's | Checked again on the module, not only the manifest |
+| it imports nothing off-origin | No remote or inline code is ever loaded |
+
+Three more are checked and reported as advisories, never as errors, because a
+text search finds a name and not a binding: `mount()` returning something with
+an `unmount`, and the module calling `host.confirm(...)` and `host.cancel()`.
+Wire both controls anyway — they are how the paused run resumes or stops.
+
+A block whose *manifest or module* fails a hard check is refused at scan time
+and does not appear in the palette. If you are writing one through the in-app
+agent, `reload_blocks` returns it in `rejected` with the reason and the repair.
+
+A core panel — one the app bundles — carries only a `panel_id` and no
+`module_url`; that is the one shape with nothing to check.
+
 ## Next
 
 [previewers.md](previewers.md) — show your types in the inspector.

--- a/docs/specs/adr-051-interactive-blocks.md
+++ b/docs/specs/adr-051-interactive-blocks.md
@@ -250,6 +250,52 @@ each is rejected at scan time; cancel a paused interaction and assert the block 
   identity needed to resolve the panel manifest, independent of whether other
   lifecycle events carry `block_type` (the known #1452/#1454 drift).
 
+#### Panel contract validation (#2196)
+
+FR-002 binds the capability to the execution mode and requires a manifest. It
+says nothing about the window that manifest names, so every way of getting the
+panel wrong reached the user as a modal that opened and immediately errored,
+with the reason visible only in the browser. All of them are statically
+decidable.
+
+- **FR-016**: One implementation MUST decide whether a panel manifest and the
+  module it names can produce a mountable window, without executing the module.
+  It MUST check, deterministically: `module_url` is site-relative and shaped
+  `/api/blocks/panels/<panel_id>/<file>` with a `panel_id` matching the
+  manifest; `asset_root` is set and is an existing directory; the file
+  `module_url` names resolves under `asset_root` with a suffix the asset route
+  serves; declared `css` entries are same-origin; the manifest's `api_version`
+  major matches `PANEL_API_VERSION`. It MUST check, statically over the module
+  source: an export matching `export_name` exists, that export carries
+  `apiVersion` and `mount`, the module's `apiVersion` major matches, and no
+  import is off-origin. Every diagnostic MUST name the failure code the frontend
+  panel host reports for the same fault. A core panel — bundled with the app and
+  resolved from the frontend's built-in registry — carries no `module_url` and
+  MUST validate clean.
+- **FR-017**: The checks MUST carry two severities. A certain runtime failure
+  (the deterministic manifest and filesystem checks; a missing export,
+  `apiVersion`, or `mount`; an off-origin import) is a hard error that refuses
+  the block and invalidates the workflow. A heuristic finding — `unmount`,
+  `host.confirm`, and `host.cancel` not found — MUST be advisory and MUST NOT
+  block. Proving that a control is bound to a DOM element requires a JavaScript
+  runtime the backend deliberately does not have; the host-owned escape hatch
+  (#2195) is the guarantee that covers it. A CSS entry naming a file that is not
+  on disk is likewise advisory: the panel host injects stylesheets best-effort
+  and mounts without them.
+- **FR-018**: The checks MUST be surfaced at three points an authoring agent
+  cannot route around, and MUST NOT require a tool the agent has to remember to
+  call. (1) The registry scan refuses a hard-invalid block and MUST report the
+  refusal — reasons and repair, per block — through `reload_blocks`, which MUST
+  do the same for every other scan-time rejection rather than dropping blocks
+  silently. (2) `validate_workflow` MUST re-run the checks against every
+  interactive node, so a panel edited or deleted after registration is caught
+  before a run reaches the pause; hard errors invalidate the workflow and
+  advisories use the `Warning:` prefix. (3) A provisioned PostToolUse hook MUST
+  fire on a written panel `.js`/`.mjs` file and warn on stderr. The hook runs
+  under the base interpreter and so MUST NOT import `scistudio`; its
+  transcription of the source checks MUST be held to the shared implementation
+  by test.
+
 ### Key Entities
 
 - **InteractiveMixin**: The capability mixed into a block to make it interactive.

--- a/src/scistudio/agent_provisioning/_orchestrate.py
+++ b/src/scistudio/agent_provisioning/_orchestrate.py
@@ -116,6 +116,7 @@ def install_project_agent_assets(
                 ".claude/hooks/remind_poll_status.py",
                 ".claude/hooks/mark_list_blocks_called.py",
                 ".claude/hooks/enforce_concrete_port_types.py",
+                ".claude/hooks/check_panel_contract.py",
             ],
         ),
         (

--- a/src/scistudio/agent_provisioning/codex_config.py
+++ b/src/scistudio/agent_provisioning/codex_config.py
@@ -101,6 +101,11 @@ _POST_HOOKS: tuple[tuple[str, str, str], ...] = (
         "enforce_concrete_port_types.py",
         "Checking port types for §3.2a compliance",
     ),
+    (
+        "^(Edit|Write|MultiEdit|apply_patch)$",
+        "check_panel_contract.py",
+        "Checking the interactive panel module contract (ADR-051)",
+    ),
 )
 
 

--- a/src/scistudio/agent_provisioning/hooks.py
+++ b/src/scistudio/agent_provisioning/hooks.py
@@ -1,6 +1,6 @@
 """Write project-scoped hook config + scripts (ADR-040 §3.6).
 
-Provisions ``<project>/.claude/settings.json`` and the 7 hook scripts at
+Provisions ``<project>/.claude/settings.json`` and the 8 hook scripts at
 ``<project>/.claude/hooks/`` for Claude Code's hook system.
 
 Per ADR §3.6 (matcher list expanded with ``MultiEdit`` per Codex P1
@@ -14,11 +14,16 @@ tool name; omitting it leaves a bypass path):
     - hook_enforce_list_blocks_before_block_write.py
         (matcher: Edit|Write|MultiEdit|Bash|mcp__scistudio__scaffold_block)
 
-  PostToolUse (3):
+  PostToolUse (4):
     - hook_remind_poll_status.py                    (matcher: mcp__scistudio__run_workflow)
     - hook_mark_list_blocks_called.py               (matcher: mcp__scistudio__list_blocks)
     - hook_enforce_concrete_port_types.py
         (matcher: Edit|Write|MultiEdit|mcp__scistudio__scaffold_block)
+    - hook_check_panel_contract.py                  (matcher: Edit|Write|MultiEdit)
+        ADR-051 / #2196: an interactive block's panel is a ``.js``/``.mjs``
+        module beside the block, and no hook matched it — the block-write hook
+        matches Python block files only. Every way of getting a panel wrong
+        therefore reached the user as a modal that opened and errored.
 
 Hook scripts read JSON from stdin (Claude Code's hook stdin contract);
 exit code 2 blocks the tool call (PreToolUse only); exit code 0 passes.
@@ -102,6 +107,7 @@ _HOOK_FILES: tuple[tuple[str, str], ...] = (
     ("hook_remind_poll_status.py", "remind_poll_status.py"),
     ("hook_mark_list_blocks_called.py", "mark_list_blocks_called.py"),
     ("hook_enforce_concrete_port_types.py", "enforce_concrete_port_types.py"),
+    ("hook_check_panel_contract.py", "check_panel_contract.py"),
 )
 
 
@@ -158,6 +164,11 @@ def _build_settings_json(hooks_dir_rel: str, project_dir_var: str = _CLAUDE_PROJ
             "Edit|Write|MultiEdit|mcp__scistudio__scaffold_block",
             "enforce_concrete_port_types.py",
         ),
+        # #2196: panel modules are written with the plain file tools; there is
+        # no MCP tool that produces one, so the file-tool matcher is the whole
+        # coverage. The script itself decides whether the written file is a
+        # panel (suffix + path/content), because a matcher cannot.
+        ("Edit|Write|MultiEdit", "check_panel_contract.py"),
     ]
 
     def _entry(matcher: str, script: str) -> dict:
@@ -523,7 +534,7 @@ def write_hooks(
     """Write the project-scope hook settings for every hook-capable provider.
 
     Writes ``<project>/.claude/settings.json`` (Claude Code),
-    ``<project>/.qoder/settings.json`` (both Qoder channels) and the seven
+    ``<project>/.qoder/settings.json`` (both Qoder channels) and the eight
     shared hook scripts under ``<project>/.claude/hooks/``. Codex's hook
     declarations live in ``<project>/.codex/config.toml`` and are written by
     :mod:`scistudio.agent_provisioning.codex_config`.

--- a/src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py
+++ b/src/scistudio/agent_provisioning/templates/hook_check_panel_contract.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+"""hook_check_panel_contract.py — PostToolUse (ADR-040 §3.6, ADR-051, #2196).
+
+After a write touched an interactive block's panel module — a ``.js`` or
+``.mjs`` file — check it against the ``PanelModule`` contract the frontend panel
+host enforces, and stderr-warn so the next turn corrects it.
+
+**Why this hook exists.** The other write-time block hook matches
+``(?:^|/)blocks/[^/]+\\.py$`` (``hook_enforce_list_blocks_before_block_write.py``),
+so a hand-written panel module was touched by no hook at all. Every way of
+getting a panel wrong therefore travelled all the way to the user as a modal
+that opened and immediately errored, with the reason visible only in the
+browser. Each finding below names the same failure code
+``panelModuleLoader.ts`` would show, so the author's vocabulary and the user's
+error text agree.
+
+**Why the rules are transcribed rather than imported.** Every provisioned hook
+script runs under the *base* interpreter and imports the standard library and
+nothing else — that is what makes
+``scistudio.agent_provisioning.hooks.hook_interpreter`` safe to freeze into a
+command that must outlive the venv it was written in. A hook that imported
+``scistudio`` would die, silently and fail-open, wherever that interpreter
+cannot see the package. So the source checks are transcribed from
+``scistudio.blocks.base.panel_contract`` and
+``tests/agent_provisioning/test_hook_panel_contract_parity.py`` fails if the
+two ever disagree on a fixture — the transcription cannot drift unnoticed.
+
+**What is not checked here.** The manifest half — ``module_url`` shape,
+``asset_root``, whether the file the URL names is on disk — lives in the Python
+block class, not in the file that was just written, so the registry scan and the
+workflow validator own it. This hook sees only the module's text.
+
+**What cannot be checked at all.** Whether a confirm control is actually bound
+to a DOM element needs a JavaScript runtime; the backend depends on none and
+this hook introduces none. ``host.confirm`` / ``host.cancel`` / ``unmount``
+findings are therefore advisory. That is a stated limit of static checking, not
+deferred work — the host-owned escape hatch (#2195) is the guarantee that
+covers it.
+
+Always exits 0 (PostToolUse cannot block).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# Mirrors ``scistudio.blocks.base.interactive.PANEL_API_VERSION``. The parity
+# test asserts the two are equal.
+PANEL_API_VERSION = "1"
+
+SEVERITY_ERROR = "error"
+SEVERITY_WARNING = "warning"
+
+CODE_IMPORT_FAILED = "import_failed"
+CODE_EXPORT_MISSING = "export_missing"
+CODE_NOT_A_PANEL_MODULE = "not_a_panel_module"
+CODE_API_VERSION_MISMATCH = "api_version_mismatch"
+CODE_MOUNT_FAILED = "mount_failed"
+CODE_PANEL_CONTROL_MISSING = "panel_control_missing"
+
+_REMOTE_PREFIXES = ("http://", "https://", "//", "data:", "file:")
+
+_PANEL_SUFFIXES = (".js", ".mjs")
+
+#: A written ``.js``/``.mjs`` file is treated as a panel when its path says so.
+#: Paired with the ``apiVersion`` content test below, this keeps the hook off
+#: ordinary project JavaScript that happens to declare a ``mount`` function.
+_PANEL_PATH_RE = re.compile(r"panel", re.IGNORECASE)
+
+_API_VERSION_LITERAL_RE = re.compile(r"""\bapiVersion\b\s*[:=]\s*(['"])([^'"]*)\1""")
+_API_VERSION_KEY_RE = re.compile(r"\bapiVersion\b")
+_MOUNT_RE = re.compile(r"\bmount\b\s*[:(=]")
+_MOUNT_HOST_PARAM_RE = re.compile(
+    r"\bmount\b\s*[:=]?\s*(?:async\s+)?(?:function\s*\*?\s*)?\(\s*[A-Za-z_$][\w$]*\s*,\s*([A-Za-z_$][\w$]*)"
+)
+_UNMOUNT_RE = re.compile(r"\bunmount\b")
+_EXPORT_STAR_RE = re.compile(r"\bexport\s*\*")
+_EXPORT_DEFAULT_RE = re.compile(r"\bexport\s+default\b")
+_STATIC_IMPORT_RE = re.compile(r"""\bimport\b(?:[^;'"()]*?\bfrom\b\s*)?(['"])([^'"]+)\1""")
+_DYNAMIC_IMPORT_RE = re.compile(r"""\bimport\s*\(\s*(['"])([^'"]+)\1""")
+_EXPORT_FROM_RE = re.compile(r"""\bexport\b[^;'"]*?\bfrom\b\s*(['"])([^'"]+)\1""")
+
+
+def _read_payload() -> dict:
+    """Read the hook payload, degrading to ``{}`` instead of ever crashing.
+
+    #1994: this used to guard only ``OSError``. When a CLI starts a hook with
+    no usable stdin, Python sets ``sys.stdin`` to ``None``, so
+    ``sys.stdin.read()`` raised ``AttributeError`` — which nothing caught. The
+    hook died with **exit 1** before evaluating anything, which the CLI reports
+    as a failed hook and then proceeds, so the guard silently did not guard.
+    It reproduced identically for all seven hooks, because they all share this
+    function.
+
+    An unreadable payload is indistinguishable from an empty one: in both cases
+    the hook cannot tell what the agent is about to do. It returns ``{}`` and
+    the caller allows the call, which is the behaviour an empty payload already
+    had — and blocking every tool call on a stdin quirk would be far worse than
+    the exposure it removes. ``BaseException`` is deliberately not caught; only
+    the ways reading a missing or closed stream can fail.
+    """
+    stream = sys.stdin
+    if stream is None:
+        return {}
+    try:
+        raw = stream.read()
+    except (OSError, ValueError, AttributeError):
+        # ValueError: reading a closed file. AttributeError: a replaced stdin
+        # that is not a stream at all.
+        return {}
+    if not isinstance(raw, str) or not raw.strip():
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except json.JSONDecodeError:
+        return {}
+
+
+def _target_file(payload: dict) -> Path | None:
+    """The ``.js``/``.mjs`` file this tool call wrote, if it wrote one."""
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return None
+    candidate = str(tool_input.get("file_path") or "")
+    if not candidate:
+        return None
+    if not candidate.replace("\\", "/").lower().endswith(_PANEL_SUFFIXES):
+        return None
+
+    path = Path(candidate)
+    if not path.is_absolute():
+        project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or os.environ.get("QODER_PROJECT_DIR")
+        if project_dir:
+            path = Path(project_dir) / candidate
+    if not path.is_file():
+        return None
+    return path
+
+
+def _is_panel_module(path: Path, source: str) -> bool:
+    """Whether this file is plausibly an interactive panel module.
+
+    Either the path says so (a panel lives in a ``panels/`` directory or is
+    named ``panel.mjs`` — both are what the scaffolding and the docs produce),
+    or the text declares the ``apiVersion`` no other kind of module carries.
+    A file that is neither is ordinary project JavaScript and is left alone;
+    warning about it would train the author to ignore this hook.
+    """
+    if _PANEL_PATH_RE.search(str(path).replace("\\", "/")):
+        return True
+    return bool(_API_VERSION_KEY_RE.search(source))
+
+
+def strip_js_comments(source: str) -> str:
+    """Remove ``//`` and ``/* */`` comments from JavaScript *source*.
+
+    Transcribed from ``scistudio.blocks.base.panel_contract.strip_js_comments``.
+    """
+    out: list[str] = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        if char == "/" and index + 1 < length:
+            following = source[index + 1]
+            if following == "/" and not (index > 0 and source[index - 1] == ":"):
+                newline = source.find("\n", index)
+                if newline == -1:
+                    break
+                index = newline
+                continue
+            if following == "*":
+                end = source.find("*/", index + 2)
+                index = length if end == -1 else end + 2
+                continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _major(version: str) -> str:
+    return version.split(".")[0].strip()
+
+
+def _is_remote_url(url: str) -> bool:
+    lowered = url.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in _REMOTE_PREFIXES)
+
+
+def _named_export_re(export_name: str) -> re.Pattern:
+    name = re.escape(export_name)
+    return re.compile(
+        r"\bexport\s+(?:async\s+)?(?:const|let|var|function\s*\*?|class)\s+" + name + r"\b"
+        r"|\bexport\s*\{[^}]*\b" + name + r"\b[^}]*\}"
+    )
+
+
+def _has_export(source: str, export_name: str) -> bool:
+    if _EXPORT_STAR_RE.search(source):
+        return True
+    if export_name == "default":
+        if _EXPORT_DEFAULT_RE.search(source):
+            return True
+        return bool(re.search(r"\bexport\s*\{[^}]*\bas\s+default\b[^}]*\}", source))
+    return bool(_named_export_re(export_name).search(source))
+
+
+def _host_binding_names(source: str) -> set:
+    names = {"host"}
+    names.update(match.group(1) for match in _MOUNT_HOST_PARAM_RE.finditer(source))
+    return names
+
+
+def _references_host_control(source: str, control: str) -> bool:
+    escaped = re.escape(control)
+    for binding in _host_binding_names(source):
+        name = re.escape(binding)
+        if re.search(r"\b" + name + r"\s*\.\s*" + escaped + r"\b", source):
+            return True
+        if re.search(r"\{[^{}]*\b" + escaped + r"\b[^{}]*\}\s*=\s*" + name + r"\b", source):
+            return True
+    return False
+
+
+def _remote_import_specifiers(source: str) -> list[str]:
+    found: list[str] = []
+    for pattern in (_STATIC_IMPORT_RE, _DYNAMIC_IMPORT_RE, _EXPORT_FROM_RE):
+        for match in pattern.finditer(source):
+            specifier = match.group(2)
+            if _is_remote_url(specifier) and specifier not in found:
+                found.append(specifier)
+    return found
+
+
+def check_panel_module_source(
+    source: str,
+    export_name: str = "default",
+    api_version: str = PANEL_API_VERSION,
+) -> list[tuple[str, str, str, str]]:
+    """Return ``(code, severity, message, fix)`` for each finding in *source*.
+
+    A stdlib transcription of
+    ``scistudio.blocks.base.panel_contract.check_panel_module_source``. The
+    parity test compares the two tuple-for-tuple over a fixture corpus, so the
+    strings below must stay byte-identical to the ones there.
+    """
+    stripped = strip_js_comments(source)
+    findings: list[tuple[str, str, str, str]] = []
+    name = export_name or "default"
+
+    if not _has_export(stripped, name) and not _has_export(source, name):
+        findings.append(
+            (
+                CODE_EXPORT_MISSING,
+                SEVERITY_ERROR,
+                f"the module declares no export named {name!r}, which is what the host imports.",
+                (
+                    "Add `export default { apiVersion, mount }`, or set export_name on the "
+                    "PanelManifest to a name the module does export."
+                    if name == "default"
+                    else f"Add `export const {name} = {{ apiVersion, mount }}`, or set export_name "
+                    "on the PanelManifest to a name the module does export."
+                ),
+            )
+        )
+
+    has_api_version = bool(_API_VERSION_KEY_RE.search(stripped) or _API_VERSION_KEY_RE.search(source))
+    has_mount = bool(_MOUNT_RE.search(stripped) or _MOUNT_RE.search(source))
+    if not has_api_version or not has_mount:
+        missing = " and ".join(
+            part for part, present in (("apiVersion", has_api_version), ("mount", has_mount)) if not present
+        )
+        findings.append(
+            (
+                CODE_NOT_A_PANEL_MODULE,
+                SEVERITY_ERROR,
+                f"the module never mentions {missing}; the host refuses an export that is not a PanelModule.",
+                (
+                    'Export an object carrying both, e.g. `export default { apiVersion: "'
+                    + api_version
+                    + '", mount(container, host) { ... } }`.'
+                ),
+            )
+        )
+
+    literal = _API_VERSION_LITERAL_RE.search(stripped) or _API_VERSION_LITERAL_RE.search(source)
+    if literal is not None:
+        declared = literal.group(2)
+        if _major(declared) != _major(api_version):
+            findings.append(
+                (
+                    CODE_API_VERSION_MISMATCH,
+                    SEVERITY_ERROR,
+                    (
+                        f"the module declares apiVersion {declared!r}, whose major does not match "
+                        f"the host's {api_version!r}."
+                    ),
+                    f'Set apiVersion to "{api_version}" (or a matching major).',
+                )
+            )
+
+    if not _UNMOUNT_RE.search(stripped):
+        findings.append(
+            (
+                CODE_MOUNT_FAILED,
+                SEVERITY_WARNING,
+                "no `unmount` appears in the module; mount() must return an object carrying one.",
+                "Return `{ unmount() { ... } }` from mount() so the host can tear the panel down.",
+            )
+        )
+
+    missing_controls = [control for control in ("confirm", "cancel") if not _references_host_control(stripped, control)]
+    if missing_controls:
+        joined = " or ".join(f"host.{control}" for control in missing_controls)
+        findings.append(
+            (
+                CODE_PANEL_CONTROL_MISSING,
+                SEVERITY_WARNING,
+                f"the module never references {joined}, so the run may have no way to resume or stop.",
+                "Call host.confirm(response) from the panel's confirm control and host.cancel() from its cancel control.",
+            )
+        )
+
+    for specifier in _remote_import_specifiers(stripped):
+        findings.append(
+            (
+                CODE_IMPORT_FAILED,
+                SEVERITY_ERROR,
+                f"the module imports {specifier!r} from off-origin; the panel host loads same-origin code only.",
+                "Vendor the dependency into the panel's asset_root and import it by a relative path.",
+            )
+        )
+
+    return findings
+
+
+def _format_message(target: Path, code: str, severity: str, message: str, fix: str) -> str:
+    label = "ERROR" if severity == SEVERITY_ERROR else "warning"
+    return f"Panel {label} [{code}] {target}: {message} Fix: {fix}"
+
+
+def main() -> int:
+    target = _target_file(_read_payload())
+    if target is None:
+        return 0
+    try:
+        source = target.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return 0
+    if not _is_panel_module(target, source):
+        return 0
+    for code, severity, message, fix in check_panel_module_source(source):
+        print(_format_message(target, code, severity, message, fix), file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scistudio/ai/agent/mcp/tools_authoring.py
+++ b/src/scistudio/ai/agent/mcp/tools_authoring.py
@@ -80,12 +80,27 @@ class ScaffoldBlockResult(BaseModel):
     )
 
 
+class RejectedBlock(BaseModel):
+    """One block the reload refused, and what to change (#2196)."""
+
+    block: str = Field(description="Block class name, or the file stem when the module never imported.")
+    reasons: list[str] = Field(default_factory=list, description="One line per distinct fault.")
+    fix: str = Field(default="", description="What to change to make the block register.")
+
+
 class ReloadBlocksResult(BaseModel):
     """Result envelope for ``reload_blocks``."""
 
     reloaded: int = Field(description="Total number of block types after reload.")
     added: list[str] = Field(default_factory=list, description="Newly added block type names.")
     removed: list[str] = Field(default_factory=list, description="Removed block type names.")
+    rejected: list[RejectedBlock] = Field(
+        default_factory=list,
+        description=(
+            "Blocks the scan refused, with the reason and the repair. A block you just wrote that "
+            "does not appear in list_blocks is here."
+        ),
+    )
     next_step: str = Field(
         default=(
             "Call mcp__scistudio__list_blocks to confirm the new block is registered, "
@@ -441,12 +456,33 @@ async def reload_blocks() -> ReloadBlocksResult:
     #9: the broadcast keeps connected GUI clients' palette and schemas current
     right after the agent edits and reloads a custom block, instead of the user
     having to hit palette reload.
+
+    #2196: a block the scan refuses is reported in ``rejected`` with the reason
+    and the repair, instead of simply not appearing in ``list_blocks``. That
+    makes the ordinary ``write -> reload_blocks -> list_blocks`` loop a
+    validation loop with no new tool and no new step: if ``rejected`` is empty
+    the block registered, and if it is not, every entry says what to change.
     """
     ctx = get_context()
     added, removed = refresh_context_registries(ctx)
-    logger.info("reload_blocks: added=%s removed=%s", added, removed)
+    rejected = [
+        RejectedBlock(block=rejection.block, reasons=list(rejection.reasons), fix=rejection.fix)
+        for rejection in ctx.block_registry.rejections()
+    ]
+    logger.info("reload_blocks: added=%s removed=%s rejected=%d", added, removed, len(rejected))
     await broadcast_blocks_reloaded(ctx, added=added, removed=removed)
-    return ReloadBlocksResult(reloaded=len(ctx.block_registry.all_specs()), added=added, removed=removed)
+    return ReloadBlocksResult(
+        reloaded=len(ctx.block_registry.all_specs()),
+        added=added,
+        removed=removed,
+        rejected=rejected,
+        next_step=(
+            "Fix the blocks in `rejected` — each carries the reason and the repair — then call "
+            "mcp__scistudio__reload_blocks again."
+            if rejected
+            else ReloadBlocksResult.model_fields["next_step"].default
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/scistudio/blocks/base/panel_contract.py
+++ b/src/scistudio/blocks/base/panel_contract.py
@@ -1,0 +1,731 @@
+"""Static validation of an interactive block's panel contract (ADR-051, #2196).
+
+An interactive block declares a :class:`~scistudio.blocks.base.interactive.PanelManifest`
+naming a JavaScript module the frontend panel host imports and mounts. Nothing
+checked that module or the manifest that points at it, so every way of getting
+it wrong reached the user as a modal that opened and immediately errored — with
+the reason living only in the browser. Every one of those failures is decidable
+without running the module, and this is where that decision is made once.
+
+**One implementation, three surfaces.** The registry scan
+(:func:`scistudio.blocks.registry._capability._validate_interactive_capability`)
+refuses a hard-invalid block and reports why through ``reload_blocks``;
+:func:`scistudio.workflow.validator.validate_workflow` refuses a workflow whose
+interactive block is hard-invalid before the run reaches a pause; and the
+provisioned ``check_panel_contract`` PostToolUse hook warns right after a panel
+module is written. The hook is the one that cannot import this module — every
+provisioned hook script runs under the *base* interpreter and imports the
+standard library and nothing else (see
+:func:`scistudio.agent_provisioning.hooks.hook_interpreter`) — so it carries a
+stdlib transcription of the source checks below, and
+``tests/agent_provisioning/test_hook_panel_contract_parity.py`` fails if the two
+ever disagree on a fixture.
+
+**Placement.** This module sits beside :mod:`scistudio.blocks.base.interactive`,
+which owns :class:`PanelManifest` and :data:`PANEL_API_VERSION` — the contract
+being validated. It imports that module and the standard library, nothing else,
+so the registry, the workflow validator, and the tests can all import it without
+a cycle: ``blocks.base.interactive`` imports neither the registry nor the
+workflow package. It deliberately does **not** import
+:mod:`scistudio.previewers.assets` for the asset-suffix allowlist, because that
+would drag the whole preview subsystem (registry, router, sessions) into the
+block-scan path for one frozen set; :data:`_ALLOWED_ASSET_SUFFIXES` is copied
+here and ``tests/blocks/test_panel_contract.py`` asserts the copy still equals
+the original.
+
+**Vocabulary.** Every diagnostic names the failure code the panel host would
+show the user (``frontend/src/App.parts/InteractiveModals.parts/panelModuleLoader.ts``),
+so the authoring agent reads the same word the user's error text will say. The
+one exception is :data:`CODE_PANEL_CONTROL_MISSING`, which has no frontend
+counterpart because the frontend cannot detect it either — a panel that never
+calls ``host.confirm`` strands the user rather than failing.
+
+**Two severities.** A hard error is a failure that is certain: the manifest or
+the file it names cannot produce a mountable module. An advisory (``warning``)
+is a heuristic: a text search cannot prove a control is wired to a button, so
+those never block. The module is never executed — the backend depends on no
+JavaScript runtime and this does not introduce one.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from scistudio.blocks.base.interactive import PANEL_API_VERSION
+
+# --------------------------------------------------------------------------
+# Vocabulary shared with the frontend panel host.
+# --------------------------------------------------------------------------
+
+SEVERITY_ERROR = "error"
+"""A certain runtime failure. Rejects the block and invalidates the workflow."""
+
+SEVERITY_WARNING = "warning"
+"""A heuristic finding. Reported, never blocking."""
+
+CODE_INVALID_MODULE_URL = "invalid_module_url"
+CODE_REMOTE_URL_REJECTED = "remote_url_rejected"
+CODE_IMPORT_FAILED = "import_failed"
+CODE_EXPORT_MISSING = "export_missing"
+CODE_NOT_A_PANEL_MODULE = "not_a_panel_module"
+CODE_API_VERSION_MISMATCH = "api_version_mismatch"
+CODE_MOUNT_FAILED = "mount_failed"
+CODE_PANEL_CONTROL_MISSING = "panel_control_missing"
+"""Advisory-only. No frontend counterpart: a panel with no confirm/cancel
+control does not fail to mount, it strands the user. The host-owned escape
+hatch (#2195) is the guarantee that covers it."""
+
+#: URL prefixes that are off-origin and refused before any import is attempted.
+#: Mirrors ``_REMOTE_PREFIXES`` in :mod:`scistudio.previewers.assets`.
+_REMOTE_PREFIXES = ("http://", "https://", "//", "data:", "file:")
+
+#: Asset suffixes the panel route will serve. Copy of
+#: ``scistudio.previewers.assets._ALLOWED_ASSET_SUFFIXES``; the copy is checked
+#: against the original by test rather than imported (see the module docstring).
+_ALLOWED_ASSET_SUFFIXES = frozenset({".js", ".mjs", ".css", ".map", ".json", ".svg", ".woff", ".woff2"})
+
+#: Router prefix + route of ``serve_panel_asset``
+#: (``src/scistudio/api/routes/blocks.py``). A ``module_url`` that does not take
+#: this shape resolves to no route at all and 404s.
+_PANEL_ROUTE_TEMPLATE = "/api/blocks/panels/{panel_id}/"
+
+#: Panel ids the app ships and the frontend resolves from its built-in registry
+#: (``InteractiveModals.tsx``) rather than by importing a module. They carry no
+#: ``module_url`` by design.
+_CORE_PANEL_ID_PREFIX = "core."
+
+
+@dataclass(frozen=True)
+class PanelDiagnostic:
+    """One finding about an interactive block's panel contract.
+
+    ``code`` is the frontend failure code the same fault would surface as, so a
+    diagnostic and the user's error text use the same word.
+    """
+
+    code: str
+    """Frontend failure code (see the module docstring)."""
+    severity: str
+    """:data:`SEVERITY_ERROR` or :data:`SEVERITY_WARNING`."""
+    message: str
+    """What is wrong, in one line."""
+    fix: str
+    """What to change to make it right."""
+
+    @property
+    def is_error(self) -> bool:
+        """Whether this finding is a certain failure that must block."""
+        return self.severity == SEVERITY_ERROR
+
+    def render(self) -> str:
+        """One-line rendering carrying the code, the fault, and the repair."""
+        return f"panel {self.code}: {self.message} Fix: {self.fix}"
+
+
+def has_errors(diagnostics: Iterable[PanelDiagnostic]) -> bool:
+    """Whether *diagnostics* contains at least one blocking finding."""
+    return any(diagnostic.is_error for diagnostic in diagnostics)
+
+
+# --------------------------------------------------------------------------
+# Manifest and filesystem checks — deterministic.
+# --------------------------------------------------------------------------
+
+
+def is_remote_url(url: str) -> bool:
+    """Whether *url* points off-origin and is refused by the panel host."""
+    lowered = url.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in _REMOTE_PREFIXES)
+
+
+def _major(version: str) -> str:
+    return version.split(".")[0].strip()
+
+
+def _resolve_asset(asset_root: str, relative_path: str) -> Path | None:
+    """Resolve *relative_path* under *asset_root*, or ``None`` if it escapes.
+
+    Mirrors :func:`scistudio.previewers.assets.resolve_asset`'s confinement so
+    this check and the route that serves the file agree about which paths exist.
+    """
+    root = Path(asset_root).resolve()
+    candidate = (root / relative_path.lstrip("/\\")).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    return candidate
+
+
+def _check_asset_url(
+    *,
+    url: str,
+    panel_id: str,
+    asset_root: str | None,
+    label: str,
+    missing_severity: str,
+) -> tuple[list[PanelDiagnostic], Path | None]:
+    """Check one declared asset URL, returning findings and the resolved file.
+
+    Shared by ``module_url`` and each ``css`` entry: both must be site-relative,
+    take the panel route's shape, and resolve to an allowed file confined under
+    ``asset_root``. They differ only in what a missing file means, which is
+    *missing_severity* — a module that is not there cannot mount, while the host
+    injects a stylesheet best-effort and mounts the panel without it
+    (``injectManifestCss`` in ``panelModuleLoader.ts``).
+    """
+    if is_remote_url(url):
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_REMOTE_URL_REJECTED,
+                    severity=SEVERITY_ERROR,
+                    message=f"{label} {url!r} is not same-origin; the panel host refuses remote code.",
+                    fix=(
+                        "Ship the file inside the package and point the URL at "
+                        f"{_PANEL_ROUTE_TEMPLATE.format(panel_id=panel_id)}<file>."
+                    ),
+                )
+            ],
+            None,
+        )
+
+    expected_prefix = _PANEL_ROUTE_TEMPLATE.format(panel_id=panel_id)
+    if not url.startswith(expected_prefix) or url == expected_prefix:
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=SEVERITY_ERROR,
+                    message=(
+                        f"{label} {url!r} does not match this panel's asset route "
+                        f"{expected_prefix}<file>, so it resolves to no route and 404s."
+                    ),
+                    fix=f"Set it to {expected_prefix}<file>, using the manifest's own panel_id.",
+                )
+            ],
+            None,
+        )
+
+    relative_path = url[len(expected_prefix) :]
+    if not asset_root:
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=SEVERITY_ERROR,
+                    message=f"{label} is declared but the manifest sets no asset_root, so nothing can be served.",
+                    fix=(
+                        "Set asset_root on the PanelManifest to the directory holding the panel's files, "
+                        "e.g. asset_root=str(Path(__file__).resolve().parent / 'panel')."
+                    ),
+                )
+            ],
+            None,
+        )
+
+    root = Path(asset_root)
+    if not root.is_dir():
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=SEVERITY_ERROR,
+                    message=f"asset_root {asset_root!r} is not a directory, so {label} cannot be served.",
+                    fix="Point asset_root at a directory that ships with the package.",
+                )
+            ],
+            None,
+        )
+
+    resolved = _resolve_asset(asset_root, relative_path)
+    if resolved is None:
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=SEVERITY_ERROR,
+                    message=f"{label} {url!r} escapes the asset_root confinement and is refused.",
+                    fix="Keep the file inside asset_root; the route never serves a path outside it.",
+                )
+            ],
+            None,
+        )
+
+    suffix = resolved.suffix.lower()
+    if suffix not in _ALLOWED_ASSET_SUFFIXES:
+        allowed = ", ".join(sorted(_ALLOWED_ASSET_SUFFIXES))
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=SEVERITY_ERROR,
+                    message=f"{label} names a {suffix or '<no suffix>'} file, which the asset route will not serve.",
+                    fix=f"Use one of the allowed asset suffixes: {allowed}.",
+                )
+            ],
+            None,
+        )
+
+    if not resolved.is_file():
+        return (
+            [
+                PanelDiagnostic(
+                    code=CODE_IMPORT_FAILED,
+                    severity=missing_severity,
+                    message=f"{label} {url!r} names a file that is not on disk under asset_root.",
+                    fix=f"Create {relative_path!r} under asset_root, or correct the URL.",
+                )
+            ],
+            None,
+        )
+
+    return [], resolved
+
+
+# --------------------------------------------------------------------------
+# Panel module source checks — static, never executed.
+# --------------------------------------------------------------------------
+
+_API_VERSION_LITERAL_RE = re.compile(r"""\bapiVersion\b\s*[:=]\s*(['"])([^'"]*)\1""")
+_API_VERSION_KEY_RE = re.compile(r"\bapiVersion\b")
+_MOUNT_RE = re.compile(r"\bmount\b\s*[:(=]")
+_MOUNT_HOST_PARAM_RE = re.compile(
+    r"\bmount\b\s*[:=]?\s*(?:async\s+)?(?:function\s*\*?\s*)?\(\s*[A-Za-z_$][\w$]*\s*,\s*([A-Za-z_$][\w$]*)"
+)
+_UNMOUNT_RE = re.compile(r"\bunmount\b")
+_EXPORT_STAR_RE = re.compile(r"\bexport\s*\*")
+_EXPORT_DEFAULT_RE = re.compile(r"\bexport\s+default\b")
+_STATIC_IMPORT_RE = re.compile(r"""\bimport\b(?:[^;'"()]*?\bfrom\b\s*)?(['"])([^'"]+)\1""")
+_DYNAMIC_IMPORT_RE = re.compile(r"""\bimport\s*\(\s*(['"])([^'"]+)\1""")
+_EXPORT_FROM_RE = re.compile(r"""\bexport\b[^;'"]*?\bfrom\b\s*(['"])([^'"]+)\1""")
+
+
+def strip_js_comments(source: str) -> str:
+    """Remove ``//`` and ``/* */`` comments from JavaScript *source*.
+
+    A deliberately small scanner: it does not track string or regex literals,
+    so text that merely looks like a comment inside a template literal is
+    dropped too. That direction is the safe one — every hard-error check below
+    re-tests the raw source before reporting, so stripping can only ever cost an
+    advisory, never invent a blocking finding. ``//`` preceded by ``:`` is left
+    alone so a URL inside a string survives for the remote-import check.
+    """
+    out: list[str] = []
+    index = 0
+    length = len(source)
+    while index < length:
+        char = source[index]
+        if char == "/" and index + 1 < length:
+            following = source[index + 1]
+            if following == "/" and not (index > 0 and source[index - 1] == ":"):
+                newline = source.find("\n", index)
+                if newline == -1:
+                    break
+                index = newline
+                continue
+            if following == "*":
+                end = source.find("*/", index + 2)
+                index = length if end == -1 else end + 2
+                continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _named_export_re(export_name: str) -> re.Pattern[str]:
+    name = re.escape(export_name)
+    return re.compile(
+        r"\bexport\s+(?:async\s+)?(?:const|let|var|function\s*\*?|class)\s+" + name + r"\b"
+        r"|\bexport\s*\{[^}]*\b" + name + r"\b[^}]*\}"
+    )
+
+
+def _has_export(source: str, export_name: str) -> bool:
+    """Whether *source* plausibly declares an export named *export_name*."""
+    if _EXPORT_STAR_RE.search(source):
+        # ``export * from ...`` re-exports names this scanner cannot enumerate;
+        # absence is unprovable, so never claim the export is missing.
+        return True
+    if export_name == "default":
+        if _EXPORT_DEFAULT_RE.search(source):
+            return True
+        return bool(re.search(r"\bexport\s*\{[^}]*\bas\s+default\b[^}]*\}", source))
+    return bool(_named_export_re(export_name).search(source))
+
+
+def _host_binding_names(source: str) -> set[str]:
+    """Names the module may be calling the host API by.
+
+    ``mount(container, host)`` is the documented signature, but the second
+    parameter is the author's to name and ``mount(el, h)`` is just as correct.
+    Reading the binding out of the signature is what keeps the advisory below
+    from firing on a perfectly good panel — and a false advisory is the one
+    outcome a non-blocking check cannot afford, because it teaches the author to
+    ignore the check.
+    """
+    names = {"host"}
+    names.update(match.group(1) for match in _MOUNT_HOST_PARAM_RE.finditer(source))
+    return names
+
+
+def _references_host_control(source: str, control: str) -> bool:
+    """Whether *source* calls ``<host>.<control>``, destructured or not."""
+    escaped = re.escape(control)
+    for binding in _host_binding_names(source):
+        name = re.escape(binding)
+        if re.search(r"\b" + name + r"\s*\.\s*" + escaped + r"\b", source):
+            return True
+        # ``const { confirm, cancel } = host`` is the other common spelling.
+        if re.search(r"\{[^{}]*\b" + escaped + r"\b[^{}]*\}\s*=\s*" + name + r"\b", source):
+            return True
+    return False
+
+
+def _remote_import_specifiers(source: str) -> list[str]:
+    """Return every off-origin module specifier *source* imports."""
+    found: list[str] = []
+    for pattern in (_STATIC_IMPORT_RE, _DYNAMIC_IMPORT_RE, _EXPORT_FROM_RE):
+        for match in pattern.finditer(source):
+            specifier = match.group(2)
+            if is_remote_url(specifier) and specifier not in found:
+                found.append(specifier)
+    return found
+
+
+def check_panel_module_source(
+    source: str,
+    *,
+    export_name: str = "default",
+    api_version: str = PANEL_API_VERSION,
+) -> list[PanelDiagnostic]:
+    """Check a panel module's *source* text against the ``PanelModule`` contract.
+
+    Never executes the module. Hard errors are only raised for evidence that is
+    absent from both the comment-stripped and the raw source, so the comment
+    scanner cannot manufacture one.
+
+    ``host.confirm`` / ``host.cancel`` / ``unmount`` are advisory by design: a
+    text search finds the name, not the binding, so it cannot prove the control
+    is attached to a DOM element. Proving that needs a JavaScript runtime, which
+    the backend deliberately does not have; the host-owned escape hatch (#2195)
+    is what actually guarantees the user can always leave the panel. This is a
+    stated limit of static checking, not deferred work.
+    """
+    stripped = strip_js_comments(source)
+    diagnostics: list[PanelDiagnostic] = []
+    name = export_name or "default"
+
+    if not _has_export(stripped, name) and not _has_export(source, name):
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_EXPORT_MISSING,
+                severity=SEVERITY_ERROR,
+                message=f"the module declares no export named {name!r}, which is what the host imports.",
+                fix=(
+                    "Add `export default { apiVersion, mount }`, or set export_name on the "
+                    "PanelManifest to a name the module does export."
+                    if name == "default"
+                    else f"Add `export const {name} = {{ apiVersion, mount }}`, or set export_name "
+                    "on the PanelManifest to a name the module does export."
+                ),
+            )
+        )
+
+    has_api_version = bool(_API_VERSION_KEY_RE.search(stripped) or _API_VERSION_KEY_RE.search(source))
+    has_mount = bool(_MOUNT_RE.search(stripped) or _MOUNT_RE.search(source))
+    if not has_api_version or not has_mount:
+        missing = " and ".join(
+            part for part, present in (("apiVersion", has_api_version), ("mount", has_mount)) if not present
+        )
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_NOT_A_PANEL_MODULE,
+                severity=SEVERITY_ERROR,
+                message=f"the module never mentions {missing}; the host refuses an export that is not a PanelModule.",
+                fix=(
+                    'Export an object carrying both, e.g. `export default { apiVersion: "'
+                    + api_version
+                    + '", mount(container, host) { ... } }`.'
+                ),
+            )
+        )
+
+    literal = _API_VERSION_LITERAL_RE.search(stripped) or _API_VERSION_LITERAL_RE.search(source)
+    if literal is not None:
+        declared = literal.group(2)
+        if _major(declared) != _major(api_version):
+            diagnostics.append(
+                PanelDiagnostic(
+                    code=CODE_API_VERSION_MISMATCH,
+                    severity=SEVERITY_ERROR,
+                    message=(
+                        f"the module declares apiVersion {declared!r}, whose major does not match "
+                        f"the host's {api_version!r}."
+                    ),
+                    fix=f'Set apiVersion to "{api_version}" (or a matching major).',
+                )
+            )
+
+    if not _UNMOUNT_RE.search(stripped):
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_MOUNT_FAILED,
+                severity=SEVERITY_WARNING,
+                message="no `unmount` appears in the module; mount() must return an object carrying one.",
+                fix="Return `{ unmount() { ... } }` from mount() so the host can tear the panel down.",
+            )
+        )
+
+    missing_controls = [control for control in ("confirm", "cancel") if not _references_host_control(stripped, control)]
+    if missing_controls:
+        joined = " or ".join(f"host.{control}" for control in missing_controls)
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_PANEL_CONTROL_MISSING,
+                severity=SEVERITY_WARNING,
+                message=f"the module never references {joined}, so the run may have no way to resume or stop.",
+                fix="Call host.confirm(response) from the panel's confirm control and host.cancel() from its cancel control.",
+            )
+        )
+
+    for specifier in _remote_import_specifiers(stripped):
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_IMPORT_FAILED,
+                severity=SEVERITY_ERROR,
+                message=f"the module imports {specifier!r} from off-origin; the panel host loads same-origin code only.",
+                fix="Vendor the dependency into the panel's asset_root and import it by a relative path.",
+            )
+        )
+
+    return diagnostics
+
+
+# --------------------------------------------------------------------------
+# Whole-manifest entry points.
+# --------------------------------------------------------------------------
+
+
+#: Source-check results keyed by ``(path, mtime_ns, size, export_name,
+#: api_version)``. The workflow validator runs the whole check set on every
+#: editor autosave, so a panel bundle would otherwise be re-read and re-scanned
+#: for every keystroke-driven save. The key changes the moment the file does, so
+#: a stale entry cannot outlive an edit — which is the whole point of checking
+#: the module at run start rather than only at scan time.
+_SOURCE_DIAGNOSTIC_CACHE: dict[tuple[str, int, int, str, str], tuple[PanelDiagnostic, ...]] = {}
+
+#: Bound on the cache. Panels are few; this only stops an unbounded process
+#: lifetime from accumulating one entry per edit of every panel ever opened.
+_SOURCE_DIAGNOSTIC_CACHE_MAX = 256
+
+
+def _cached_module_source_diagnostics(
+    module_path: Path,
+    *,
+    export_name: str,
+    api_version: str,
+) -> list[PanelDiagnostic]:
+    """Read and check a panel module, reusing the last result for an unchanged file."""
+    try:
+        stat = module_path.stat()
+        key = (str(module_path), stat.st_mtime_ns, stat.st_size, export_name, api_version)
+    except OSError:
+        key = None
+    if key is not None:
+        cached = _SOURCE_DIAGNOSTIC_CACHE.get(key)
+        if cached is not None:
+            return list(cached)
+
+    try:
+        source = module_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        return [
+            PanelDiagnostic(
+                code=CODE_IMPORT_FAILED,
+                severity=SEVERITY_ERROR,
+                message=f"the panel module could not be read as UTF-8 text ({type(exc).__name__}).",
+                fix="Ship the panel module as a UTF-8 encoded ES module.",
+            )
+        ]
+
+    diagnostics = check_panel_module_source(source, export_name=export_name, api_version=api_version)
+    if key is not None:
+        if len(_SOURCE_DIAGNOSTIC_CACHE) >= _SOURCE_DIAGNOSTIC_CACHE_MAX:
+            _SOURCE_DIAGNOSTIC_CACHE.clear()
+        _SOURCE_DIAGNOSTIC_CACHE[key] = tuple(diagnostics)
+    return diagnostics
+
+
+def validate_panel(
+    *,
+    panel_id: str,
+    module_url: str = "",
+    export_name: str = "default",
+    css: Sequence[str] = (),
+    api_version: str = PANEL_API_VERSION,
+    asset_root: str | None = None,
+) -> list[PanelDiagnostic]:
+    """Validate one panel manifest and, when it resolves, its module source.
+
+    A core panel — one the app bundles and the frontend resolves from its
+    built-in registry — carries no ``module_url`` and no ``asset_root`` by
+    design, so there is nothing here to check and the result is empty. A panel
+    id outside the ``core.`` namespace that still declares no ``module_url``
+    gets an advisory instead: it is far more likely to be a package author who
+    forgot the URL than a new built-in.
+    """
+    diagnostics: list[PanelDiagnostic] = []
+    url = (module_url or "").strip()
+
+    if not panel_id:
+        return [
+            PanelDiagnostic(
+                code=CODE_INVALID_MODULE_URL,
+                severity=SEVERITY_ERROR,
+                message="the panel manifest has an empty panel_id, so no panel can be resolved.",
+                fix="Give the PanelManifest a stable panel_id, e.g. '<package>.<block>'.",
+            )
+        ]
+
+    if not url:
+        if asset_root:
+            return [
+                PanelDiagnostic(
+                    code=CODE_INVALID_MODULE_URL,
+                    severity=SEVERITY_ERROR,
+                    message="the manifest declares an asset_root but no module_url, so nothing is ever imported.",
+                    fix=(
+                        "Set module_url to "
+                        f"{_PANEL_ROUTE_TEMPLATE.format(panel_id=panel_id)}<file> naming the module under asset_root."
+                    ),
+                )
+            ]
+        if not panel_id.startswith(_CORE_PANEL_ID_PREFIX):
+            return [
+                PanelDiagnostic(
+                    code=CODE_INVALID_MODULE_URL,
+                    severity=SEVERITY_WARNING,
+                    message=(
+                        f"panel {panel_id!r} declares no module_url, so the frontend will look for a built-in "
+                        "panel registered under that id; a package-provided panel must ship a module."
+                    ),
+                    fix=(
+                        "Set module_url and asset_root on the PanelManifest, or use a 'core.' panel id "
+                        "that the app actually bundles."
+                    ),
+                )
+            ]
+        return []
+
+    if api_version and _major(api_version) != _major(PANEL_API_VERSION):
+        diagnostics.append(
+            PanelDiagnostic(
+                code=CODE_API_VERSION_MISMATCH,
+                severity=SEVERITY_ERROR,
+                message=(
+                    f"the manifest declares api_version {api_version!r}, whose major does not match "
+                    f"the host's {PANEL_API_VERSION!r}; the host refuses before importing."
+                ),
+                fix=f'Set api_version="{PANEL_API_VERSION}" on the PanelManifest.',
+            )
+        )
+
+    module_findings, module_path = _check_asset_url(
+        url=url,
+        panel_id=panel_id,
+        asset_root=asset_root,
+        label="module_url",
+        missing_severity=SEVERITY_ERROR,
+    )
+    diagnostics.extend(module_findings)
+
+    for css_url in css:
+        css_findings, _ = _check_asset_url(
+            url=(css_url or "").strip(),
+            panel_id=panel_id,
+            asset_root=asset_root,
+            # A stylesheet that is not on disk is the one asset fault the host
+            # survives: injectManifestCss appends the <link>, the request 404s,
+            # and the panel still mounts. Reported, never blocking.
+            label="css entry",
+            missing_severity=SEVERITY_WARNING,
+        )
+        diagnostics.extend(css_findings)
+
+    if module_path is not None:
+        diagnostics.extend(
+            _cached_module_source_diagnostics(
+                module_path,
+                export_name=export_name,
+                api_version=api_version or PANEL_API_VERSION,
+            )
+        )
+
+    return diagnostics
+
+
+def diagnostics_for_manifest(manifest: Any) -> list[PanelDiagnostic]:
+    """Validate a :class:`PanelManifest` instance (the block-class side)."""
+    return validate_panel(
+        panel_id=getattr(manifest, "panel_id", "") or "",
+        module_url=getattr(manifest, "module_url", "") or "",
+        export_name=getattr(manifest, "export_name", "default") or "default",
+        css=tuple(getattr(manifest, "css", ()) or ()),
+        api_version=getattr(manifest, "api_version", PANEL_API_VERSION) or PANEL_API_VERSION,
+        asset_root=getattr(manifest, "asset_root", None),
+    )
+
+
+def diagnostics_for_spec(spec: Any) -> list[PanelDiagnostic]:
+    """Validate the panel a registered :class:`BlockSpec` carries.
+
+    The spec keeps the manifest's wire form (``panel_manifest``) and the
+    backend-only ``panel_asset_root`` separately, because ``to_dict()`` drops
+    the root before it goes to the browser. A spec with no panel manifest is not
+    an interactive block and yields nothing.
+
+    This is the run-start half of the check, and it is not redundant with the
+    scan-time half: editing a panel's ``.js`` file changes nothing the registry
+    watches — Tier-1 hot reload keys on the block's ``.py`` mtime — so a block
+    that registered cleanly can be pointing at a module that has since been
+    broken or deleted.
+    """
+    manifest = getattr(spec, "panel_manifest", None)
+    if not isinstance(manifest, dict):
+        return []
+    css = manifest.get("css") or ()
+    return validate_panel(
+        panel_id=str(manifest.get("panel_id") or ""),
+        module_url=str(manifest.get("module_url") or ""),
+        export_name=str(manifest.get("export_name") or "default"),
+        css=tuple(str(entry) for entry in css),
+        api_version=str(manifest.get("api_version") or PANEL_API_VERSION),
+        asset_root=getattr(spec, "panel_asset_root", None),
+    )
+
+
+__all__ = [
+    "CODE_API_VERSION_MISMATCH",
+    "CODE_EXPORT_MISSING",
+    "CODE_IMPORT_FAILED",
+    "CODE_INVALID_MODULE_URL",
+    "CODE_MOUNT_FAILED",
+    "CODE_NOT_A_PANEL_MODULE",
+    "CODE_PANEL_CONTROL_MISSING",
+    "CODE_REMOTE_URL_REJECTED",
+    "SEVERITY_ERROR",
+    "SEVERITY_WARNING",
+    "PanelDiagnostic",
+    "check_panel_module_source",
+    "diagnostics_for_manifest",
+    "diagnostics_for_spec",
+    "has_errors",
+    "is_remote_url",
+    "strip_js_comments",
+    "validate_panel",
+]

--- a/src/scistudio/blocks/registry/__init__.py
+++ b/src/scistudio/blocks/registry/__init__.py
@@ -14,8 +14,10 @@ disturbing blocks already running in a workflow.
 
 This module also defines the errors raised when registration or a
 file-format lookup fails: :class:`BlockRegistrationError`,
-:class:`CapabilityRegistrationError`, :class:`CapabilityLookupError`,
-:class:`MissingCapabilityError`, and :class:`AmbiguousCapabilityError`.
+:class:`CapabilityRegistrationError`, :class:`BlockContractError`,
+:class:`CapabilityLookupError`, :class:`MissingCapabilityError`, and
+:class:`AmbiguousCapabilityError`, plus :class:`BlockRejection` — the
+per-block record of what a scan refused and how to repair it (#2196).
 """
 
 # Maintainer notes (provenance):
@@ -35,6 +37,7 @@ from __future__ import annotations
 import contextlib
 import importlib
 import importlib.util
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -143,6 +146,57 @@ class AmbiguousCapabilityError(CapabilityLookupError):
     ``capability_id`` to :meth:`BlockRegistry.find_loader_capability` or
     :meth:`BlockRegistry.find_saver_capability`.
     """
+
+
+class BlockContractError(BlockRegistrationError, ValueError):
+    """Raised when a block class violates a declared contract, with the repair.
+
+    Also a ``ValueError`` because that is what every other scan-time class-shape
+    validator raises (see ``registry._capability``); a caller that already
+    handles those keeps working when one of them starts carrying structure.
+
+    An ordinary ``ValueError`` from a scan-time validator carries one string,
+    and the scan turns that string into a log line. That is enough for a person
+    reading a server log and not enough for the authoring agent, which sees only
+    that the block it just wrote is absent from ``list_blocks`` (#2196). This
+    error carries the individual reasons and the change that fixes them, so the
+    scan can record a :class:`BlockRejection` a tool can hand back verbatim.
+
+    Args:
+        block: Name of the block class that was refused.
+        reasons: One line per distinct fault.
+        fix: What to change, as one line.
+    """
+
+    def __init__(self, block: str, reasons: Sequence[str], fix: str) -> None:
+        super().__init__(f"{block}: " + " ".join(reasons))
+        self.block = block
+        """Name of the block class that was refused."""
+        self.reasons = tuple(reasons)
+        """One line per distinct fault."""
+        self.fix = fix
+        """What to change to make the block registrable."""
+
+
+@dataclass(frozen=True)
+class BlockRejection:
+    """One block (or block file) the scan refused, and why (#2196).
+
+    :class:`DropinFailure` records the same event for drop-in *files*, keyed by
+    path and shaped for the palette's "these files did not load" surface. This
+    records it per *block*, with the reasons split apart and a repair attached,
+    because the consumer is an authoring agent deciding what to edit next rather
+    than a person reading a list. Both are rebuilt by every scan.
+    """
+
+    block: str
+    """Block class name, or the file stem when the module never imported."""
+    reasons: tuple[str, ...]
+    """One line per distinct fault."""
+    fix: str
+    """What to change to make the block registrable."""
+    source: str
+    """Which scan pass refused it: ``"tier1"``, ``"entry_point"``, or ``"package_src"``."""
 
 
 @dataclass(frozen=True)
@@ -363,6 +417,7 @@ class BlockRegistry:
         self._packages: dict[str, PackageInfo] = {}
         self._dropin_failures: list[DropinFailure] = []
         self._entry_point_diagnostics: list[str] = []
+        self._rejections: list[BlockRejection] = []
 
     def add_scan_dir(self, directory: str | Path) -> None:
         """Register a directory of drop-in block files to scan.
@@ -416,6 +471,10 @@ class BlockRegistry:
             >>> registry.scan()
             >>> specs = registry.all_specs()  # name -> BlockSpec
         """
+        # #2196: every pass appends to ``_rejections``; a full scan starts a
+        # fresh list so the surface always describes the most recent catalogue,
+        # the way ``dropin_failures`` and ``diagnostics`` already do.
+        self._rejections = []
         self._scan_builtins()
         self._scan_tier1()
         self._scan_tier2()
@@ -617,6 +676,17 @@ class BlockRegistry:
         :meth:`hot_reload`.
         """
         return list(self._dropin_failures)
+
+    def rejections(self) -> list[BlockRejection]:
+        """Return every block the most recent scan refused, and why (#2196).
+
+        See :class:`BlockRejection`. A full :meth:`scan` rebuilds the whole
+        list; :meth:`hot_reload` rescans drop-ins only and so replaces just the
+        ``tier1`` entries, leaving what the entry-point and source-package
+        passes found in place — those passes did not run again, so their
+        findings are still the current truth about them.
+        """
+        return list(self._rejections)
 
     @property
     def diagnostics(self) -> list[str]:
@@ -823,8 +893,10 @@ from scistudio.blocks.registry._spec import (  # noqa: E402
 
 __all__ = [
     "AmbiguousCapabilityError",
+    "BlockContractError",
     "BlockRegistrationError",
     "BlockRegistry",
+    "BlockRejection",
     "BlockSpec",
     "CapabilityLookupError",
     "CapabilityRegistrationError",

--- a/src/scistudio/blocks/registry/_capability.py
+++ b/src/scistudio/blocks/registry/_capability.py
@@ -293,6 +293,17 @@ def _validate_interactive_capability(cls: type) -> None:
     that an interactive block defines ``prepare_prompt`` and declares a valid
     :class:`~scistudio.blocks.base.interactive.PanelManifest`. A no-op for the
     common AUTO/EXTERNAL case (neither half present).
+
+    #2196 extends it past the class shape to the panel the manifest names: the
+    module URL's route, the asset root, the file on disk, and the module's own
+    source are all checked statically by
+    :mod:`scistudio.blocks.base.panel_contract`. A certain failure raises
+    :class:`~scistudio.blocks.registry.BlockContractError` — a ``ValueError``
+    like every other refusal here, but carrying the individual reasons and the
+    repair so the scan can record a
+    :class:`~scistudio.blocks.registry.BlockRejection` instead of dropping the
+    block in silence. Heuristic findings never raise; they are logged here and
+    reported to the author by the workflow validator and the write-time hook.
     """
     # Local imports keep this registry helper import-light and avoid a cycle
     # with blocks.base (mirrors the lazy-import style used across this module).
@@ -328,6 +339,30 @@ def _validate_interactive_capability(cls: type) -> None:
             f"{cls_name}: INTERACTIVE block must declare a valid interactive_panel "
             f"PanelManifest with a non-empty panel_id (ADR-051 FR-002)."
         )
+
+    # #2196: the manifest is only half the contract. The window the user sees is
+    # the JavaScript module the manifest points at, and until now nothing looked
+    # at it — a module_url that resolves to no route, an asset_root that is not
+    # there, or an export the host cannot mount all passed this check and became
+    # a modal that opened and immediately errored, with the reason visible only
+    # in the browser. The panel checks live in ``blocks.base.panel_contract`` so
+    # the workflow validator and the write-time hook decide the same way; it is
+    # imported here rather than at module scope for the same reason the
+    # ``interactive`` import above is (keep this registry helper import-light).
+    from scistudio.blocks.base.panel_contract import diagnostics_for_manifest
+
+    diagnostics = diagnostics_for_manifest(panel)
+    blocking = [diagnostic for diagnostic in diagnostics if diagnostic.is_error]
+    if blocking:
+        from scistudio.blocks.registry import BlockContractError
+
+        raise BlockContractError(
+            cls_name,
+            [diagnostic.message for diagnostic in blocking],
+            " ".join(diagnostic.fix for diagnostic in blocking),
+        )
+    for diagnostic in diagnostics:
+        logger.info("registry: %s panel advisory — %s %s", cls_name, diagnostic.code, diagnostic.message)
 
 
 def _resolve_class(spec: BlockSpec) -> type | None:

--- a/src/scistudio/blocks/registry/_scan.py
+++ b/src/scistudio/blocks/registry/_scan.py
@@ -19,6 +19,9 @@ Owns:
   ``packages/*/src`` source packages (desktop runtime).
 - ``_register_spec`` — apply per-spec validation and write into the
   registry's ``_registry`` + ``_aliases`` dicts.
+- ``_record_rejection`` — record why one block (or one drop-in file) was
+  refused, so ``reload_blocks`` can tell the author instead of the block
+  simply not appearing (#2196).
 - ``_validate_capability_registration`` — ADR-043 capability-id and
   default-conflict cross-spec validation.
 """
@@ -171,6 +174,59 @@ def _record_dropin_failure(registry: BlockRegistry, py_file: Path, error_type: s
     registry._dropin_failures.append(DropinFailure(file_path=str(py_file), error_type=error_type, message=message))
 
 
+#: What to tell an author who has no more specific repair to offer. A rejection
+#: with no fix is the silence this record exists to end, so there is always one.
+_GENERIC_REJECTION_FIX = (
+    "Read the reasons above, correct the block class, then call reload_blocks again "
+    "and check the 'rejected' list is empty."
+)
+
+
+def _record_rejection(
+    registry: BlockRegistry,
+    *,
+    block: str,
+    reasons: list[str],
+    fix: str,
+    source: str,
+) -> None:
+    """Record why one block was refused, for ``reload_blocks`` to report (#2196).
+
+    The scan already logs every refusal and, for drop-in files, records a
+    :class:`~scistudio.blocks.registry.DropinFailure` the palette can show. An
+    authoring agent reads neither: it writes a block, reloads, and sees the block
+    absent from ``list_blocks`` with nothing to act on. This is the same event,
+    kept per block and shaped for that reader.
+    """
+    from scistudio.blocks.registry import BlockRejection
+
+    registry._rejections.append(BlockRejection(block=block, reasons=tuple(reasons), fix=fix, source=source))
+
+
+def _record_rejected_class(
+    registry: BlockRegistry,
+    *,
+    block: str,
+    exc: BaseException,
+    source: str,
+) -> None:
+    """Record a rejection raised while turning one class into a ``BlockSpec``.
+
+    A :class:`~scistudio.blocks.registry.BlockContractError` already carries the
+    split reasons and the repair; anything else contributes the one string it
+    has, plus the generic repair.
+    """
+    from scistudio.blocks.registry import BlockContractError
+
+    if isinstance(exc, BlockContractError):
+        reasons = list(exc.reasons)
+        fix = exc.fix
+    else:
+        reasons = [str(exc) or type(exc).__name__]
+        fix = _GENERIC_REJECTION_FIX
+    _record_rejection(registry, block=block, reasons=reasons, fix=fix, source=source)
+
+
 def _reject_shadowing_type_files(registry: BlockRegistry, import_roots: tuple[Path, ...]) -> None:
     """Report every FR-016 collision in *import_roots* on the registry.
 
@@ -182,6 +238,17 @@ def _reject_shadowing_type_files(registry: BlockRegistry, import_roots: tuple[Pa
     for collision in guard_dropin_type_roots(import_roots):
         logger.error("ADR-053 FR-016: rejected drop-in type %s — %s", collision.path, collision.message)
         _record_dropin_failure(registry, collision.path, "DropinTypeNameCollision", collision.message)
+        # #2196: a refused type file is a scan-time rejection too, and it is one
+        # an author hits by naming a file after an installed module. Reported in
+        # the same list so ``reload_blocks`` covers every reason something the
+        # author just wrote did not appear.
+        _record_rejection(
+            registry,
+            block=collision.path.stem,
+            reasons=[collision.message],
+            fix="Rename the drop-in type file so its stem does not shadow an installed top-level module.",
+            source="tier1",
+        )
 
 
 def _scan_tier1(registry: BlockRegistry) -> None:
@@ -235,6 +302,10 @@ def _scan_tier1(registry: BlockRegistry) -> None:
     from scistudio.blocks.registry._spec import _spec_from_class
 
     registry._dropin_failures = []
+    # #2196: ``hot_reload`` rescans this tier alone, so only this tier's
+    # rejections are stale. What the entry-point and source-package passes found
+    # is left in place — those passes did not run again.
+    registry._rejections = [rejection for rejection in registry._rejections if rejection.source != "tier1"]
     import_roots = dropin_import_roots_for_block_dirs(registry._scan_dirs)
     _reject_shadowing_type_files(registry, import_roots)
 
@@ -288,6 +359,16 @@ def _scan_tier1(registry: BlockRegistry) -> None:
                         exc_info=True,
                     )
                     _record_dropin_failure(registry, py_file, type(exc).__name__, str(exc) or type(exc).__name__)
+                    _record_rejection(
+                        registry,
+                        block=py_file.stem,
+                        reasons=[f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__],
+                        fix=(
+                            "The module raised while importing, so none of its blocks were seen. "
+                            "Fix the import-time error and call reload_blocks again."
+                        ),
+                        source="tier1",
+                    )
                     continue
 
                 for attr_name in dir(module):
@@ -320,12 +401,27 @@ def _scan_tier1(registry: BlockRegistry) -> None:
                         # than silently mis-dispatching.
                         with suppress(AttributeError, TypeError):
                             obj._scistudio_file_path = str(py_file)  # type: ignore[attr-defined]
-                        block_spec = _spec_from_class(obj, source="tier1")
-                        block_spec.file_path = str(py_file)
-                        block_spec.file_mtime = mtime
-                        block_spec.module_path = mod_name
-                        block_spec.runtime_import_roots = [str(path) for path in import_roots]
-                        _register_spec(registry, block_spec)
+                        # #2196: contain a refusal to the offending class. It
+                        # used to fall to the file-level handler below, which
+                        # abandoned every remaining class in the file and left
+                        # the author with one log line naming a path. Now the
+                        # rest of the file still registers, the FR-015 file
+                        # record is still written, and the reason is attached to
+                        # the block that caused it.
+                        try:
+                            block_spec = _spec_from_class(obj, source="tier1")
+                            block_spec.file_path = str(py_file)
+                            block_spec.file_mtime = mtime
+                            block_spec.module_path = mod_name
+                            block_spec.runtime_import_roots = [str(path) for path in import_roots]
+                            _register_spec(registry, block_spec)
+                        except Exception as exc:
+                            logger.warning("Failed to register block %s from %s", obj.__name__, py_file, exc_info=True)
+                            _record_dropin_failure(
+                                registry, py_file, type(exc).__name__, str(exc) or type(exc).__name__
+                            )
+                            _record_rejected_class(registry, block=obj.__name__, exc=exc, source="tier1")
+                            continue
             except Exception as exc:
                 logger.warning(
                     "Failed to import block from %s",
@@ -454,15 +550,31 @@ def _register_entry_point_blocks(
 
         for cls in block_classes:
             if isinstance(cls, type) and issubclass(cls, Block) and not inspect.isabstract(cls):
-                block_spec = _spec_from_class(cls, source="entry_point")
-                block_spec.module_path = cls.__module__
-                block_spec.class_name = cls.__name__
-                block_spec.package_name = pkg_name
-                # #1772: surface shared user-site deps (installed via the
-                # in-app Python terminal) to the worker for entry-point
-                # blocks too, matching the source-package path.
-                block_spec.runtime_import_roots = [str(path) for path in _desktop_user_python_import_roots()]
-                _register_spec(registry, block_spec)
+                # #2196: same containment as Tier 1 — one refused class must not
+                # take the rest of the package's blocks with it, and the reason
+                # belongs on the block rather than only in the log.
+                try:
+                    block_spec = _spec_from_class(cls, source="entry_point")
+                    block_spec.module_path = cls.__module__
+                    block_spec.class_name = cls.__name__
+                    block_spec.package_name = pkg_name
+                    # #1772: surface shared user-site deps (installed via the
+                    # in-app Python terminal) to the worker for entry-point
+                    # blocks too, matching the source-package path.
+                    block_spec.runtime_import_roots = [str(path) for path in _desktop_user_python_import_roots()]
+                    _register_spec(registry, block_spec)
+                except Exception as exc:
+                    message = f"{cls.__name__}: {exc}" if str(exc) else f"{cls.__name__}: {type(exc).__name__}"
+                    logger.warning("Entry-point '%s' block %s", ep_name, message, exc_info=True)
+                    diagnostics.append(
+                        EntryPointDiagnostic(
+                            group=BLOCKS_ENTRY_POINT_GROUP,
+                            entry_point=ep_name,
+                            stage=STAGE_REGISTER,
+                            message=message,
+                        )
+                    )
+                    _record_rejected_class(registry, block=cls.__name__, exc=exc, source="entry_point")
             elif isinstance(cls, type) and issubclass(cls, Block) and inspect.isabstract(cls):
                 message = f"contained abstract Block subclass: {cls}"
                 logger.warning("Entry-point '%s' %s", ep_name, message)
@@ -560,8 +672,24 @@ def _process_package_protocol_result(
     for cls in block_classes:
         if not (isinstance(cls, type) and issubclass(cls, Block) and not inspect.isabstract(cls)):
             logger.warning("Package '%s' contained non-concrete Block item: %s", module_name, cls)
+            _record_rejection(
+                registry,
+                block=getattr(cls, "__name__", str(cls)),
+                reasons=[f"package '{module_name}' returned a non-concrete Block item: {cls}"],
+                fix="Return only concrete Block subclasses from get_blocks()/get_block_package().",
+                source=source,
+            )
             continue
-        block_spec = _spec_from_class(cls, source=source)
+        # #2196: this loop had no containment at all — a refused class raised
+        # out of ``_scan_source_package_module``'s handler, which logged one
+        # warning and dropped the *entire package*. Every block in a source
+        # package could vanish because of one of them.
+        try:
+            block_spec = _spec_from_class(cls, source=source)
+        except Exception as exc:
+            logger.warning("Package '%s' block %s was refused", module_name, cls.__name__, exc_info=True)
+            _record_rejected_class(registry, block=cls.__name__, exc=exc, source=source)
+            continue
         block_spec.module_path = cls.__module__
         block_spec.class_name = cls.__name__
         block_spec.package_name = pkg_name

--- a/src/scistudio/workflow/validator.py
+++ b/src/scistudio/workflow/validator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from scistudio.blocks.base.panel_contract import diagnostics_for_spec
 from scistudio.blocks.base.ports import InputPort, OutputPort, validate_connection
 from scistudio.blocks.code.validation import validate_codeblock_config
 from scistudio.blocks.registry import BlockRegistry, BlockSpec, CapabilityLookupError
@@ -220,6 +221,11 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
        (case-insensitive) would make extension-based binning ambiguous, so
        such configurations are rejected at workflow save time
        (issue #680).
+    11. **Interactive panel contract** (#2196) -- an interactive node whose
+       panel manifest or panel module cannot produce a mountable window is
+       rejected here, before the run reaches the pause and the user gets an
+       empty modal. Certain failures are errors; the heuristic source checks
+       are ``Warning:`` advisories. Only when *registry* is provided.
 
     Parameters
     ----------
@@ -624,5 +630,32 @@ def validate_workflow(  # noqa: C901 — grandfathered (#1602): mccabe 60 > 30; 
                 )
             except CapabilityLookupError as exc:
                 errors.append(f"Node '{node.id}' output port '{port_name}': {exc}")
+
+    # ------------------------------------------------------------------
+    # Check 11: interactive panel contract (ADR-051, #2196)
+    # ------------------------------------------------------------------
+    # The registry refuses a hard-invalid interactive block at scan time, so
+    # most of these never reach a workflow. This check is what catches the case
+    # the scan cannot: a panel is a JavaScript file beside the block, and
+    # nothing re-registers the block when that file changes — Tier-1 hot reload
+    # keys on the block's ``.py`` mtime. A block that registered cleanly can be
+    # pointing at a module that has since been edited into something that will
+    # not mount, or deleted outright. Reaching a paused block and a broken modal
+    # is a much worse way to find that out than refusing to start.
+    #
+    # Runs in draft mode too, unlike Checks 6/9/10: this is not a
+    # partially-configured-node condition that resolves as the user keeps
+    # working, and the advisories are exactly what an author editing a panel
+    # wants to see while they edit it.
+    for node in workflow.nodes:
+        spec = registry.get_spec(node.block_type)
+        if spec is None or getattr(spec, "panel_manifest", None) is None:
+            continue
+        for diagnostic in diagnostics_for_spec(spec):
+            # ``Warning:`` marks an advisory, the convention the API layer and
+            # the MCP tool split on (#1988): a heuristic finding must never
+            # decide whether a workflow saves or dispatches.
+            prefix = "" if diagnostic.is_error else "Warning: "
+            errors.append(f"{prefix}Node '{node.id}': {diagnostic.render()}")
 
     return errors

--- a/tests/agent_provisioning/test_codex_config.py
+++ b/tests/agent_provisioning/test_codex_config.py
@@ -100,7 +100,7 @@ def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
     pre = data.get("hooks", {}).get("PreToolUse", [])
     post = data.get("hooks", {}).get("PostToolUse", [])
     assert len(pre) == 4, f"expected 4 PreToolUse hooks, got {len(pre)}"
-    assert len(post) == 3, f"expected 3 PostToolUse hooks, got {len(post)}"
+    assert len(post) == 4, f"expected 4 PostToolUse hooks, got {len(post)}"
 
     expected_pre_scripts = {
         "deny_scistudio_cli.py",
@@ -112,6 +112,7 @@ def test_codex_config_emits_hooks(tmp_project_dir: Path) -> None:
         "remind_poll_status.py",
         "mark_list_blocks_called.py",
         "enforce_concrete_port_types.py",
+        "check_panel_contract.py",
     }
 
     def _script_names(groups: list[dict]) -> set[str]:

--- a/tests/agent_provisioning/test_hook_panel_contract_parity.py
+++ b/tests/agent_provisioning/test_hook_panel_contract_parity.py
@@ -1,0 +1,221 @@
+"""Surface 3 (#2196): the panel-contract hook, and the guard against it drifting.
+
+The hook script cannot import ``scistudio``. Every provisioned hook runs under
+the *base* interpreter — that is what makes the frozen command outlive the venv
+it was written in (``hooks.hook_interpreter``) — so the panel source checks are
+transcribed into the template rather than imported from
+:mod:`scistudio.blocks.base.panel_contract`.
+
+A transcription that nobody compares is a copy that silently rots, so the parity
+test below runs both implementations over the same fixture corpus and requires
+identical output, code, severity, message, and repair alike. If you change a
+rule or a word in one, this test tells you to change it in the other.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from scistudio.blocks.base.interactive import PANEL_API_VERSION
+from scistudio.blocks.base.panel_contract import check_panel_module_source
+
+_TEMPLATE = (
+    Path(__file__).resolve().parents[2]
+    / "src"
+    / "scistudio"
+    / "agent_provisioning"
+    / "templates"
+    / "hook_check_panel_contract.py"
+)
+
+GOOD_PANEL = """
+// A panel that satisfies the contract.
+export default {
+  apiVersion: "1",
+  mount(container, host) {
+    const ok = document.createElement("button");
+    ok.addEventListener("click", () => host.confirm({ picked: 1 }));
+    ok.addEventListener("auxclick", () => host.cancel());
+    container.append(ok);
+    return { unmount() { container.replaceChildren(); } };
+  },
+};
+"""
+
+#: One entry per rule the two implementations share, plus the shapes that must
+#: *not* be flagged. Every case is a whole module so both sides see the same
+#: text a real write would produce.
+FIXTURES = {
+    "good": GOOD_PANEL,
+    "named_export_only": 'export const panel = { apiVersion: "1", mount(c, host) { host.confirm(); '
+    "host.cancel(); return { unmount() {} }; } };",
+    "no_api_version": "export default { mount(c, host) { host.confirm(); host.cancel(); return { unmount() {} }; } };",
+    "no_mount": 'export default { apiVersion: "1", render() {} };',
+    "wrong_major": 'export default { apiVersion: "3", mount(c, host) { host.confirm(); host.cancel(); '
+    "return { unmount() {} }; } };",
+    "no_unmount": GOOD_PANEL.replace("return { unmount() { container.replaceChildren(); } };", "return {};"),
+    "no_controls": 'export default { apiVersion: "1", mount(container, host) { return { unmount() {} }; } };',
+    "destructured_controls": 'export default { apiVersion: "1", mount(c, host) { const { confirm, cancel } = host; '
+    "return { unmount() {} }; } };",
+    "renamed_host_binding": 'export default { apiVersion: "1", mount(el, h) { h.confirm(); h.cancel(); '
+    "return { unmount() {} }; } };",
+    "remote_import": 'import lib from "https://cdn.example.com/lib.js";\n' + GOOD_PANEL,
+    "relative_import": 'import lib from "./helpers.mjs";\n' + GOOD_PANEL,
+    "star_reexport": 'export * from "./impl.mjs";\n',
+    "export_as_default": 'const panel = { apiVersion: "1", mount(c, host) { host.confirm(); host.cancel(); '
+    "return { unmount() {} }; } };\nexport { panel as default };",
+    "comment_only_controls": "// calls host.confirm and host.cancel\n"
+    'export default { apiVersion: "1", mount(c, h) { return {}; } };',
+    "template_literal_that_looks_like_a_comment": "const tip = `/*`;\n" + GOOD_PANEL,
+    "empty": "",
+}
+
+
+@pytest.fixture(scope="module")
+def hook_module() -> ModuleType:
+    """Import the template as a module, the way the parity check needs it."""
+    spec = importlib.util.spec_from_file_location("_panel_contract_hook_under_test", _TEMPLATE)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_hook_pins_the_same_panel_api_version(hook_module: ModuleType) -> None:
+    """The hook hardcodes the version because it cannot import it — so pin it here."""
+    assert hook_module.PANEL_API_VERSION == PANEL_API_VERSION
+
+
+@pytest.mark.parametrize("case", sorted(FIXTURES))
+def test_hook_and_shared_module_agree(hook_module: ModuleType, case: str) -> None:
+    source = FIXTURES[case]
+
+    expected = [(d.code, d.severity, d.message, d.fix) for d in check_panel_module_source(source)]
+    actual = hook_module.check_panel_module_source(source)
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("case", ["named_export_only"])
+def test_hook_and_shared_module_agree_on_a_custom_export_name(hook_module: ModuleType, case: str) -> None:
+    source = FIXTURES[case]
+
+    expected = [(d.code, d.severity, d.message, d.fix) for d in check_panel_module_source(source, export_name="panel")]
+    actual = hook_module.check_panel_module_source(source, export_name="panel")
+
+    assert actual == expected
+
+
+def test_the_shipped_tutorial_panel_is_clean_under_the_hook(hook_module: ModuleType) -> None:
+    panel = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "scistudio"
+        / "tutorials"
+        / "core"
+        / "what-is-a-type"
+        / "assets"
+        / "panels"
+        / "review_labels"
+        / "panel.mjs"
+    )
+    if not panel.is_file():  # pragma: no cover - only when tutorial assets are stripped
+        pytest.skip("tutorial panel assets are not present in this checkout")
+
+    assert hook_module.check_panel_module_source(panel.read_text(encoding="utf-8")) == []
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the provisioned script, driven the way the CLI drives it.
+# ---------------------------------------------------------------------------
+
+
+def _run_hook(script: Path, payload: dict) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.fixture
+def hook_script(tmp_project_dir: Path) -> Path:
+    from scistudio.agent_provisioning.hooks import write_hooks
+
+    write_hooks(tmp_project_dir, force=False)
+    return tmp_project_dir / ".claude" / "hooks" / "check_panel_contract.py"
+
+
+def test_hook_is_provisioned(hook_script: Path) -> None:
+    assert hook_script.is_file()
+
+
+@pytest.mark.parametrize("suffix", [".js", ".mjs"])
+def test_hook_warns_after_a_panel_write(hook_script: Path, tmp_project_dir: Path, suffix: str) -> None:
+    """The gap this hook closes: no hook matched a panel module at all."""
+    panels = tmp_project_dir / "panels"
+    panels.mkdir(parents=True, exist_ok=True)
+    target = panels / f"panel{suffix}"
+    target.write_text('export const p = { apiVersion: "5", mount(c, h) {} };', encoding="utf-8")
+
+    result = _run_hook(hook_script, {"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+
+    assert result.returncode == 0  # PostToolUse can never block
+    assert "export_missing" in result.stderr
+    assert "api_version_mismatch" in result.stderr
+
+
+def test_hook_is_silent_on_a_sound_panel(hook_script: Path, tmp_project_dir: Path) -> None:
+    panels = tmp_project_dir / "panels"
+    panels.mkdir(parents=True, exist_ok=True)
+    target = panels / "panel.mjs"
+    target.write_text(GOOD_PANEL, encoding="utf-8")
+
+    result = _run_hook(hook_script, {"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+
+    assert result.returncode == 0
+    assert result.stderr.strip() == ""
+
+
+def test_hook_ignores_ordinary_project_javascript(hook_script: Path, tmp_project_dir: Path) -> None:
+    """A ``mount`` function in unrelated JS must not train the author to ignore this hook."""
+    target = tmp_project_dir / "scripts" / "widget.js"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("export function mount(el) { el.textContent = 'hi'; }\n", encoding="utf-8")
+
+    result = _run_hook(hook_script, {"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+
+    assert result.stderr.strip() == ""
+
+
+def test_hook_ignores_a_python_write(hook_script: Path, tmp_project_dir: Path) -> None:
+    target = tmp_project_dir / "blocks" / "thing.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("x = 1\n", encoding="utf-8")
+
+    result = _run_hook(hook_script, {"tool_name": "Write", "tool_input": {"file_path": str(target)}})
+
+    assert result.returncode == 0
+    assert result.stderr.strip() == ""
+
+
+def test_hook_survives_an_empty_payload(hook_script: Path) -> None:
+    """#1994: an unreadable payload must exit 0, not die and be reported as failed."""
+    result = subprocess.run(
+        [sys.executable, str(hook_script)],
+        input="",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0

--- a/tests/agent_provisioning/test_hooks.py
+++ b/tests/agent_provisioning/test_hooks.py
@@ -27,6 +27,9 @@ _HOOK_NAMES = (
     "remind_poll_status.py",
     "mark_list_blocks_called.py",
     "enforce_concrete_port_types.py",
+    # #2196: the panel-module contract check — the only hook that matches a
+    # written ``.js``/``.mjs`` file.
+    "check_panel_contract.py",
 )
 
 
@@ -41,7 +44,7 @@ def test_write_hooks_creates_settings_json(tmp_project_dir: Path) -> None:
     pre = data["hooks"]["PreToolUse"]
     post = data["hooks"]["PostToolUse"]
     assert len(pre) == 4  # +protect_data_dir.py (#1858)
-    assert len(post) == 3
+    assert len(post) == 4  # +check_panel_contract.py (#2196)
 
     # #1858: the data/ guard is registered for both file tools and Bash.
     data_dir_entries = [e for e in pre if "protect_data_dir.py" in e["hooks"][0]["command"]]
@@ -691,7 +694,7 @@ def test_write_hooks_creates_qoder_settings(tmp_project_dir: Path) -> None:
 
     data = json.loads((tmp_project_dir / ".qoder" / "settings.json").read_text(encoding="utf-8"))
     assert len(data["hooks"]["PreToolUse"]) == 4
-    assert len(data["hooks"]["PostToolUse"]) == 3
+    assert len(data["hooks"]["PostToolUse"]) == 4
 
 
 def test_qoder_hooks_expand_qoders_own_project_dir_variable(tmp_project_dir: Path) -> None:

--- a/tests/agent_provisioning/test_orchestrate.py
+++ b/tests/agent_provisioning/test_orchestrate.py
@@ -30,6 +30,7 @@ def test_install_project_agent_assets_fresh_project(tmp_project_dir: Path) -> No
         ".claude/hooks/remind_poll_status.py",
         ".claude/hooks/mark_list_blocks_called.py",
         ".claude/hooks/enforce_concrete_port_types.py",
+        ".claude/hooks/check_panel_contract.py",
         ".codex/config.toml",
         ".claude/.scistudio-provision-version",
     }

--- a/tests/ai/test_mcp_tools_authoring.py
+++ b/tests/ai/test_mcp_tools_authoring.py
@@ -165,6 +165,65 @@ def test_reload_blocks_no_context_raises() -> None:
         _run(tools_authoring.reload_blocks())
 
 
+def test_reload_blocks_reports_a_refused_block_instead_of_dropping_it(ctx: _StubRuntime, tmp_path: Path) -> None:
+    """#2196: the ``write -> reload_blocks -> list_blocks`` loop becomes a validation loop.
+
+    A block the scan refuses used to be indistinguishable, from the agent's
+    side, from a block it never wrote: absent from ``list_blocks``, with the
+    reason in a server log. Now the reason and the repair come back from the
+    reload that dropped it.
+    """
+    panel_root = tmp_path / "panel_assets"
+    panel_root.mkdir()
+    (panel_root / "panel.mjs").write_text(
+        'export default { apiVersion: "1", mount(c, host) { host.confirm(); host.cancel(); '
+        "return { unmount() {} }; } };",
+        encoding="utf-8",
+    )
+    blocks_dir = tmp_path / "blocks"
+    blocks_dir.mkdir()
+    (blocks_dir / "broken_panel.py").write_text(
+        "from typing import Any, ClassVar\n\n"
+        "from scistudio.blocks.base.config import BlockConfig\n"
+        "from scistudio.blocks.base.interactive import (\n"
+        "    InteractiveMixin,\n"
+        "    InteractivePrompt,\n"
+        "    PanelManifest,\n"
+        ")\n"
+        "from scistudio.blocks.base.state import ExecutionMode\n"
+        "from scistudio.blocks.process.process_block import ProcessBlock\n\n\n"
+        "class BrokenPanel(InteractiveMixin, ProcessBlock):\n"
+        '    name: ClassVar[str] = "BrokenPanel"\n'
+        "    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE\n"
+        "    interactive_panel: ClassVar[PanelManifest] = PanelManifest(\n"
+        '        panel_id="pkg.broken",\n'
+        '        module_url="/api/blocks/panels/pkg.broken/typo.mjs",\n'
+        f"        asset_root={str(panel_root)!r},\n"
+        "    )\n\n"
+        "    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:\n"
+        "        return InteractivePrompt(panel_payload={})\n",
+        encoding="utf-8",
+    )
+    ctx.block_registry.add_scan_dir(blocks_dir)
+
+    result = _run(tools_authoring.reload_blocks())
+
+    assert "BrokenPanel" not in ctx.block_registry.all_specs()
+    assert [entry.block for entry in result.rejected] == ["BrokenPanel"]
+    assert result.rejected[0].reasons
+    assert result.rejected[0].fix
+    assert "rejected" in result.next_step
+
+
+def test_reload_blocks_next_step_points_at_list_blocks_when_nothing_was_refused(
+    ctx: _StubRuntime,
+) -> None:
+    result = _run(tools_authoring.reload_blocks())
+
+    assert result.rejected == []
+    assert "list_blocks" in result.next_step
+
+
 # --- run_block_tests -------------------------------------------------------
 
 

--- a/tests/blocks/test_interactive_adversarial_registry.py
+++ b/tests/blocks/test_interactive_adversarial_registry.py
@@ -262,33 +262,46 @@ def test_non_interactive_block_spec_has_no_manifest() -> None:
     assert spec.panel_asset_root is None
 
 
-class _PackagePanelBlock(InteractiveMixin, ProcessBlock):
-    """Package-style interactive block whose panel is wheel-served (has asset_root)."""
+def test_package_panel_asset_root_kept_off_the_wire(tmp_path: Path) -> None:
+    """§4.2: asset_root is server-only — it must never appear in the serialized manifest.
 
-    name = "PackagePanelBlock"
-    execution_mode = ExecutionMode.INTERACTIVE
-    interactive_panel = PanelManifest(
-        panel_id="pkg.interactive.demo",
-        module_url="/api/blocks/panels/pkg.interactive.demo/index.js",
-        asset_root="/server/only/secret/root",
-        version="2",
+    #2196: the root has to be a real directory holding the real module now, so
+    the block is built here rather than at module scope. A manifest pointing at
+    a path that does not exist is the ``import_failed`` the scan refuses — which
+    is the behaviour this file's other new cases cover.
+    """
+    root = tmp_path / "server_only_secret_root"
+    root.mkdir()
+    (root / "index.js").write_text(
+        'export default { apiVersion: "1", mount(c, host) { host.confirm(); host.cancel(); '
+        "return { unmount() {} }; } };",
+        encoding="utf-8",
     )
 
-    def prepare_prompt(self, inputs: dict[str, Any], config: Any) -> InteractivePrompt:
-        return InteractivePrompt(panel_payload={})
+    class _PackagePanelBlock(InteractiveMixin, ProcessBlock):
+        """Package-style interactive block whose panel is wheel-served (has asset_root)."""
 
-    def run(self, inputs: dict[str, Any], config: Any) -> dict[str, Any]:  # type: ignore[override]
-        return {}
+        name = "PackagePanelBlock"
+        execution_mode = ExecutionMode.INTERACTIVE
+        interactive_panel = PanelManifest(
+            panel_id="pkg.interactive.demo",
+            module_url="/api/blocks/panels/pkg.interactive.demo/index.js",
+            asset_root=str(root),
+            version="2",
+        )
 
+        def prepare_prompt(self, inputs: dict[str, Any], config: Any) -> InteractivePrompt:
+            return InteractivePrompt(panel_payload={})
 
-def test_package_panel_asset_root_kept_off_the_wire() -> None:
-    """§4.2: asset_root is server-only — it must never appear in the serialized manifest."""
+        def run(self, inputs: dict[str, Any], config: Any) -> dict[str, Any]:  # type: ignore[override]
+            return {}
+
     spec = _spec_from_class(_PackagePanelBlock)
     assert spec.panel_manifest is not None
     assert "asset_root" not in spec.panel_manifest, "asset_root leaked onto the wire"
     assert spec.panel_manifest["module_url"].startswith("/api/")
     # The server-side confinement root is captured separately on the spec.
-    assert spec.panel_asset_root == "/server/only/secret/root"
+    assert spec.panel_asset_root == str(root)
 
 
 # ===========================================================================

--- a/tests/blocks/test_panel_contract.py
+++ b/tests/blocks/test_panel_contract.py
@@ -1,0 +1,430 @@
+"""Static panel-contract checks (ADR-051, #2196).
+
+Every failure mode the issue tabulates is exercised here at the severity it is
+supposed to carry, plus the two drift guards that keep this module honest: the
+copied asset-suffix allowlist and the copied remote-URL prefixes must still
+equal the originals in :mod:`scistudio.previewers.assets`, which this module
+cannot import (``blocks/`` is Layer 2, ``previewers/`` is Layer 4).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scistudio.blocks.base.interactive import PANEL_API_VERSION, PanelManifest
+from scistudio.blocks.base.panel_contract import (
+    _ALLOWED_ASSET_SUFFIXES,
+    _REMOTE_PREFIXES,
+    CODE_API_VERSION_MISMATCH,
+    CODE_EXPORT_MISSING,
+    CODE_IMPORT_FAILED,
+    CODE_INVALID_MODULE_URL,
+    CODE_MOUNT_FAILED,
+    CODE_NOT_A_PANEL_MODULE,
+    CODE_PANEL_CONTROL_MISSING,
+    CODE_REMOTE_URL_REJECTED,
+    SEVERITY_ERROR,
+    SEVERITY_WARNING,
+    check_panel_module_source,
+    diagnostics_for_manifest,
+    has_errors,
+    strip_js_comments,
+    validate_panel,
+)
+
+GOOD_PANEL = """
+// A panel that satisfies the contract.
+const API = "1";
+export default {
+  apiVersion: API,
+  mount(container, host) {
+    const ok = document.createElement("button");
+    ok.addEventListener("click", () => host.confirm({ picked: 1 }));
+    const no = document.createElement("button");
+    no.addEventListener("click", () => host.cancel());
+    container.append(ok, no);
+    return { unmount() { container.replaceChildren(); } };
+  },
+};
+"""
+
+
+def _codes(diagnostics: list, severity: str | None = None) -> set[str]:
+    return {d.code for d in diagnostics if severity is None or d.severity == severity}
+
+
+def _write_panel(tmp_path: Path, body: str = GOOD_PANEL, name: str = "panel.mjs") -> Path:
+    root = tmp_path / "assets"
+    root.mkdir(exist_ok=True)
+    (root / name).write_text(body, encoding="utf-8")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Drift guards for the two constants this module copies rather than imports.
+# ---------------------------------------------------------------------------
+
+
+def test_asset_suffix_allowlist_matches_the_asset_route() -> None:
+    """The copied allowlist still equals the one the panel route serves by."""
+    from scistudio.previewers import assets
+
+    assert set(_ALLOWED_ASSET_SUFFIXES) == set(assets._ALLOWED_ASSET_SUFFIXES)
+
+
+def test_remote_prefixes_match_the_asset_route() -> None:
+    """The copied off-origin prefixes still equal the ones the route refuses."""
+    from scistudio.previewers import assets
+
+    assert tuple(_REMOTE_PREFIXES) == tuple(assets._REMOTE_PREFIXES)
+
+
+# ---------------------------------------------------------------------------
+# Manifest / filesystem checks — hard errors.
+# ---------------------------------------------------------------------------
+
+
+def test_core_panel_with_no_module_url_is_clean() -> None:
+    """A bundled core panel carries no module by design; there is nothing to check."""
+    assert validate_panel(panel_id="core.interactive.data_router") == []
+
+
+def test_package_panel_with_no_module_url_is_advisory_only() -> None:
+    """A non-core id with no module is probably a forgotten URL — but never blocking."""
+    diagnostics = validate_panel(panel_id="pkg.my_block")
+
+    assert _codes(diagnostics) == {CODE_INVALID_MODULE_URL}
+    assert not has_errors(diagnostics)
+
+
+def test_asset_root_without_module_url_is_an_error() -> None:
+    """Shipping assets and never naming one means nothing is ever imported."""
+    diagnostics = validate_panel(panel_id="pkg.my_block", asset_root="/somewhere")
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_INVALID_MODULE_URL}
+
+
+def test_empty_panel_id_is_an_error() -> None:
+    diagnostics = validate_panel(panel_id="", module_url="/api/blocks/panels/x/panel.mjs")
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_INVALID_MODULE_URL}
+
+
+def test_remote_module_url_is_rejected(tmp_path: Path) -> None:
+    """`remote_url_rejected`: the host refuses off-origin code before importing."""
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="https://cdn.example.com/panel.mjs",
+        asset_root=str(_write_panel(tmp_path)),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_REMOTE_URL_REJECTED}
+
+
+@pytest.mark.parametrize(
+    "module_url",
+    [
+        "/api/previews/assets/pkg.my_block/panel.mjs",  # the previewer route, not the panel route
+        "/api/blocks/panels/other.panel/panel.mjs",  # panel_id does not match the manifest
+        "panel.mjs",  # not site-relative
+        "/api/blocks/panels/pkg.my_block/",  # names no file
+    ],
+)
+def test_module_url_that_resolves_to_no_route_is_an_error(tmp_path: Path, module_url: str) -> None:
+    """`import_failed`: a URL off the panel route 404s, so the import fails."""
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url=module_url,
+        asset_root=str(_write_panel(tmp_path)),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_missing_asset_root_is_an_error(tmp_path: Path) -> None:
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        asset_root=None,
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_asset_root_that_is_not_a_directory_is_an_error(tmp_path: Path) -> None:
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        asset_root=str(tmp_path / "not-there"),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_module_file_absent_from_disk_is_an_error(tmp_path: Path) -> None:
+    """The reported `import_failed` — the 404 the issue's table names."""
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/missing.mjs",
+        asset_root=str(_write_panel(tmp_path)),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_module_path_escaping_asset_root_is_an_error(tmp_path: Path) -> None:
+    root = _write_panel(tmp_path)
+    (tmp_path / "outside.mjs").write_text(GOOD_PANEL, encoding="utf-8")
+
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/../outside.mjs",
+        asset_root=str(root),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_disallowed_asset_suffix_is_an_error(tmp_path: Path) -> None:
+    root = _write_panel(tmp_path, name="panel.ts")
+
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.ts",
+        asset_root=str(root),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_IMPORT_FAILED}
+
+
+def test_manifest_api_version_mismatch_is_an_error(tmp_path: Path) -> None:
+    """The host checks the manifest's own api_version before it imports anything."""
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        asset_root=str(_write_panel(tmp_path)),
+        api_version="99",
+    )
+
+    assert CODE_API_VERSION_MISMATCH in _codes(diagnostics, SEVERITY_ERROR)
+
+
+# ---------------------------------------------------------------------------
+# CSS entries: off-origin is certain, absent-from-disk is survivable.
+# ---------------------------------------------------------------------------
+
+
+def test_remote_css_url_is_an_error(tmp_path: Path) -> None:
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        css=("https://cdn.example.com/panel.css",),
+        asset_root=str(_write_panel(tmp_path)),
+    )
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_REMOTE_URL_REJECTED}
+
+
+def test_missing_css_file_is_advisory_not_blocking(tmp_path: Path) -> None:
+    """``injectManifestCss`` mounts the panel anyway, so a 404 stylesheet must not block."""
+    diagnostics = validate_panel(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        css=("/api/blocks/panels/pkg.my_block/panel.css",),
+        asset_root=str(_write_panel(tmp_path)),
+    )
+
+    assert not has_errors(diagnostics)
+    assert _codes(diagnostics, SEVERITY_WARNING) == {CODE_IMPORT_FAILED}
+
+
+# ---------------------------------------------------------------------------
+# Panel module source checks.
+# ---------------------------------------------------------------------------
+
+
+def test_good_panel_source_is_clean() -> None:
+    assert check_panel_module_source(GOOD_PANEL) == []
+
+
+def test_named_export_when_manifest_expects_default_is_export_missing() -> None:
+    """The issue's first row: named exports against the default ``export_name``."""
+    source = (
+        'export const panel = { apiVersion: "1", mount(c, h) { h.confirm(); h.cancel(); return { unmount() {} }; } };'
+    )
+
+    diagnostics = check_panel_module_source(source)
+
+    assert _codes(diagnostics, SEVERITY_ERROR) == {CODE_EXPORT_MISSING}
+
+
+def test_named_export_is_found_when_the_manifest_names_it() -> None:
+    source = (
+        'export const panel = { apiVersion: "1", mount(c, h) { h.confirm(); h.cancel(); return { unmount() {} }; } };'
+    )
+
+    assert check_panel_module_source(source, export_name="panel") == []
+
+
+def test_export_as_default_is_found() -> None:
+    source = GOOD_PANEL.replace("export default {", "const panel = {").replace(
+        "};\n", "};\nexport { panel as default };\n", 1
+    )
+
+    assert CODE_EXPORT_MISSING not in _codes(check_panel_module_source(source))
+
+
+def test_star_reexport_never_claims_a_missing_export() -> None:
+    """``export *`` re-exports names this scanner cannot enumerate — never a hard error."""
+    source = 'export * from "./impl.mjs";\n'
+
+    assert CODE_EXPORT_MISSING not in _codes(check_panel_module_source(source))
+
+
+@pytest.mark.parametrize(
+    ("source", "missing"),
+    [
+        ("export default { mount(c, h) { h.confirm(); h.cancel(); return { unmount() {} }; } };", "apiVersion"),
+        ('export default { apiVersion: "1", render() {} };', "mount"),
+    ],
+)
+def test_export_without_apiversion_or_mount_is_not_a_panel_module(source: str, missing: str) -> None:
+    """The issue's second row: the host's ``isPanelModule`` guard refuses it."""
+    diagnostics = check_panel_module_source(source)
+
+    assert CODE_NOT_A_PANEL_MODULE in _codes(diagnostics, SEVERITY_ERROR)
+    assert missing in next(d for d in diagnostics if d.code == CODE_NOT_A_PANEL_MODULE).message
+
+
+def test_wrong_module_apiversion_major_is_an_error() -> None:
+    source = GOOD_PANEL.replace('const API = "1";', 'const API = "1";').replace(
+        "apiVersion: API,", 'apiVersion: "2.0",'
+    )
+
+    assert CODE_API_VERSION_MISMATCH in _codes(check_panel_module_source(source), SEVERITY_ERROR)
+
+
+def test_non_literal_apiversion_is_not_compared() -> None:
+    """A module that computes its version cannot be checked, so it is not flagged."""
+    assert CODE_API_VERSION_MISMATCH not in _codes(check_panel_module_source(GOOD_PANEL))
+
+
+def test_remote_import_is_an_error() -> None:
+    source = 'import lib from "https://cdn.example.com/lib.js";\n' + GOOD_PANEL
+
+    assert CODE_IMPORT_FAILED in _codes(check_panel_module_source(source), SEVERITY_ERROR)
+
+
+def test_relative_import_is_fine() -> None:
+    source = 'import lib from "./helpers.mjs";\n' + GOOD_PANEL
+
+    assert check_panel_module_source(source) == []
+
+
+def test_missing_unmount_is_advisory() -> None:
+    source = GOOD_PANEL.replace("return { unmount() { container.replaceChildren(); } };", "return {};")
+
+    diagnostics = check_panel_module_source(source)
+
+    assert not has_errors(diagnostics)
+    assert _codes(diagnostics, SEVERITY_WARNING) == {CODE_MOUNT_FAILED}
+
+
+def test_missing_host_controls_is_advisory() -> None:
+    """A string search cannot prove a control is wired, so it must never block."""
+    source = 'export default { apiVersion: "1", mount(c, h) { return { unmount() {} }; } };'
+
+    diagnostics = check_panel_module_source(source)
+
+    assert not has_errors(diagnostics)
+    assert _codes(diagnostics, SEVERITY_WARNING) == {CODE_PANEL_CONTROL_MISSING}
+
+
+def test_destructured_host_controls_are_recognised() -> None:
+    source = (
+        'export default { apiVersion: "1", mount(c, host) { const { confirm, cancel } = host; '
+        "return { unmount() {} }; } };"
+    )
+
+    assert CODE_PANEL_CONTROL_MISSING not in _codes(check_panel_module_source(source))
+
+
+def test_comment_only_mentions_do_not_satisfy_the_source_checks() -> None:
+    """Prose about ``host.confirm`` is not a call to it."""
+    source = '// calls host.confirm and host.cancel\nexport default { apiVersion: "1", mount(c, h) { return {}; } };'
+
+    assert CODE_PANEL_CONTROL_MISSING in _codes(check_panel_module_source(source), SEVERITY_WARNING)
+
+
+def test_comment_stripping_never_manufactures_a_hard_error() -> None:
+    """A template literal that looks like a comment must not lose the export.
+
+    The comment scanner does not track string literals, so it can swallow real
+    code. Every hard-error check re-tests the raw source for exactly this
+    reason; if that guard is removed this test fails.
+    """
+    source = "const tip = `/*`;\n" + GOOD_PANEL
+
+    assert not has_errors(check_panel_module_source(source))
+
+
+def test_strip_js_comments_keeps_urls_intact() -> None:
+    assert "https://x/y" in strip_js_comments('const u = "https://x/y";')
+
+
+# ---------------------------------------------------------------------------
+# Adapters.
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_for_manifest_reads_a_panel_manifest(tmp_path: Path) -> None:
+    manifest = PanelManifest(
+        panel_id="pkg.my_block",
+        module_url="/api/blocks/panels/pkg.my_block/panel.mjs",
+        asset_root=str(_write_panel(tmp_path)),
+        api_version=PANEL_API_VERSION,
+    )
+
+    assert diagnostics_for_manifest(manifest) == []
+
+
+def test_the_shipped_tutorial_panel_validates_clean() -> None:
+    """The one real package-shaped panel in the tree must not be flagged."""
+    root = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "scistudio"
+        / "tutorials"
+        / "core"
+        / "what-is-a-type"
+        / "assets"
+        / "panels"
+        / "review_labels"
+    )
+    if not root.is_dir():  # pragma: no cover - only when tutorial assets are stripped
+        pytest.skip("tutorial panel assets are not present in this checkout")
+
+    diagnostics = validate_panel(
+        panel_id="tutorial.review_labels",
+        module_url="/api/blocks/panels/tutorial.review_labels/panel.mjs",
+        asset_root=str(root),
+    )
+
+    assert diagnostics == []
+
+
+def test_source_check_result_tracks_the_file_on_disk(tmp_path: Path) -> None:
+    """The cached result must not outlive an edit — that is the whole point of Check 11."""
+    root = _write_panel(tmp_path)
+    kwargs = {
+        "panel_id": "pkg.my_block",
+        "module_url": "/api/blocks/panels/pkg.my_block/panel.mjs",
+        "asset_root": str(root),
+    }
+    assert validate_panel(**kwargs) == []
+
+    (root / "panel.mjs").write_text('export default { apiVersion: "7", mount(c, h) {} };', encoding="utf-8")
+
+    assert CODE_API_VERSION_MISMATCH in _codes(validate_panel(**kwargs), SEVERITY_ERROR)

--- a/tests/blocks/test_registry_package_layout.py
+++ b/tests/blocks/test_registry_package_layout.py
@@ -79,17 +79,21 @@ def test_sibling_modules_define_no_classes(module_name: str) -> None:
 
 
 def test_registry_init_defines_exactly_the_public_classes() -> None:
-    """``__init__.py`` owns the registry, its two records, and 5 error classes.
+    """``__init__.py`` owns the registry, its three records, and 6 error classes.
 
     ``DropinFailure`` joined the inventory with ADR-053 FR-015 (the drop-in
-    refusals the palette listing reports). ADR-047 §C9 keeps every public class
-    of the package here, so this is the only legal home for it.
+    refusals the palette listing reports), and ``BlockRejection`` /
+    ``BlockContractError`` with #2196 (the same refusals kept per block, with
+    the repair attached, for the authoring agent). ADR-047 §C9 keeps every
+    public class of the package here, so this is the only legal home for them.
     """
     assert sorted(_module_class_names("scistudio.blocks.registry")) == sorted(
         [
             "AmbiguousCapabilityError",
+            "BlockContractError",
             "BlockRegistrationError",
             "BlockRegistry",
+            "BlockRejection",
             "BlockSpec",
             "CapabilityLookupError",
             "CapabilityRegistrationError",

--- a/tests/blocks/test_registry_rejections.py
+++ b/tests/blocks/test_registry_rejections.py
@@ -1,0 +1,275 @@
+"""Surface 1 (#2196): the scan says why it refused a block instead of dropping it.
+
+Before this, a block the scan refused simply stopped appearing in the palette
+and in ``list_blocks``. The refusal was in a server log and, for a whole
+drop-in file, in ``dropin_failures()`` — neither of which the authoring agent
+reads. These tests cover the per-block record that replaces the silence, at
+every tier that can refuse one, plus the panel half of the interactive contract
+that is the reason the record was needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.interactive import InteractiveMixin, InteractivePrompt, PanelManifest
+from scistudio.blocks.base.state import ExecutionMode
+from scistudio.blocks.process.process_block import ProcessBlock
+from scistudio.blocks.registry import BlockContractError, BlockRegistry
+from scistudio.blocks.registry._capability import _validate_interactive_capability
+
+GOOD_PANEL = """
+export default {
+  apiVersion: "1",
+  mount(container, host) {
+    container.onclick = () => host.confirm({});
+    container.oncontextmenu = () => host.cancel();
+    return { unmount() {} };
+  },
+};
+"""
+
+
+def _panel_root(tmp_path: Path, body: str = GOOD_PANEL) -> str:
+    root = tmp_path / "panel_assets"
+    root.mkdir(exist_ok=True)
+    (root / "panel.mjs").write_text(body, encoding="utf-8")
+    return str(root)
+
+
+def _interactive_class(block_name: str, manifest: PanelManifest) -> type:
+    """Build an otherwise-valid interactive block carrying *manifest*."""
+    declared_name = block_name
+
+    class _Block(InteractiveMixin, ProcessBlock):
+        name: ClassVar[str] = declared_name
+        execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+        interactive_panel: ClassVar[PanelManifest] = manifest
+
+        def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:
+            return InteractivePrompt(panel_payload={})
+
+    _Block.__name__ = block_name
+    return _Block
+
+
+# ---------------------------------------------------------------------------
+# The panel half of the scan-time contract.
+# ---------------------------------------------------------------------------
+
+
+def test_valid_package_panel_passes_the_scan_validator(tmp_path: Path) -> None:
+    cls = _interactive_class(
+        "GoodPanelBlock",
+        PanelManifest(
+            panel_id="pkg.good",
+            module_url="/api/blocks/panels/pkg.good/panel.mjs",
+            asset_root=_panel_root(tmp_path),
+        ),
+    )
+
+    _validate_interactive_capability(cls)  # must not raise
+
+
+def test_panel_module_missing_from_disk_is_refused(tmp_path: Path) -> None:
+    """`import_failed`: the 404 that used to reach the user as a broken modal."""
+    cls = _interactive_class(
+        "MissingModuleBlock",
+        PanelManifest(
+            panel_id="pkg.missing",
+            module_url="/api/blocks/panels/pkg.missing/nope.mjs",
+            asset_root=_panel_root(tmp_path),
+        ),
+    )
+
+    with pytest.raises(BlockContractError) as excinfo:
+        _validate_interactive_capability(cls)
+
+    assert excinfo.value.block == "MissingModuleBlock"
+    assert any("import_failed" in reason or "not on disk" in reason for reason in excinfo.value.reasons)
+    assert excinfo.value.fix
+
+
+def test_block_contract_error_is_still_a_value_error(tmp_path: Path) -> None:
+    """Every other scan-time class-shape refusal is a ``ValueError``; so is this one."""
+    cls = _interactive_class(
+        "RemotePanelBlock",
+        PanelManifest(panel_id="pkg.remote", module_url="https://cdn.example.com/panel.mjs"),
+    )
+
+    with pytest.raises(ValueError):
+        _validate_interactive_capability(cls)
+
+
+def test_panel_advisories_never_refuse_a_block(tmp_path: Path) -> None:
+    """A panel with no confirm control is a real problem, but not a scan-time one."""
+    cls = _interactive_class(
+        "AdvisoryOnlyBlock",
+        PanelManifest(
+            panel_id="pkg.advisory",
+            module_url="/api/blocks/panels/pkg.advisory/panel.mjs",
+            asset_root=_panel_root(tmp_path, 'export default { apiVersion: "1", mount(c, h) { return {}; } };'),
+        ),
+    )
+
+    _validate_interactive_capability(cls)  # advisories are logged, never raised
+
+
+def test_builtin_core_panels_still_scan_clean() -> None:
+    """DataRouter / PairEditor carry no ``module_url`` by design and must not regress."""
+    registry = BlockRegistry()
+    registry.scan()
+
+    assert registry.get_spec("Data Router") is not None
+    assert registry.get_spec("Pair Editor") is not None
+    # Scoped to the built-ins: a developer machine may carry a stale third-party
+    # plugin whose own rejection is not this test's business.
+    assert not [r for r in registry.rejections() if r.block in {"DataRouter", "PairEditor"}]
+
+
+# ---------------------------------------------------------------------------
+# The rejection record itself, from a real Tier-1 drop-in scan.
+# ---------------------------------------------------------------------------
+
+_DROPIN_TEMPLATE = """
+from typing import Any, ClassVar
+
+from scistudio.blocks.base.config import BlockConfig
+from scistudio.blocks.base.interactive import InteractiveMixin, InteractivePrompt, PanelManifest
+from scistudio.blocks.base.state import ExecutionMode
+from scistudio.blocks.process.process_block import ProcessBlock
+
+
+class {class_name}(InteractiveMixin, ProcessBlock):
+    name: ClassVar[str] = "{class_name}"
+    execution_mode: ClassVar[ExecutionMode] = ExecutionMode.INTERACTIVE
+    interactive_panel: ClassVar[PanelManifest] = PanelManifest(
+        panel_id="pkg.{panel_id}",
+        module_url="{module_url}",
+        asset_root={asset_root!r},
+    )
+
+    def prepare_prompt(self, inputs: dict[str, Any], config: BlockConfig) -> InteractivePrompt:
+        return InteractivePrompt(panel_payload={{}})
+"""
+
+
+def _scan_dropins(tmp_path: Path, files: dict[str, str]) -> BlockRegistry:
+    blocks_dir = tmp_path / "blocks"
+    blocks_dir.mkdir(exist_ok=True)
+    for filename, body in files.items():
+        (blocks_dir / filename).write_text(body, encoding="utf-8")
+    registry = BlockRegistry()
+    registry.add_scan_dir(blocks_dir)
+    registry.scan()
+    return registry
+
+
+def test_a_refused_dropin_block_is_reported_with_reason_and_fix(tmp_path: Path) -> None:
+    registry = _scan_dropins(
+        tmp_path,
+        {
+            "broken_panel.py": _DROPIN_TEMPLATE.format(
+                class_name="BrokenPanel",
+                panel_id="broken",
+                module_url="/api/blocks/panels/pkg.broken/nope.mjs",
+                asset_root=_panel_root(tmp_path),
+            )
+        },
+    )
+
+    assert registry.get_spec("BrokenPanel") is None
+    rejections = registry.rejections()
+    assert [r.block for r in rejections] == ["BrokenPanel"]
+    assert rejections[0].reasons
+    assert rejections[0].fix
+    assert rejections[0].source == "tier1"
+
+
+def test_one_refused_block_no_longer_takes_the_rest_of_its_file(tmp_path: Path) -> None:
+    """A refusal used to fall to the file-level handler and abandon the whole module."""
+    good = _DROPIN_TEMPLATE.format(
+        class_name="GoodInFile",
+        panel_id="good",
+        module_url="/api/blocks/panels/pkg.good/panel.mjs",
+        asset_root=_panel_root(tmp_path),
+    )
+    bad = _DROPIN_TEMPLATE.format(
+        class_name="BadInFile",
+        panel_id="bad",
+        module_url="/api/blocks/panels/pkg.bad/nope.mjs",
+        asset_root=_panel_root(tmp_path),
+    )
+    # ``dir(module)`` is alphabetical, so BadInFile is validated first.
+    registry = _scan_dropins(tmp_path, {"mixed.py": bad + good})
+
+    assert registry.get_spec("GoodInFile") is not None
+    assert [r.block for r in registry.rejections()] == ["BadInFile"]
+
+
+def test_a_dropin_that_raises_on_import_is_reported_by_file(tmp_path: Path) -> None:
+    """A module that never imports contributes no class name — the file stem stands in."""
+    registry = _scan_dropins(tmp_path, {"explodes.py": "raise RuntimeError('boom')\n"})
+
+    rejections = registry.rejections()
+    assert [r.block for r in rejections] == ["explodes"]
+    assert "boom" in rejections[0].reasons[0]
+    # FR-015's file-level record is still written; the two surfaces coexist.
+    assert [f.error_type for f in registry.dropin_failures()] == ["RuntimeError"]
+
+
+def test_a_full_scan_starts_a_fresh_rejection_list(tmp_path: Path) -> None:
+    registry = _scan_dropins(
+        tmp_path,
+        {
+            "broken_panel.py": _DROPIN_TEMPLATE.format(
+                class_name="BrokenPanel",
+                panel_id="broken",
+                module_url="/api/blocks/panels/pkg.broken/nope.mjs",
+                asset_root=_panel_root(tmp_path),
+            )
+        },
+    )
+    assert len(registry.rejections()) == 1
+
+    registry.scan()
+
+    assert len(registry.rejections()) == 1  # rebuilt, not appended to
+
+
+def test_hot_reload_replaces_only_the_dropin_rejections(tmp_path: Path) -> None:
+    """``hot_reload`` rescans Tier 1 alone, so only Tier 1's findings are stale."""
+    blocks_dir = tmp_path / "blocks"
+    blocks_dir.mkdir()
+    target = blocks_dir / "broken_panel.py"
+    target.write_text(
+        _DROPIN_TEMPLATE.format(
+            class_name="BrokenPanel",
+            panel_id="broken",
+            module_url="/api/blocks/panels/pkg.broken/nope.mjs",
+            asset_root=_panel_root(tmp_path),
+        ),
+        encoding="utf-8",
+    )
+    registry = BlockRegistry()
+    registry.add_scan_dir(blocks_dir)
+    registry.scan()
+    assert len(registry.rejections()) == 1
+
+    target.write_text(
+        _DROPIN_TEMPLATE.format(
+            class_name="BrokenPanel",
+            panel_id="broken",
+            module_url="/api/blocks/panels/pkg.broken/panel.mjs",
+            asset_root=_panel_root(tmp_path),
+        ),
+        encoding="utf-8",
+    )
+    registry.hot_reload()
+
+    assert registry.rejections() == []
+    assert registry.get_spec("BrokenPanel") is not None

--- a/tests/tutorials/test_core_tutorial_what_is_a_type.py
+++ b/tests/tutorials/test_core_tutorial_what_is_a_type.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import ast
 import importlib.util
+import shutil
 import sys
 from pathlib import Path, PurePosixPath
 from types import ModuleType
@@ -55,6 +56,17 @@ from .conftest import say_text
 
 TUTORIAL_DIR = Path(__file__).resolve().parents[2] / "src" / "scistudio" / "tutorials" / "core" / "what-is-a-type"
 ASSETS = TUTORIAL_DIR / "assets"
+
+
+def _module_from(path: Path, name: str) -> ModuleType:
+    """Import one drop-in file under *name*, the way a Tier-1 scan does."""
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
 
 # ---------------------------------------------------------------------------
 # ---------------------------------------------------------------------------
@@ -799,21 +811,46 @@ def test_the_step_texts_stand_on_what_the_pixels_do(manifest: TutorialManifest) 
 # ---------------------------------------------------------------------------
 
 
-def test_the_review_block_is_a_real_interactive_block(assets: dict[str, ModuleType]) -> None:
-    """Mixin + execution mode + panel manifest: the registry's own validation gate."""
+def test_the_review_block_is_a_real_interactive_block(assets: dict[str, ModuleType], tmp_path: Path) -> None:
+    """Mixin + execution mode + panel manifest: the registry's own validation gate.
+
+    Loaded from a **deployed** copy rather than the ``assets`` fixture, because
+    the block's ``asset_root`` is ``Path(__file__).parent / "review_labels_panel"``
+    and the panel does not sit there in this repository — ``tutorial.yaml`` copies
+    ``assets/panels/review_labels`` to ``blocks/review_labels_panel`` when the
+    reader starts the tutorial. The staged file is a template; only the deployed
+    pair is a block. Since #2196 the registry checks the panel the manifest names
+    and not just the class shape, so validating the template where it is staged
+    asks it to satisfy a contract that layout was never meant to satisfy.
+
+    Reproducing the copy is also the stronger test: it proves the layout the
+    reader actually gets satisfies the panel contract, which is what breaks their
+    tutorial if it is wrong. The ``assets`` fixture is still requested: it binds
+    ``image`` in ``sys.modules``, which this block imports, and unbinds it after.
+    """
     from scistudio.blocks.base import ExecutionMode, InteractiveMixin
     from scistudio.blocks.registry._spec import _spec_from_class
 
-    cls = assets["review"].ReviewLabelsBlock
-    assert issubclass(cls, InteractiveMixin)
-    assert cls.execution_mode is ExecutionMode.INTERACTIVE
+    blocks_dir = tmp_path / "blocks"
+    blocks_dir.mkdir()
+    shutil.copy(ASSETS / "code" / "review_labels.py", blocks_dir / "review_labels.py")
+    shutil.copytree(ASSETS / "panels" / "review_labels", blocks_dir / "review_labels_panel")
 
-    spec = _spec_from_class(cls, source="custom")
+    module_name = "_scistudio_dropin_test_t2_review_deployed"
+    try:
+        cls = _module_from(blocks_dir / "review_labels.py", module_name).ReviewLabelsBlock
+        assert issubclass(cls, InteractiveMixin)
+        assert cls.execution_mode is ExecutionMode.INTERACTIVE
+
+        spec = _spec_from_class(cls, source="custom")
+    finally:
+        sys.modules.pop(module_name, None)
+
     assert spec.type_name == "review_labels"
     assert spec.execution_mode == "interactive"
     assert spec.panel_manifest is not None
     assert spec.panel_manifest["panel_id"] == "tutorial.review_labels"
-    assert spec.panel_asset_root is not None and spec.panel_asset_root.endswith("review_labels_panel")
+    assert spec.panel_asset_root == str(blocks_dir / "review_labels_panel")
 
 
 def test_the_panel_manifest_names_the_served_module(assets: dict[str, ModuleType]) -> None:

--- a/tests/workflow/test_validator_panel_contract.py
+++ b/tests/workflow/test_validator_panel_contract.py
@@ -1,0 +1,156 @@
+"""Surface 2 (#2196): ``validate_workflow`` Check 11, the interactive panel contract.
+
+The registry refuses a hard-invalid interactive block at scan time, so most of
+these never reach a workflow. What Check 11 catches is the case the scan cannot:
+a panel is a JavaScript file beside the block, and nothing re-registers the block
+when that file changes. A block that registered cleanly can be pointing at a
+module that has since been edited into something that will not mount, or deleted
+outright — and finding that out at a paused block with an empty modal is exactly
+the failure this whole change exists to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scistudio.blocks.registry import BlockRegistry, BlockSpec
+from scistudio.workflow.definition import NodeDef, WorkflowDefinition
+from scistudio.workflow.validator import validate_workflow
+
+GOOD_PANEL = """
+export default {
+  apiVersion: "1",
+  mount(container, host) {
+    container.onclick = () => host.confirm({});
+    container.oncontextmenu = () => host.cancel();
+    return { unmount() {} };
+  },
+};
+"""
+
+
+@pytest.fixture
+def panel_root(tmp_path: Path) -> Path:
+    root = tmp_path / "panel_assets"
+    root.mkdir()
+    (root / "panel.mjs").write_text(GOOD_PANEL, encoding="utf-8")
+    return root
+
+
+def _registry_with_panel(panel_root: Path | None, *, module_file: str = "panel.mjs") -> BlockRegistry:
+    """A spec-only registry carrying one interactive block with a package panel."""
+    registry = BlockRegistry()
+    registry._registry["PanelBlock"] = BlockSpec(
+        name="PanelBlock",
+        description="",
+        version="0.1.0",
+        module_path="tests.synthetic",
+        class_name="PanelBlock",
+        base_category="process",
+        type_name="panel_block",
+        execution_mode="interactive",
+        panel_manifest={
+            "panel_id": "pkg.panel_block",
+            "module_url": f"/api/blocks/panels/pkg.panel_block/{module_file}",
+            "export_name": "default",
+            "css": [],
+            "version": "1",
+            "api_version": "1",
+        },
+        panel_asset_root=str(panel_root) if panel_root is not None else None,
+    )
+    registry._aliases["panel_block"] = "PanelBlock"
+    return registry
+
+
+def _workflow() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        id="wf",
+        nodes=[NodeDef(id="n1", block_type="PanelBlock", config={})],
+        edges=[],
+    )
+
+
+def _hard_errors(diagnostics: list[str]) -> list[str]:
+    return [d for d in diagnostics if not d.startswith("Warning:")]
+
+
+def test_a_sound_panel_produces_no_diagnostics(panel_root: Path) -> None:
+    assert validate_workflow(_workflow(), _registry_with_panel(panel_root)) == []
+
+
+def test_a_panel_module_deleted_after_registration_invalidates_the_workflow(panel_root: Path) -> None:
+    """The case scan-time validation structurally cannot catch."""
+    registry = _registry_with_panel(panel_root)
+    assert validate_workflow(_workflow(), registry) == []
+
+    (panel_root / "panel.mjs").unlink()
+
+    errors = _hard_errors(validate_workflow(_workflow(), registry))
+    assert errors
+    assert "n1" in errors[0]
+    assert "import_failed" in errors[0]
+
+
+def test_a_panel_edited_into_a_wrong_api_version_invalidates_the_workflow(panel_root: Path) -> None:
+    registry = _registry_with_panel(panel_root)
+    (panel_root / "panel.mjs").write_text(
+        'export default { apiVersion: "4", mount(c, host) { host.confirm(); host.cancel(); '
+        "return { unmount() {} }; } };",
+        encoding="utf-8",
+    )
+
+    errors = _hard_errors(validate_workflow(_workflow(), registry))
+    assert any("api_version_mismatch" in error for error in errors)
+
+
+def test_a_missing_asset_root_invalidates_the_workflow() -> None:
+    errors = _hard_errors(validate_workflow(_workflow(), _registry_with_panel(None)))
+
+    assert any("import_failed" in error for error in errors)
+
+
+def test_heuristic_findings_are_warnings_and_leave_the_workflow_valid(panel_root: Path) -> None:
+    """``Warning:`` is the prefix every consumer splits on (#1988); advisories must use it."""
+    (panel_root / "panel.mjs").write_text(
+        'export default { apiVersion: "1", mount(container, host) { return {}; } };',
+        encoding="utf-8",
+    )
+
+    diagnostics = validate_workflow(_workflow(), _registry_with_panel(panel_root))
+
+    assert _hard_errors(diagnostics) == []
+    assert diagnostics
+    assert all(d.startswith("Warning:") for d in diagnostics)
+    assert any("panel_control_missing" in d for d in diagnostics)
+
+
+def test_the_diagnostic_names_the_node_and_the_repair(panel_root: Path) -> None:
+    (panel_root / "panel.mjs").unlink()
+
+    errors = _hard_errors(validate_workflow(_workflow(), _registry_with_panel(panel_root)))
+
+    assert errors[0].startswith("Node 'n1': panel ")
+    assert " Fix: " in errors[0]
+
+
+def test_check_11_also_runs_in_draft_mode(panel_root: Path) -> None:
+    """Unlike the completeness checks, a broken panel is not work-in-progress."""
+    (panel_root / "panel.mjs").unlink()
+
+    errors = _hard_errors(validate_workflow(_workflow(), _registry_with_panel(panel_root), mode="draft"))
+
+    assert errors
+
+
+def test_a_non_interactive_block_is_untouched(panel_root: Path) -> None:
+    registry = _registry_with_panel(panel_root)
+    registry._registry["PanelBlock"].panel_manifest = None
+
+    assert validate_workflow(_workflow(), registry) == []
+
+
+def test_check_11_is_skipped_without_a_registry() -> None:
+    assert validate_workflow(_workflow(), None) == []


### PR DESCRIPTION
## What

An interactive block opens a block-owned window built from a JavaScript module
the package ships beside it. Nothing checked that module, or the `PanelManifest`
pointing at it: `_validate_interactive_capability` checked the class shape and
stopped there. So a `module_url` off the asset route, an `asset_root` that is not
a directory, a file that is not on disk, a named export against the default
`export_name`, a wrong `apiVersion`, or an off-origin import all arrived the same
way — the panel opened and immediately errored, mid-run, with the reason living
only in the browser. And when the class-shape check *did* reject a block, the
scanner dropped it silently: `reload_blocks` returned `{reloaded, added, removed}`
and the authoring agent saw its block vanish from `list_blocks` with nothing to
act on.

This adds one static validator and mounts it at three points an authoring agent
cannot route around. No JavaScript is ever executed, no CLI entry point is added,
and no new MCP tool: a tool the agent has to remember to call is a tool it will
not call.

## The shared implementation

`src/scistudio/blocks/base/panel_contract.py` — beside `interactive.py`, which
owns `PanelManifest` and `PANEL_API_VERSION`. It imports that module and the
standard library and nothing else, so the registry, the workflow validator, and
the tests import it without a cycle. It deliberately does not import
`previewers.assets` for the asset-suffix allowlist: `blocks/` is Layer 2 and
`previewers/` is Layer 4, so the allowlist and the off-origin prefixes are copied
and held to the originals by test.

Every diagnostic names the failure code `panelModuleLoader.ts` shows the user —
`export_missing`, `not_a_panel_module`, `api_version_mismatch`, `import_failed`,
`remote_url_rejected`, `invalid_module_url` — so the agent's vocabulary and the
user's error text agree.

Two severities. **Hard errors** are certain failures: the deterministic manifest
and filesystem checks, a missing export / `apiVersion` / `mount`, an off-origin
import. **Advisories** are heuristics that must never block: `unmount`,
`host.confirm`, and `host.cancel` not found. A text search finds a name, not a
binding; proving a control is bound to a DOM element needs a JavaScript runtime
the backend deliberately does not have, and the host-owned escape hatch (#2195)
is the guarantee that covers it. Two judgement calls are recorded in the code:

- **A CSS entry naming a file that is not on disk is an advisory, not an error.**
  The issue lists `css` under the deterministic checks, whose stated justification
  is "these fail at runtime with certainty" — and this one does not.
  `injectManifestCss` appends the `<link>`, the request 404s, and the panel
  mounts anyway. An off-origin CSS URL *is* a certain refusal and stays a hard
  error, which is exactly where the issue's own dividing line falls.
- **`host.confirm` detection reads the host binding out of the `mount` signature**
  (`mount(el, h)` is as correct as `mount(container, host)`), because a false
  advisory teaches the author to ignore the check.

## The three surfaces

1. **Registry scan / `reload_blocks`.** `_validate_interactive_capability` now
   raises `BlockContractError` — a `ValueError` like every other refusal there,
   but carrying the split reasons and the repair — and the scan records a
   `BlockRejection` per block. `reload_blocks` returns them as
   `rejected: [{block, reasons[], fix}]`, which turns the agent's existing
   `write -> reload_blocks -> list_blocks` loop into a validation loop with no
   new tool and no new step.

   This fixes the silent drop for **every** scan-time rejection, not only
   interactive ones, and contains it per class: Tier 1 and Tier 2 used to abandon
   the rest of a file / package's blocks when one was refused, and Tier 3 had no
   containment at all — one refused class dropped the whole source package with a
   single log line. The FR-015 `DropinFailure` record the palette reads is still
   written alongside.

2. **Workflow validator (Check 11).** The same checks run against every
   interactive node in `validate_workflow`, so `write_workflow`'s post-write
   verification and run start both refuse a hard-invalid panel before the user
   reaches a paused block and an empty modal. This is not redundant with the scan:
   a panel is a `.js` file and nothing re-registers the block when it changes —
   Tier-1 hot reload keys on the block's `.py` mtime — so a block that registered
   cleanly can be pointing at a module that has since been broken or deleted.
   Advisories use the existing `Warning:` prefix. Runs in draft mode too, unlike
   the completeness checks: a broken panel is not work-in-progress.

3. **PostToolUse hook.** `hook_check_panel_contract.py`, registered for Claude
   Code, both Qoder channels, and Codex. The existing block-write hook matches
   Python block files only, so a hand-written panel module was touched by no hook
   at all.

   **The hook transcribes the source checks instead of importing them, and this
   is deliberate.** Every provisioned hook runs under the *base* interpreter —
   that is what lets `hook_interpreter()` freeze a command that outlives the venv
   it was written in — so a hook that imported `scistudio` would die fail-open
   wherever that interpreter cannot see the package, which is the silent
   non-enforcement this whole change exists to end.
   `tests/agent_provisioning/test_hook_panel_contract_parity.py` runs both
   implementations over a 16-case fixture corpus and requires identical output —
   code, severity, message, and repair — plus pins the hook's hardcoded
   `PANEL_API_VERSION`. The transcription cannot drift unnoticed.

## Notes for review

- `src/scistudio/blocks/**` is a protected core path: this PR needs the
  `admin-approved:core-change` label (recorded in the ledger).
- The shipped tutorial panel (`tutorials/core/what-is-a-type/.../panel.mjs`) and
  the built-in `Data Router` / `Pair Editor` core panels validate clean; there
  are tests for both.
- Two existing tests changed for a real reason, not to make room:
  `test_package_panel_asset_root_kept_off_the_wire` used
  `asset_root="/server/only/secret/root"`, a path that does not exist and is now
  a rejection, so it builds its fixture on a real directory; and the ADR-047 §C9
  class inventory gained `BlockContractError` and `BlockRejection`.

Gate record: .workflow/records/2196-feat-2196-interactive-contract-validation.json

Closes #2196
