### PR TITLE
fix(#2206): let --build name the build a migration notice must land on

### DIFF
--- a/.workflow/records/2206-2206-ota-build-override.json
+++ b/.workflow/records/2206-2206-ota-build-override.json
@@ -1,0 +1,684 @@
+{
+  "base_ref": "origin/main",
+  "branch": "fix/2206-ota-build-override",
+  "check_events": [
+    {
+      "at": "2026-08-28T20:21:07.521901Z",
+      "command": "pytest tests/architecture/ -v --no-cov",
+      "covered_surface": "architecture",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:0deac04405434cdca6d65dc3c51f5b5938ddb201f6adf484ce98451ad607e155",
+      "name": "architecture_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/architecture_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:21:11.638733Z",
+      "command": "pre-commit run --all-files --hook-stage manual",
+      "covered_surface": "hygiene",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:aea2eb5a546f909e8b6f855803c4ff88cf84edbd59fe67fc2b118ddbdc1d9ba4",
+      "name": "commit_hygiene",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/commit_hygiene.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:21:12.638992Z",
+      "command": "python scripts/deferral_scan.py --check docs/audit/baselines/deferral-baseline.json",
+      "covered_surface": "python_deferrals",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:1aaab0ccae0897400a5fce68bfac01f5d7687ef5c9f5b452c0823d79d6d6109f",
+      "name": "deferral_discipline",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/deferral_discipline.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:21:12.941953Z",
+      "command": "ruff format scripts/ota_publish.py tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:9ef5f0c6afe33566e78e0b7fcb990a9b5865b3a1ee3915aea3553ce6b3151306",
+      "name": "format_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/format_check.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-28T20:21:17.253623Z",
+      "command": "python -m scistudio.qa.audit.full_audit --repo-root . --format json --output .audit/full-audit.json",
+      "covered_surface": "governance",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:fa5b7daa675ab41c2a62474ecef6ca41af5278b83e74efc40a981ddd91c8c8fa",
+      "name": "full_audit",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/full_audit.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:21:17.754998Z",
+      "command": "lint-imports",
+      "covered_surface": "python_imports",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:179b1cba851dd153ae0ab07e4f5ff8b2a735cc2c3d6d4494d3c0100847360442",
+      "name": "import_contracts",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/import_contracts.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:21:17.767895Z",
+      "command": "ruff check scripts/ota_publish.py tests/scripts/test_ota_publish.py",
+      "covered_surface": "python_lint",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:157473a8c7d2660a3f66404adb406193497cc1e114e8a7a1a79baf00a7b6a140",
+      "name": "lint_format",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/lint_format.log",
+      "scope": "diff",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {
+        "ruff": "0.15.15"
+      }
+    },
+    {
+      "at": "2026-08-28T20:24:07.103814Z",
+      "command": "python -m scistudio.qa.testing.run_python_tests --timeout=60 --timeout-method=thread",
+      "covered_surface": "python_tests",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:af2ca7e388c12a9d8050a75b431101f8541d5162bac4b8c84608a8be4f5dc3a3",
+      "name": "python_tests",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/python_tests.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    },
+    {
+      "at": "2026-08-28T20:24:13.583459Z",
+      "command": "mypy src/scistudio/ --ignore-missing-imports",
+      "covered_surface": "python_types",
+      "exit_code": 0,
+      "input_fingerprint": "sha256:e94394e48009cd8fbd5108426e57662cdd3e4d99e817a3b4494b7e53776b5c37",
+      "name": "type_check",
+      "parity_detail": null,
+      "parity_gap": false,
+      "pr_only": false,
+      "raw_log_ref": ".workflow/local/logs/type_check.log",
+      "scope": "repo",
+      "status": "pass",
+      "summary": "clean",
+      "tool_versions": {}
+    }
+  ],
+  "check_na": [],
+  "commit": {
+    "sha": "327c47304d81c370b08ffcc936bffe2950901da3",
+    "shas": [
+      "327c47304d81c370b08ffcc936bffe2950901da3"
+    ],
+    "trailers": []
+  },
+  "declared_scope": {
+    "exclude": [],
+    "include": []
+  },
+  "directive_events": [],
+  "docs_events": [
+    {
+      "at": "2026-08-28T20:20:24.832019Z",
+      "class": null,
+      "kind": "path",
+      "path": "docs/ai-developer/release-runbook.md",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ],
+  "governance_touch": true,
+  "guard_events": [
+    {
+      "at": "2026-08-28T20:24:13.611748Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.620546Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.629460Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.638429Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.647198Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.656071Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.665369Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.674582Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.684298Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.692899Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:13.702187Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.685362Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.697532Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.707052Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.716315Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.725571Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.734987Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.744653Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.753470Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.762755Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.774923Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:40.790860Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.705269Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.714673Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.725536Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.743538Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.758193Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.770276Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.780092Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.789230Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.798691Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.807889Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:24:53.817472Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.889760Z",
+      "findings": [],
+      "guard": "architecture_doc_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.899100Z",
+      "findings": [],
+      "guard": "core_change_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.908098Z",
+      "findings": [],
+      "guard": "docs_landing",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.917179Z",
+      "findings": [],
+      "guard": "human_bypass_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.926211Z",
+      "findings": [],
+      "guard": "issue_link",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.934893Z",
+      "findings": [],
+      "guard": "mod_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.943696Z",
+      "findings": [],
+      "guard": "persona_policy",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.952527Z",
+      "findings": [],
+      "guard": "pr_merge_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.961333Z",
+      "findings": [
+        {
+          "actual": null,
+          "drift_class": null,
+          "evidence": {},
+          "expected": null,
+          "file": "",
+          "finding_class": "sentrux",
+          "git_evidence": null,
+          "id": "sentrux.free_tier.advisory-missing-evidence",
+          "line": null,
+          "message": "Sentrux evidence is recommended for source/workflow/architecture changes (advisory, opt-in).",
+          "path": "",
+          "related_findings": [],
+          "remediation": null,
+          "rule_id": "sentrux.free_tier.advisory-missing-evidence",
+          "severity": "info",
+          "subject": null,
+          "suggested_fix": null,
+          "symbol": null,
+          "tool": null
+        }
+      ],
+      "guard": "sentrux_gate",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.970448Z",
+      "findings": [],
+      "guard": "test_engineer_scope_guard",
+      "status": "pass"
+    },
+    {
+      "at": "2026-08-28T20:25:15.979664Z",
+      "findings": [],
+      "guard": "weakened_ci_check",
+      "status": "pass"
+    }
+  ],
+  "issues": [
+    {
+      "close_in_pr": true,
+      "followup_rationale": null,
+      "number": 2206,
+      "url": null
+    }
+  ],
+  "observed_admin_labels": [],
+  "observed_diff": {
+    "base": "b2445c38df9e5fa3d71f982c91400a9b54801e7d",
+    "base_sha": "b2445c38",
+    "changed_files": [
+      "docs/ai-developer/release-runbook.md",
+      "scripts/ota_publish.py",
+      "tests/scripts/test_ota_publish.py"
+    ],
+    "diff_fingerprint": "sha256:f371dec36eab3403abeea773366bac132c0af03b7cb926dd22ab93c23748bba4",
+    "head": "HEAD",
+    "head_sha": "327c4730",
+    "surfaces": {
+      "docs": 1,
+      "frontend": 0,
+      "governance": 1,
+      "governed_docs": 1,
+      "implementation": 0,
+      "packaging": 0,
+      "protected_architecture": 0,
+      "protected_core": 0,
+      "sentrux": 1,
+      "test": 1,
+      "workflow_ci": 0
+    }
+  },
+  "owner_directive": "Owner: 0.3.3 users never received the build26 reinstall notice and get an incompatible dialog with no download address instead. Directive: republish it as build28.",
+  "persona": "implementer",
+  "pull_request": {
+    "body_closes_issues": [],
+    "closes": [],
+    "number": 2207,
+    "url": "https://github.com/jiazhenz026/SciStudio/pull/2207"
+  },
+  "reconcile_events": [
+    {
+      "at": "2026-08-28T20:24:13.702215Z",
+      "diff_fingerprint": "sha256:f371dec36eab3403abeea773366bac132c0af03b7cb926dd22ab93c23748bba4",
+      "mode": "local",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-28T20:24:40.790909Z",
+      "diff_fingerprint": "sha256:f371dec36eab3403abeea773366bac132c0af03b7cb926dd22ab93c23748bba4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-28T20:24:53.817501Z",
+      "diff_fingerprint": "sha256:f371dec36eab3403abeea773366bac132c0af03b7cb926dd22ab93c23748bba4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    },
+    {
+      "at": "2026-08-28T20:25:15.979690Z",
+      "diff_fingerprint": "sha256:f371dec36eab3403abeea773366bac132c0af03b7cb926dd22ab93c23748bba4",
+      "mode": "pre-pr",
+      "result": "pass",
+      "tier": 1,
+      "unsatisfied": []
+    }
+  ],
+  "record_id": "2206-2206-ota-build-override",
+  "requested_admin_labels": [],
+  "required_obligations": {
+    "admin_labels": [],
+    "checks": [
+      "architecture_tests",
+      "commit_hygiene",
+      "deferral_discipline",
+      "format_check",
+      "full_audit",
+      "import_contracts",
+      "lint_format",
+      "python_tests",
+      "type_check"
+    ],
+    "docs": [
+      "docs_required_or_na"
+    ],
+    "guards": [
+      "architecture_doc_guard",
+      "core_change_guard",
+      "docs_landing",
+      "human_bypass_guard",
+      "issue_link",
+      "mod_guard",
+      "persona_policy",
+      "pr_merge_guard",
+      "sentrux_gate",
+      "test_engineer_scope_guard",
+      "weakened_ci_check"
+    ],
+    "tests": []
+  },
+  "runtime": "claude",
+  "schema_version": 2,
+  "scope_events": [
+    {
+      "action": "add-include",
+      "at": "2026-08-28T20:20:24.831852Z",
+      "pattern": "scripts/ota_publish.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-28T20:20:24.832004Z",
+      "pattern": "tests/scripts/test_ota_publish.py",
+      "reason": "plan"
+    },
+    {
+      "action": "add-include",
+      "at": "2026-08-28T20:20:24.832007Z",
+      "pattern": "docs/ai-developer/release-runbook.md",
+      "reason": "plan"
+    }
+  ],
+  "session_id": "f3274d1a-e9ed-4ef3-a8c0-2c2d5534cab1",
+  "strictness_tier": 1,
+  "task_kind": "bugfix",
+  "test_events": [
+    {
+      "at": "2026-08-28T20:20:24.832025Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/scripts/test_ota_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    },
+    {
+      "at": "2026-08-28T20:20:38.871965Z",
+      "class": null,
+      "kind": "path",
+      "path": "tests/scripts/test_ota_publish.py",
+      "rationale": null,
+      "verified_in_diff": null
+    }
+  ]
+}

--- a/docs/ai-developer/release-runbook.md
+++ b/docs/ai-developer/release-runbook.md
@@ -207,6 +207,40 @@ that branch never downloads anything. The notice page would be built,
 uploaded, and never fetched, leaving the user at the plain native dialog the
 notice exists to avoid.
 
+**The notice also has to land in a build window, not just any build.** It is
+one manifest for the whole channel, so the build number is what keeps the page
+away from clients that are fine: the new-base population evaluates
+`up-to-date` for any build at or below the number their installer reports, and
+that is the only thing stopping the notice replacing their working SPA. The
+number must therefore be
+
+* **above** the last build the old-base clients applied, and
+* **at or below** the new installer's baseline build (`build0030` in
+  `SciStudio-0.3.4-alpha-build0030.dmg` means 30).
+
+`--min-build` then makes it mandatory for the old-base clients without touching
+the new ones, because `evaluateUpdate` returns `up-to-date` before it ever looks
+at `requires.min_build`.
+
+**Publishing anything else on the channel closes that window (#2206).** An
+ordinary patch for the new base overwrites `manifest.json` wholesale — its own
+`build`, and a `requires.min_base` back at the new base — and from that moment
+the old-base clients are on the native dialog again. Either hold the channel
+until the old base is retired, or restore the notice with `--build`:
+
+```bash
+python scripts/ota_publish.py --channel alpha --build 28 --min-build 28 \
+  --min-base 0.3.3 \
+  --reinstall-notice "https://github.com/jiazhenz026/SciStudio/releases/tag/v0.3.4-alpha"
+```
+
+`--build` names the number outright instead of taking the next one in the
+sequence, which by then is above the new baseline. It refuses to go backwards
+unless `--min-base` says which older population the publish is for. The
+new-base clients keep the last build they were given; they will not receive
+another until a publish rises above their number again, which closes the window
+a second time.
+
 Check the decision before publishing rather than reasoning about it:
 
 ```bash
@@ -220,6 +254,10 @@ console.log(JSON.stringify(ota.evaluateUpdate(
 )));   // must read kind:'patch', mandatory:true
 "
 ```
+
+Run it a second time for a client you are **not** migrating — the new base, at
+the build it is actually on — and require `kind:'none'`. That is the assertion
+that the window holds.
 
 ### 5.2 Making an update mandatory
 

--- a/scripts/ota_publish.py
+++ b/scripts/ota_publish.py
@@ -14,7 +14,9 @@ Design (issue #1775):
 * The build number is the patch sequence. Its source of truth is the published
   manifest, not any local counter: the next build is
   ``max(latest_published_build, installer_baseline_build) + 1`` so it is always
-  strictly greater than what any shipped installer reports.
+  strictly greater than what any shipped installer reports. ``--build`` names a
+  number outright, for the one case the sequence cannot express (#2206): a
+  reinstall notice aimed at clients the sequence has already moved past.
 * ``base`` (the ``a.b.c`` from ``desktop/package.json``) is the installer
   baseline. The patch records ``requires.min_base = base``; a client whose
   installer base is older must reinstall instead of hot-patching.
@@ -109,6 +111,42 @@ def next_build_number(latest_published_build: int | None, baseline_build: int) -
     return max(candidates) + 1
 
 
+def resolve_build_number(
+    override: int | None,
+    latest_published_build: int | None,
+    baseline_build: int,
+    min_base: str | None,
+) -> int:
+    """Pick the build number this publish will carry.
+
+    Without an override the sequence is monotonic (``next_build_number``).
+
+    #2206: the reinstall notice reaches old-base clients by sitting in a build
+    *window* -- strictly above the last build those clients applied, and at or
+    below the new installer's baseline, so the new-base population evaluates
+    ``up-to-date`` and keeps its working SPA. Once an ordinary patch for the new
+    base is published, the monotonic sequence has walked past that window and
+    the notice can only be restored by naming its number.
+
+    Going backwards is therefore legitimate, and only for that case: it is
+    refused unless ``--min-base`` names the older population the publish is
+    aimed at. A build at or below the sequence with no such target would land
+    on nobody at best, and replace a working SPA with a notice at worst.
+    """
+    if override is None:
+        return next_build_number(latest_published_build, baseline_build)
+    if override < 1:
+        raise ValueError(f"--build must be a positive build number; got {override}.")
+    sequence = max(baseline_build, latest_published_build or 0)
+    if override <= sequence and not min_base:
+        raise ValueError(
+            f"--build {override} is at or below the current sequence ({sequence}). "
+            "Only a migration notice aimed at an older base may publish backwards; "
+            "pass --min-base <that base> as well, or drop --build."
+        )
+    return override
+
+
 def asset_name(build: int) -> str:
     return f"backend-build{build}.tar.gz"
 
@@ -194,6 +232,17 @@ def render_reinstall_notice(download_url: str, version_line: str) -> str:
         raise SystemExit(f"Missing template: {REINSTALL_NOTICE_TEMPLATE}")
     html = REINSTALL_NOTICE_TEMPLATE.read_text(encoding="utf-8")
     return html.replace("__DOWNLOAD_URL__", download_url).replace("__VERSION_LINE__", version_line)
+
+
+def notice_version_line(min_base: str | None, build_base: str, build: int) -> str:
+    """The "Installed X · update N" line at the foot of the reinstall notice.
+
+    #2206: it names what the *reader* is running, and the reader is the old-base
+    population ``--min-base`` selects -- not this build's own base, which is the
+    version they are being sent to download. Taking it from the publishing
+    checkout put "Installed 0.3.4" in front of every 0.3.3 user.
+    """
+    return f"Installed {min_base or build_base} · update {build}"
 
 
 def shell_sources(desktop_dir: Path = DESKTOP_DIR) -> list[Path]:
@@ -366,6 +415,19 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     parser.add_argument(
+        "--build",
+        type=int,
+        default=None,
+        help=(
+            "#2206: publish this exact build number instead of the next one in the "
+            "monotonic sequence. Needed to restore a migration notice after an "
+            "ordinary patch has advanced the channel past the notice's build window: "
+            "pick a number above the last build the old-base clients applied and at or "
+            "below the new installer's baseline, so the new-base population still "
+            "evaluates up-to-date. Requires --min-base when it goes backwards."
+        ),
+    )
+    parser.add_argument(
         "--reinstall-notice",
         metavar="URL",
         default=None,
@@ -391,15 +453,24 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("Refusing to publish an OTA patch on the 'stable' channel; pass --channel.")
     tag = channel_tag(channel)
 
-    latest = None if args.dry_run else fetch_latest_build(args.repo, tag)
-    build = next_build_number(latest, baseline["build"])
+    # A dry run normally skips the network and reports a meaningless build. With
+    # an explicit --build the number is the thing under review, and the guard that
+    # accepts it reads the latest published build -- so fetch it either way, or the
+    # rehearsal would not exercise the check the real publish makes.
+    latest = fetch_latest_build(args.repo, tag) if args.build is not None or not args.dry_run else None
+    try:
+        build = resolve_build_number(args.build, latest, baseline["build"], args.min_base)
+    except ValueError as error:
+        parser.error(str(error))
     name = asset_name(build)
 
     workdir = Path(tempfile.mkdtemp(prefix="scistudio-ota-"))
     tarball = workdir / name
     notice = None
     if args.reinstall_notice:
-        notice = render_reinstall_notice(args.reinstall_notice, f"Installed {baseline['base']} · update {build}")
+        notice = render_reinstall_notice(
+            args.reinstall_notice, notice_version_line(args.min_base, baseline["base"], build)
+        )
         print(f"Snapshot SPA replaced with the reinstall notice -> {args.reinstall_notice}")
 
     print(f"Packing snapshot of {src_dir} -> {tarball.name} ...")

--- a/tests/scripts/test_ota_publish.py
+++ b/tests/scripts/test_ota_publish.py
@@ -69,6 +69,46 @@ def test_next_build_never_below_baseline(mod: ModuleType) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# resolve_build_number (#2206)
+# --------------------------------------------------------------------------- #
+def test_build_number_follows_the_sequence_without_an_override(mod: ModuleType) -> None:
+    assert mod.resolve_build_number(None, 31, 30, None) == 32
+
+
+def test_override_names_the_build_outright(mod: ModuleType) -> None:
+    assert mod.resolve_build_number(40, 31, 30, None) == 40
+
+
+def test_override_may_publish_below_the_sequence_for_an_older_base(mod: ModuleType) -> None:
+    # The notice window: above what 0.3.3 clients applied (25), at or below the
+    # 0.3.4 installer baseline (30) so 0.3.4 clients still evaluate up-to-date.
+    assert mod.resolve_build_number(28, 31, 30, "0.3.3") == 28
+
+
+def test_override_below_the_sequence_is_refused_without_a_target_base(mod: ModuleType) -> None:
+    # Publishing backwards with no older population named would either reach
+    # nobody or replace a working SPA with the notice.
+    with pytest.raises(ValueError, match="--min-base"):
+        mod.resolve_build_number(28, 31, 30, None)
+
+
+def test_override_equal_to_the_sequence_is_refused_without_a_target_base(mod: ModuleType) -> None:
+    with pytest.raises(ValueError, match="at or below"):
+        mod.resolve_build_number(31, 31, 30, None)
+
+
+def test_override_below_the_sequence_counts_the_baseline_too(mod: ModuleType) -> None:
+    # No patch published yet, but a shipped installer already reports build 30.
+    with pytest.raises(ValueError, match=r"sequence \(30\)"):
+        mod.resolve_build_number(30, None, 30, None)
+
+
+def test_override_must_be_a_positive_build(mod: ModuleType) -> None:
+    with pytest.raises(ValueError, match="positive"):
+        mod.resolve_build_number(0, 31, 30, "0.3.3")
+
+
+# --------------------------------------------------------------------------- #
 # naming / urls
 # --------------------------------------------------------------------------- #
 def test_asset_and_url_and_tag(mod: ModuleType) -> None:
@@ -296,6 +336,15 @@ def test_reinstall_notice_says_what_to_do_with_the_address(mod: ModuleType) -> N
     # shown inside the app, so "open this in a browser" is not obvious.
     html = mod.render_reinstall_notice("https://example.test/download", "x")
     assert "browser" in html.lower()
+
+
+def test_notice_names_the_readers_base_not_the_builds(mod: ModuleType) -> None:
+    # The page reaches 0.3.3 clients; 0.3.4 is what it sends them to download.
+    assert mod.notice_version_line("0.3.3", "0.3.4", 28) == "Installed 0.3.3 · update 28"
+
+
+def test_notice_falls_back_to_the_builds_base_without_a_target(mod: ModuleType) -> None:
+    assert mod.notice_version_line(None, "0.3.4", 28) == "Installed 0.3.4 · update 28"
 
 
 def test_reinstall_notice_does_not_promise_notarization(mod: ModuleType) -> None:


### PR DESCRIPTION
Closes #2206

## What was wrong

A channel carries one `manifest.json`, and every publish overwrites it. The
build number is therefore the only thing keeping a reinstall notice away from
clients that are fine: the new-base population evaluates `up-to-date` for any
build at or below what their installer reports, so the notice has to land in a
window — above the last build the old-base clients applied, at or below the new
installer's baseline.

`next_build_number` can only produce `max(latest_published, baseline) + 1`. Once
an ordinary patch for the new base is published, the sequence has walked past
that window and the notice cannot be put back.

That is what happened to the 0.3.4 migration:

| build | published | payload | reaches |
|---|---|---|---|
| 26 | 08-26 00:05 | notice | 0.3.3 (window `(25, 30]`) |
| 27 | 08-26 00:12 | notice, corrected copy (#2183) | 0.3.3 |
| 31 | 08-26 15:13 | ordinary 0.3.4 SPA | 0.3.4 — **and reset `min_base` to 0.3.4** |

From 15:13 onward every 0.3.3 client evaluated `incompatible` and got the native
dialog whose address can be neither clicked nor selected. That is the precise
outcome #2169 was filed to prevent, reintroduced by an unrelated publish.

## What changed

**`--build`** names the build number outright instead of taking the next one in
the sequence. It refuses to publish below the sequence unless `--min-base` says
which older population the publish is for — a backwards build with no such
target either reaches nobody or replaces a working SPA with a notice. A dry run
now fetches the latest published build whenever `--build` is given, so the
rehearsal exercises the same guard as the real publish rather than skipping it.

**The notice's version line** was built from the publishing checkout's base,
which after a bump is the version the reader is being sent to *download*. It
told every 0.3.3 user "Installed 0.3.4". It now names the target base, via a
`notice_version_line` helper that can be asserted on.

**Runbook §5.1** gains the two rules that were only ever in someone's head: the
build window the notice must land in, and that any further publish on the
channel closes it. The verification snippet now asks for a second run against a
client you are *not* migrating, requiring `kind:'none'` — that is the assertion
the window holds.

## Already published

OTA build 28 went out with this change (`--build 28 --min-build 28
--min-base 0.3.3 --reinstall-notice`), snapshotting build 27's backend tree so
the payload is the one already proven to boot on a 0.3.3 client. Verified
against the live manifest and the downloaded tarball:

```
0.3.3 dmg/AppImage, never updated    {"kind":"patch","build":28,"mandatory":true}
0.3.3 windows build0022              {"kind":"patch","build":28,"mandatory":true}
0.3.3 on build25                     {"kind":"patch","build":28,"mandatory":true}
0.3.3 on build27                     {"kind":"patch","build":28,"mandatory":true}
0.3.4 fresh install build0030        {"kind":"none","reason":"up-to-date"}
0.3.4 on build31                     {"kind":"none","reason":"up-to-date"}
```

sha256 and size match the published asset; the page inside it reads
`Installed 0.3.3 · update 28`.

The channel is now held at build 28 for the 0.3.4 population: they keep build 31
and receive nothing further until a publish rises above 31, which closes the
window again. Making the two coexist needs a manifest that can address more than
one base, and is not attempted here.

## Governance

`docs/ai-developer/release-runbook.md` is a governance surface (ADR-042
Addendum 6 §7.8); `governance_touch` is declared in the ledger.

## Tests

`tests/scripts/test_ota_publish.py` — the sequence default, the override, the
backwards publish with and without a target base, the baseline counted as part
of the sequence, a non-positive build, and both version-line cases.
